### PR TITLE
V6.0: X.BUS closed-loop RPM with curvatureDrive (closes #20, #21)

### DIFF
--- a/sketches/xbus_master/xbus_master.ino
+++ b/sketches/xbus_master/xbus_master.ino
@@ -373,9 +373,10 @@ void printTelemetry() {
 
   // Use the actual elapsed wall time — loop slip or serial backpressure can
   // stretch the print interval, and a constant divisor would misreport Hz.
+  // elapsedMs is guaranteed >= PRINT_INTERVAL_MS by the gate above, so no /0 guard needed.
   uint32_t avgCycleUs  = cycleTimeN ? (cycleTimeSumUs / cycleTimeN) : 0;
   uint32_t maxCycleUs  = cycleTimeMaxUs;
-  float    effectiveHz = elapsedMs ? ((float)cycleTimeN * 1000.0f / (float)elapsedMs) : 0.0f;
+  float    effectiveHz = (float)cycleTimeN * 1000.0f / (float)elapsedMs;
   cycleTimeSumUs = 0; cycleTimeN = 0; cycleTimeMaxUs = 0;
 
   Serial.print("# Polls:");

--- a/sketches/xbus_master/xbus_master.ino
+++ b/sketches/xbus_master/xbus_master.ino
@@ -259,7 +259,10 @@ bool receiveTelemetry(uint8_t expectedESC) {
 
     bool haveFullFrame = false;
     for (int i = 0; i + TELEM_FRAME_LEN <= rxLen; i++) {
-      if (rxBuf[i] == HEADER_SLAVE) { haveFullFrame = true; break; }
+      if (rxBuf[i] == HEADER_SLAVE) {
+        haveFullFrame = true;
+        break;
+      }
     }
     if (haveFullFrame) break;
   }
@@ -459,7 +462,7 @@ int16_t scaleAxis(int raw, int16_t maxOut) {
   if (deflection > 0) deflection -= ADC_DEADBAND;
   else                deflection += ADC_DEADBAND;
   const int usable = ADC_CENTER - ADC_DEADBAND;
-  long scaled = (long)deflection * maxOut / usable;
+  int32_t scaled = (int32_t)deflection * maxOut / usable;
   return (int16_t)constrain(scaled, -maxOut, maxOut);
 }
 
@@ -496,7 +499,10 @@ WS curvatureDrive(float xSpeed, float zRotation) {
 
   // Desaturate: scale down proportionally if either exceeds ±1
   float m = max(fabsf(left), fabsf(right));
-  if (m > 1.0f) { left /= m; right /= m; }
+  if (m > 1.0f) {
+    left /= m;
+    right /= m;
+  }
   return {left, right};
 }
 

--- a/sketches/xbus_master/xbus_master.ino
+++ b/sketches/xbus_master/xbus_master.ino
@@ -64,7 +64,6 @@ const int ADC_MAX          = 16383;     // 2^14 - 1
 const int ADC_CENTER       = 8192;      // ADC mid-scale (~2.5V)
 const int ADC_DEADBAND     = 400;       // ±400 counts = small dead zone around center
 const int16_t THROTTLE_MAX = 200;       // Cap at 20% for bench safety (out of 1000)
-const int16_t STEER_MAX    = 150;       // Steering authority (x0.1%) — not used with curvatureDrive
 const int  STEER_INVERT    = 0;         // set to 1 if steering feels reversed
 
 // curvatureDrive tuning (same values as rc_test.ino V5.0)
@@ -89,6 +88,16 @@ const float EXPO_CUBIC  = 0.65f;        // cubic term weight (more = softer cent
 // Think of this as "how long to reach 63% of the new target".
 const float TAU_ACCEL = 0.30f;          // seconds to ramp UP
 const float TAU_DECEL = 0.50f;          // seconds to ramp DOWN (gentler)
+
+// Drive-feel tuning
+const float STRAIGHT_LINE_THRESHOLD = 0.05f;  // |zRotation| below this = "going straight" — applies reverse limiter
+
+// BUS_MODE watchdog (XC flowchart: resend Restart if an ESC drops out of BUS_MODE)
+const uint32_t BUS_MODE_TIMEOUT_MS      = 2000;  // No ESC reported BUS_MODE for this long → trigger restart
+const uint32_t BUS_MODE_RESTART_RATE_MS = 3000;  // Minimum spacing between Restart broadcasts
+
+// Non-blocking read-register ('r' debug command) timing
+const uint32_t READ_REG_TIMEOUT_US = 10000;  // 10 ms per spec + margin
 
 // Step response test state
 bool     stepActive   = false;
@@ -124,10 +133,13 @@ const uint8_t FUNC_RESTART     = 0xA0;
 const uint8_t FUNC_CLEAR_FLAGS = 0xA1;
 
 // Telemetry response length (fixed for func 0x50)
-// Observed: ESC sends DataLen=0x11 (17) in header but actual frame is 22 bytes.
-// Interpretation: DataLen counts 16 data bytes + 1 checksum.
-const uint8_t TELEM_DATA_LEN = 17;
-const uint8_t TELEM_FRAME_LEN = 22;
+// Observed: ESC sends DataLen=0x11 (17) in header; actual on-wire frame is 22 bytes.
+// 5 header bytes (0xF0 + SAdr + Extra + Func + Len) + 16 data bytes + 1 checksum = 22.
+// DataLen=17 in the header counts 16 real data bytes + the trailing checksum.
+// So we parse only 16 data bytes; byte 17 is the checksum (verified separately).
+const uint8_t TELEM_DATA_LEN      = 17;  // as reported by the ESC in the Length field
+const uint8_t TELEM_PAYLOAD_BYTES = 16;  // actual telemetry payload bytes (d[0..15])
+const uint8_t TELEM_FRAME_LEN     = 22;  // total on-wire bytes (header + payload + checksum)
 
 // Telemetry data structure
 struct ESCTelemetry {
@@ -139,7 +151,6 @@ struct ESCTelemetry {
   int16_t  outputThrottle;  // x0.1%
   int16_t  busVoltage;      // x0.1V
   int16_t  escTempRaw;      // Actual = raw - 40 degC
-  uint8_t  motorTemp;       // Spare/reserved
   bool     valid;           // True if successfully parsed
   uint32_t timestamp;  // micros() when received
 };
@@ -257,9 +268,14 @@ bool receiveTelemetry(uint8_t expectedESC) {
       rxBuf[rxLen++] = Serial1.read();
     }
 
+    // Check full header signature (0xF0 + 0xFF SAdr + 0x50 Func), not just 0xF0.
+    // Half-duplex RX sees our TX echo first, and the encoded throttle high byte
+    // can be 0xF0 for values near -1000 — matching 0xF0 alone would false-trigger.
     bool haveFullFrame = false;
     for (int i = 0; i + TELEM_FRAME_LEN <= rxLen; i++) {
-      if (rxBuf[i] == HEADER_SLAVE) {
+      if (rxBuf[i]     == HEADER_SLAVE   &&
+          rxBuf[i + 1] == ADDR_BROADCAST &&
+          rxBuf[i + 3] == FUNC_THROTTLE) {
         haveFullFrame = true;
         break;
       }
@@ -267,11 +283,13 @@ bool receiveTelemetry(uint8_t expectedESC) {
     if (haveFullFrame) break;
   }
 
-  // Skip our own TX echo (half-duplex: we'll see our transmitted bytes)
-  // Look for the slave header (0xF0) in the received data
+  // Skip our own TX echo (half-duplex). Match full header signature to avoid
+  // false-triggering on an echoed 0xF0 that happens to appear inside a TX byte.
   int frameStart = -1;
-  for (int i = 0; i < rxLen; i++) {
-    if (rxBuf[i] == HEADER_SLAVE) {
+  for (int i = 0; i + TELEM_FRAME_LEN <= rxLen; i++) {
+    if (rxBuf[i]     == HEADER_SLAVE   &&
+        rxBuf[i + 1] == ADDR_BROADCAST &&
+        rxBuf[i + 3] == FUNC_THROTTLE) {
       frameStart = i;
       break;
     }
@@ -302,6 +320,8 @@ bool receiveTelemetry(uint8_t expectedESC) {
   const uint8_t *d = &frame[5];
   ESCTelemetry *t = &telem[expectedESC];
 
+  // Parse 16 payload bytes (d[0..15]). Byte d[16] / frame[21] is the checksum,
+  // already verified above — do not read it as data.
   t->rpmHz            = (int16_t)(d[0]  | (d[1]  << 8));
   t->busCurrent       = (int16_t)(d[2]  | (d[3]  << 8));
   t->phaseCurrent     = (int16_t)(d[4]  | (d[5]  << 8));
@@ -310,7 +330,6 @@ bool receiveTelemetry(uint8_t expectedESC) {
   t->outputThrottle   = (int16_t)(d[10] | (d[11] << 8));
   t->busVoltage       = (int16_t)(d[12] | (d[13] << 8));
   t->escTempRaw       = (int16_t)(d[14] | (d[15] << 8));
-  t->motorTemp        = d[16];
   t->valid            = true;
   t->timestamp        = micros();
 
@@ -348,12 +367,15 @@ void printStatus(uint16_t status) {
 
 void printTelemetry() {
   uint32_t now = millis();
-  if ((now - lastPrintMs) < PRINT_INTERVAL_MS) return;
+  uint32_t elapsedMs = now - lastPrintMs;
+  if (elapsedMs < PRINT_INTERVAL_MS) return;
   lastPrintMs = now;
 
-  uint32_t avgCycleUs   = cycleTimeN ? (cycleTimeSumUs / cycleTimeN) : 0;
-  uint32_t maxCycleUs   = cycleTimeMaxUs;
-  float    effectiveHz  = (cycleTimeN * 1000.0f) / (float)PRINT_INTERVAL_MS;
+  // Use the actual elapsed wall time — loop slip or serial backpressure can
+  // stretch the print interval, and a constant divisor would misreport Hz.
+  uint32_t avgCycleUs  = cycleTimeN ? (cycleTimeSumUs / cycleTimeN) : 0;
+  uint32_t maxCycleUs  = cycleTimeMaxUs;
+  float    effectiveHz = elapsedMs ? ((float)cycleTimeN * 1000.0f / (float)elapsedMs) : 0.0f;
   cycleTimeSumUs = 0; cycleTimeN = 0; cycleTimeMaxUs = 0;
 
   Serial.print("# Polls:");
@@ -447,6 +469,10 @@ uint32_t lastBusModeMs = 0;   // last time we saw BUS_MODE=1 on any ESC
 uint32_t lastRestartMs = 0;   // last time we broadcast Restart
 bool firstReport = true;
 
+// Non-blocking 'r' command state (register read)
+bool     readRegPending  = false;
+uint32_t readRegStartUs  = 0;
+
 // Exponential stick curve — preserves sign, soft near zero, steep at ±1.
 // x in [-1..+1], y in [-1..+1]. Same shape as rc_test.ino.
 float expoCurve(float x) {
@@ -466,16 +492,8 @@ int16_t scaleAxis(int raw, int16_t maxOut) {
   return (int16_t)constrain(scaled, -maxOut, maxOut);
 }
 
-int16_t readJoystickThrottle() {
-  rawJoyY = analogRead(JOYSTICK_Y_PIN);
-  return scaleAxis(rawJoyY, THROTTLE_MAX);
-}
-
-int16_t readJoystickSteer() {
-  rawJoyX = analogRead(JOYSTICK_X_PIN);
-  int16_t s = scaleAxis(rawJoyX, STEER_MAX);
-  return STEER_INVERT ? -s : s;
-}
+// Joystick sampling is done directly in the control loop (single authoritative
+// path: analogRead() → scaleAxis() → expoCurve() → curvatureDrive).
 
 // ─── curvatureDrive (WPILib DifferentialDrive.curvatureDriveIK) ───
 // At speed: steering ONLY slows the inner track, outer holds throttle.
@@ -532,11 +550,12 @@ void setup() {
   Serial.println("#   Pull-up: 3K-10K to 5V on bus");
   Serial.println("#   ESC Brown -> GND, Red -> NOT CONNECTED");
   Serial.println("#");
-  Serial.println("# NOTE: USB Serial is shared with D0/D1.");
-  Serial.println("# Debug output may be garbled when X.BUS is connected.");
-  Serial.println("# Disconnect X.BUS Yellow from D0 to read this output.");
+  Serial.println("# NOTE: Nano R4 USB Serial (`Serial`) is independent of D0/D1.");
+  Serial.println("# X.BUS runs on `Serial1` (D0 RX / D1 TX) and does NOT share");
+  Serial.println("# the USB connection, so the Serial Monitor stays readable");
+  Serial.println("# while the bus is live — commands below are fully usable.");
   Serial.println("#");
-  Serial.println("# Commands via Serial Monitor:");
+  Serial.println("# Commands via Serial Monitor (work while X.BUS is connected):");
   Serial.println("#   t0 <val>  — set ESC0 throttle (-1000 to 1000)");
   Serial.println("#   t1 <val>  — set ESC1 throttle (-1000 to 1000)");
   Serial.println("#   s  <val>  — step response: slam both ESCs to val for 500ms");
@@ -564,8 +583,25 @@ void setup() {
 void loop() {
   uint32_t now = millis();
 
-  // === Control loop at fixed period ===
-  if ((now - lastControlMs) >= CONTROL_PERIOD_MS) {
+  // === Non-blocking 'r' register read completion ===
+  // Debug-only path: we collect the register response across loop iterations
+  // instead of delay()ing. While pending, we suppress the control-loop branch
+  // below (not the whole loop()) so serial commands and prints still flow.
+  // At 10 ms timeout this skips at most one control cycle — well inside the
+  // ESC's own THR_LOST grace window.
+  if (readRegPending) {
+    while (Serial1.available() && rxLen < (int)sizeof(rxBuf)) {
+      rxBuf[rxLen++] = Serial1.read();
+    }
+    if ((micros() - readRegStartUs) >= READ_REG_TIMEOUT_US) {
+      printRawRX();
+      readRegPending = false;
+      lastControlMs = now;  // resync so the next control cycle fires on schedule
+    }
+  }
+
+  // === Control loop at fixed period (skipped while register read is pending) ===
+  if (!readRegPending && (now - lastControlMs) >= CONTROL_PERIOD_MS) {
     uint32_t cycleStartUs = micros();
     lastControlMs = now;
     totalPolls++;
@@ -580,7 +616,7 @@ void loop() {
     float zRotation = expoCurve(STEER_INVERT ? normX : -normX);
 
     // Reverse limit (only when going straight)
-    if (fabsf(zRotation) < 0.05f && xSpeed < -REVERSE_LIMIT) {
+    if (fabsf(zRotation) < STRAIGHT_LINE_THRESHOLD && xSpeed < -REVERSE_LIMIT) {
       xSpeed = -REVERSE_LIMIT;
     }
 
@@ -670,7 +706,8 @@ void loop() {
     // === BUS_MODE watchdog ===
     // If we haven't seen any ESC report BUS_MODE=1 for 2s, resend Restart.
     // Rate-limit to once every 3s so we don't spam.
-    if ((now - lastBusModeMs) > 2000 && (now - lastRestartMs) > 3000) {
+    if ((now - lastBusModeMs) > BUS_MODE_TIMEOUT_MS &&
+        (now - lastRestartMs) > BUS_MODE_RESTART_RATE_MS) {
       Serial.println("# BUS_MODE lost — broadcasting Restart (0xA0)...");
       sendRestart(0xFF);
       lastRestartMs = now;
@@ -696,8 +733,9 @@ void loop() {
     } else if (cmd == "r") {
       Serial.println("# Reading register 0x04 (ProtocolType) from ESC 0...");
       sendReadRegister(0, 0x04);
-      delay(15);  // 10ms timeout per spec + margin
-      printRawRX();
+      readRegPending = true;
+      readRegStartUs = micros();
+      rxLen = 0;  // start fresh so the poll collects only the register response
     } else if (cmd == "x") {
       Serial.println("# Restarting all ESCs...");
       sendRestart(0xFF);

--- a/sketches/xbus_master/xbus_master.ino
+++ b/sketches/xbus_master/xbus_master.ino
@@ -32,24 +32,74 @@
 // FQBN:  arduino:renesas_uno:nanor4
 // Port:  COM8
 
+// Forward-declared struct for curvatureDrive return (normalized wheel speeds).
+// Must be above any function that references it, or Arduino's auto-prototype
+// inserts a prototype before the struct definition.
+struct WS { float left; float right; };
+
+
 // ═══════════════════════════════════════════════════════════════
 // [CONFIG]
 // ═══════════════════════════════════════════════════════════════
 
-// Number of ESCs on the bus (our setup: 2, addresses 0 and 1)
+// Number of ESCs on the bus (both tracks)
 const uint8_t NUM_ESCS = 2;
 
 // Which ESC to request telemetry from (alternates each cycle)
 uint8_t telemetryTarget = 0;
 
 // Control loop period (ms) — protocol spec says 10-50ms acceptable
-const uint32_t CONTROL_PERIOD_MS = 20;  // 50 Hz
+const uint32_t CONTROL_PERIOD_MS = 10;  // 100 Hz
 
-// Telemetry response timeout (us) — spec says 2ms for broadcast
-const uint32_t TELEM_TIMEOUT_US = 3000;  // 3ms with margin
+// Telemetry response timeout (us) — spec says 2ms for broadcast.
+// Half-duplex bus: RX buffer also contains our own TX echo (~8 bytes),
+// so we need to wait for TX(8) + response(23) = 31 bytes at 115200 baud = 2.7ms.
+const uint32_t TELEM_TIMEOUT_US = 5000;  // 5ms = comfortable margin
 
-// Throttle values for bench testing (0 = neutral, safe)
+// Joystick config — Y axis on A0 = throttle, X axis on A1 = steering
+const int JOYSTICK_Y_PIN   = A0;
+const int JOYSTICK_X_PIN   = A1;
+const int ADC_RESOLUTION   = 14;        // Nano R4 14-bit ADC
+const int ADC_MAX          = 16383;     // 2^14 - 1
+const int ADC_CENTER       = 8192;      // ADC mid-scale (~2.5V)
+const int ADC_DEADBAND     = 400;       // ±400 counts = small dead zone around center
+const int16_t THROTTLE_MAX = 200;       // Cap at 20% for bench safety (out of 1000)
+const int16_t STEER_MAX    = 150;       // Steering authority (x0.1%) — not used with curvatureDrive
+const int  STEER_INVERT    = 0;         // set to 1 if steering feels reversed
+
+// curvatureDrive tuning (same values as rc_test.ino V5.0)
+const float PIVOT_THRESHOLD = 0.10f;    // Below 10% throttle: allow pivot turns
+const float PIVOT_SPEED_CAP = 0.45f;    // Max track speed during pivot (45%)
+const float REVERSE_LIMIT   = 0.35f;    // Max reverse (straight-line only)
+
+// Closed-loop RPM mode — ON by default (no RC switch available)
+bool     rpmMode = true;
+int16_t  rpmTargetL = 0;                // smoothed target RPM (what PID chases)
+int16_t  rpmTargetR = 0;
+const int16_t RPM_MAX = 27000;          // motor no-load max (~2500KV × 11V)
+const float   KP_RPM  = 0.02f;          // proportional gain (throttle units per RPM err)
+
+// Stick → RPM shaping
+// Expo curve: soft near center (fine control), aggressive toward full stick.
+// y = EXPO_LINEAR * x + EXPO_CUBIC * x^3   with EXPO_LINEAR + EXPO_CUBIC = 1
+const float EXPO_LINEAR = 0.35f;        // linear term weight
+const float EXPO_CUBIC  = 0.65f;        // cubic term weight (more = softer center)
+
+// First-order lag on target RPM — instant stick response with smooth ramp.
+// Think of this as "how long to reach 63% of the new target".
+const float TAU_ACCEL = 0.30f;          // seconds to ramp UP
+const float TAU_DECEL = 0.50f;          // seconds to ramp DOWN (gentler)
+
+// Step response test state
+bool     stepActive   = false;
+uint32_t stepStartUs  = 0;
+int16_t  stepValue    = 0;
+const uint32_t STEP_DURATION_MS = 500;
+
+// Throttle values for bench testing (updated from joystick in loop)
 int16_t throttle[2] = {0, 0};  // -1000 to +1000 (x0.1%)
+int rawJoyY = 0;                // Raw ADC reading for debug display
+int rawJoyX = 0;                // Raw ADC reading for debug display
 
 // Debug print interval
 const uint32_t PRINT_INTERVAL_MS = 500;
@@ -74,10 +124,10 @@ const uint8_t FUNC_RESTART     = 0xA0;
 const uint8_t FUNC_CLEAR_FLAGS = 0xA1;
 
 // Telemetry response length (fixed for func 0x50)
+// Observed: ESC sends DataLen=0x11 (17) in header but actual frame is 22 bytes.
+// Interpretation: DataLen counts 16 data bytes + 1 checksum.
 const uint8_t TELEM_DATA_LEN = 17;
-// Total response frame: header(1) + SAdr(1) + extra(1) + func(1) + len(1)
-//                       + data(17) + checksum(1) = 23 bytes
-const uint8_t TELEM_FRAME_LEN = 23;
+const uint8_t TELEM_FRAME_LEN = 22;
 
 // Telemetry data structure
 struct ESCTelemetry {
@@ -152,11 +202,11 @@ void sendThrottleCommand(const int16_t *values, uint8_t numESCs, uint8_t targetE
   txBuf[frameLen - 1] = checksumFull(txBuf, frameLen);
 
   // Flush any stale RX data before sending
-  while (Serial.available()) Serial.read();
+  while (Serial1.available()) Serial1.read();
 
   // Send the frame
-  Serial.write(txBuf, frameLen);
-  Serial.flush();  // Wait for TX to complete before switching to RX
+  Serial1.write(txBuf, frameLen);
+  Serial1.flush();  // Wait for TX to complete before switching to RX
 }
 
 // Send a read-register command to a specific ESC (point-to-point)
@@ -169,9 +219,9 @@ void sendReadRegister(uint8_t escAddr, uint8_t regAddr) {
   txBuf[5] = regAddr;
   txBuf[6] = checksumFull(txBuf, 7);
 
-  while (Serial.available()) Serial.read();
-  Serial.write(txBuf, 7);
-  Serial.flush();
+  while (Serial1.available()) Serial1.read();
+  Serial1.write(txBuf, 7);
+  Serial1.flush();
 }
 
 // Send restart command to a specific ESC or all (0xFF)
@@ -183,8 +233,8 @@ void sendRestart(uint8_t target) {
   txBuf[4] = 0;              // Length: 0
   txBuf[5] = checksumFull(txBuf, 6);
 
-  Serial.write(txBuf, 6);
-  Serial.flush();
+  Serial1.write(txBuf, 6);
+  Serial1.flush();
 }
 
 
@@ -198,14 +248,20 @@ bool receiveTelemetry(uint8_t expectedESC) {
   uint32_t startUs = micros();
   rxLen = 0;
 
-  // Wait for response bytes within timeout
+  // Wait for response bytes within timeout.
+  // Half-duplex bus: RX buffer also contains our TX echo. Exit early only
+  // when we have located the slave header 0xF0 AND enough bytes follow it
+  // to cover a full telemetry frame.
   while ((micros() - startUs) < TELEM_TIMEOUT_US) {
-    while (Serial.available() && rxLen < (int)sizeof(rxBuf)) {
-      rxBuf[rxLen++] = Serial.read();
+    while (Serial1.available() && rxLen < (int)sizeof(rxBuf)) {
+      rxBuf[rxLen++] = Serial1.read();
     }
 
-    // Check if we have enough bytes for a complete frame
-    if (rxLen >= TELEM_FRAME_LEN) break;
+    bool haveFullFrame = false;
+    for (int i = 0; i + TELEM_FRAME_LEN <= rxLen; i++) {
+      if (rxBuf[i] == HEADER_SLAVE) { haveFullFrame = true; break; }
+    }
+    if (haveFullFrame) break;
   }
 
   // Skip our own TX echo (half-duplex: we'll see our transmitted bytes)
@@ -267,6 +323,9 @@ uint32_t lastPrintMs = 0;
 uint32_t totalPolls = 0;
 uint32_t goodFrames = 0;
 uint32_t badFrames = 0;
+uint32_t cycleTimeSumUs = 0;  // rolling sum of cycle times (TX+RX)
+uint32_t cycleTimeMaxUs = 0;  // peak cycle time since last print
+uint32_t cycleTimeN     = 0;
 
 // Print status bits in human-readable format
 void printStatus(uint16_t status) {
@@ -289,12 +348,40 @@ void printTelemetry() {
   if ((now - lastPrintMs) < PRINT_INTERVAL_MS) return;
   lastPrintMs = now;
 
+  uint32_t avgCycleUs   = cycleTimeN ? (cycleTimeSumUs / cycleTimeN) : 0;
+  uint32_t maxCycleUs   = cycleTimeMaxUs;
+  float    effectiveHz  = (cycleTimeN * 1000.0f) / (float)PRINT_INTERVAL_MS;
+  cycleTimeSumUs = 0; cycleTimeN = 0; cycleTimeMaxUs = 0;
+
   Serial.print("# Polls:");
   Serial.print(totalPolls);
   Serial.print(" Good:");
   Serial.print(goodFrames);
   Serial.print(" Bad:");
-  Serial.println(badFrames);
+  Serial.print(badFrames);
+  Serial.print(" JoyY=");
+  Serial.print(rawJoyY);
+  Serial.print(" JoyX=");
+  Serial.print(rawJoyX);
+  Serial.print(" ThrL=");
+  Serial.print(throttle[0]);
+  Serial.print(" ThrR=");
+  Serial.print(throttle[1]);
+  Serial.print(" loop_Hz=");
+  Serial.print(effectiveHz, 1);
+  Serial.print(" cycle_avg=");
+  Serial.print(avgCycleUs);
+  Serial.print("us max=");
+  Serial.print(maxCycleUs);
+  Serial.print("us");
+  if (rpmMode) {
+    Serial.print(" [RPM tgtL=");
+    Serial.print(rpmTargetL);
+    Serial.print(" tgtR=");
+    Serial.print(rpmTargetR);
+    Serial.print("]");
+  }
+  Serial.println();
 
   for (uint8_t i = 0; i < NUM_ESCS; i++) {
     ESCTelemetry *t = &telem[i];
@@ -353,10 +440,71 @@ void printRawRX() {
 // ═══════════════════════════════════════════════════════════════
 
 uint32_t lastControlMs = 0;
+uint32_t lastBusModeMs = 0;   // last time we saw BUS_MODE=1 on any ESC
+uint32_t lastRestartMs = 0;   // last time we broadcast Restart
 bool firstReport = true;
 
+// Exponential stick curve — preserves sign, soft near zero, steep at ±1.
+// x in [-1..+1], y in [-1..+1]. Same shape as rc_test.ino.
+float expoCurve(float x) {
+  float a = fabsf(x);
+  float sign = (x >= 0.0f) ? 1.0f : -1.0f;
+  return sign * (EXPO_LINEAR * a + EXPO_CUBIC * a * a * a);
+}
+
+// Generic axis reader: raw ADC → signed deflection with deadband, scaled to ±maxOut
+int16_t scaleAxis(int raw, int16_t maxOut) {
+  int deflection = raw - ADC_CENTER;
+  if (abs(deflection) < ADC_DEADBAND) return 0;
+  if (deflection > 0) deflection -= ADC_DEADBAND;
+  else                deflection += ADC_DEADBAND;
+  const int usable = ADC_CENTER - ADC_DEADBAND;
+  long scaled = (long)deflection * maxOut / usable;
+  return (int16_t)constrain(scaled, -maxOut, maxOut);
+}
+
+int16_t readJoystickThrottle() {
+  rawJoyY = analogRead(JOYSTICK_Y_PIN);
+  return scaleAxis(rawJoyY, THROTTLE_MAX);
+}
+
+int16_t readJoystickSteer() {
+  rawJoyX = analogRead(JOYSTICK_X_PIN);
+  int16_t s = scaleAxis(rawJoyX, STEER_MAX);
+  return STEER_INVERT ? -s : s;
+}
+
+// ─── curvatureDrive (WPILib DifferentialDrive.curvatureDriveIK) ───
+// At speed: steering ONLY slows the inner track, outer holds throttle.
+// At standstill: arcade-style pivot, capped by PIVOT_SPEED_CAP.
+// Inputs/outputs in normalized -1..+1 range.
+WS curvatureDrive(float xSpeed, float zRotation) {
+  xSpeed    = constrain(xSpeed,    -1.0f, 1.0f);
+  zRotation = constrain(zRotation, -1.0f, 1.0f);
+
+  float left, right;
+  if (fabsf(xSpeed) < PIVOT_THRESHOLD) {
+    // Pivot — arcade with cap
+    float capped = constrain(zRotation, -PIVOT_SPEED_CAP, PIVOT_SPEED_CAP);
+    left  = xSpeed - capped;
+    right = xSpeed + capped;
+  } else {
+    // Curvature — steering scales by |speed|; outer never exceeds throttle
+    left  = xSpeed - fabsf(xSpeed) * zRotation;
+    right = xSpeed + fabsf(xSpeed) * zRotation;
+  }
+
+  // Desaturate: scale down proportionally if either exceeds ±1
+  float m = max(fabsf(left), fabsf(right));
+  if (m > 1.0f) { left /= m; right /= m; }
+  return {left, right};
+}
+
 void setup() {
-  Serial.begin(115200);
+  Serial.begin(115200);    // USB CDC — debug output to Serial Monitor
+  Serial1.begin(115200);   // Hardware UART on D0/D1 — X.BUS bus
+
+  analogReadResolution(ADC_RESOLUTION);  // 14-bit ADC on Nano R4
 
   // Wait for USB serial on Nano R4 (up to 2 seconds, then continue)
   uint32_t waitStart = millis();
@@ -385,6 +533,8 @@ void setup() {
   Serial.println("# Commands via Serial Monitor:");
   Serial.println("#   t0 <val>  — set ESC0 throttle (-1000 to 1000)");
   Serial.println("#   t1 <val>  — set ESC1 throttle (-1000 to 1000)");
+  Serial.println("#   s  <val>  — step response: slam both ESCs to val for 500ms");
+  Serial.println("#   m         — toggle closed-loop RPM mode");
   Serial.println("#   r         — read register 0x04 (protocol type)");
   Serial.println("#   x         — restart all ESCs");
   Serial.println("#");
@@ -394,6 +544,14 @@ void setup() {
     telem[i].valid = false;
   }
 
+  // Give ESCs a moment to finish booting, then kick them into BUS_MODE
+  // by broadcasting Restart. Per XC flowchart, this activates X.BUS control.
+  delay(500);
+  Serial.println("# Sending Restart (0xA0) broadcast to activate BUS_MODE...");
+  while (Serial1.available()) Serial1.read();
+  sendRestart(0xFF);
+  delay(200);  // ESC reboots and comes back in BUS mode
+
   lastControlMs = millis();
 }
 
@@ -402,8 +560,61 @@ void loop() {
 
   // === Control loop at fixed period ===
   if ((now - lastControlMs) >= CONTROL_PERIOD_MS) {
+    uint32_t cycleStartUs = micros();
     lastControlMs = now;
     totalPolls++;
+
+    // --- Compute throttle commands ---
+    // Stage 1: Read axes, normalize to -1..+1, apply expo for feel
+    rawJoyY = analogRead(JOYSTICK_Y_PIN);
+    rawJoyX = analogRead(JOYSTICK_X_PIN);
+    float normY = scaleAxis(rawJoyY, 1000) / 1000.0f;
+    float normX = scaleAxis(rawJoyX, 1000) / 1000.0f;
+    float xSpeed    = expoCurve(normY);
+    float zRotation = expoCurve(STEER_INVERT ? normX : -normX);
+
+    // Reverse limit (only when going straight)
+    if (fabsf(zRotation) < 0.05f && xSpeed < -REVERSE_LIMIT) {
+      xSpeed = -REVERSE_LIMIT;
+    }
+
+    // Stage 2: curvatureDrive → normalized wheel speeds
+    WS ws = curvatureDrive(xSpeed, zRotation);
+
+    if (stepActive) {
+      // Step response override: both tracks slammed to stepValue (bypasses all shaping)
+      throttle[0] = stepValue;
+      throttle[1] = stepValue;
+      if ((micros() - stepStartUs) / 1000 > STEP_DURATION_MS) {
+        stepActive = false;
+        Serial.println("# step response complete");
+      }
+    } else if (rpmMode) {
+      // Stage 3: wheel speeds → static RPM target → smoothed RPM target
+      float rpmStaticL = ws.left  * RPM_MAX;
+      float rpmStaticR = ws.right * RPM_MAX;
+
+      static float rpmSmoothL = 0.0f, rpmSmoothR = 0.0f;
+      const float dts = CONTROL_PERIOD_MS / 1000.0f;
+      bool  accelL = fabsf(rpmStaticL) > fabsf(rpmSmoothL);
+      bool  accelR = fabsf(rpmStaticR) > fabsf(rpmSmoothR);
+      float alphaL = dts / (dts + (accelL ? TAU_ACCEL : TAU_DECEL));
+      float alphaR = dts / (dts + (accelR ? TAU_ACCEL : TAU_DECEL));
+      rpmSmoothL += (rpmStaticL - rpmSmoothL) * alphaL;
+      rpmSmoothR += (rpmStaticR - rpmSmoothR) * alphaR;
+      rpmTargetL = (int16_t)rpmSmoothL;
+      rpmTargetR = (int16_t)rpmSmoothR;
+
+      // Stage 4: P controller — throttle driven by RPM error
+      int32_t actualL = telem[0].valid ? (int32_t)telem[0].rpmHz * 30 : 0;
+      int32_t actualR = telem[1].valid ? (int32_t)telem[1].rpmHz * 30 : 0;
+      throttle[0] = constrain((int32_t)((rpmTargetL - actualL) * KP_RPM), -THROTTLE_MAX, THROTTLE_MAX);
+      throttle[1] = constrain((int32_t)((rpmTargetR - actualR) * KP_RPM), -THROTTLE_MAX, THROTTLE_MAX);
+    } else {
+      // Open-loop: wheel speeds → scaled throttle directly (no RPM target)
+      throttle[0] = constrain((int16_t)(ws.left  * THROTTLE_MAX), -THROTTLE_MAX, THROTTLE_MAX);
+      throttle[1] = constrain((int16_t)(ws.right * THROTTLE_MAX), -THROTTLE_MAX, THROTTLE_MAX);
+    }
 
     // Send throttle to all ESCs, request telemetry from one
     sendThrottleCommand(throttle, NUM_ESCS, telemetryTarget);
@@ -416,6 +627,10 @@ void loop() {
         Serial.println("# >>> FIRST TELEMETRY RECEIVED! Protocol is working. <<<");
         firstReport = false;
       }
+      // Track BUS_MODE (bit 3) for watchdog
+      if (telem[telemetryTarget].status & (1 << 3)) {
+        lastBusModeMs = now;
+      }
     } else {
       badFrames++;
       // Print raw bytes on first few failures for debugging
@@ -424,8 +639,36 @@ void loop() {
       }
     }
 
+    // Cycle time measurement (TX + telemetry wait + parse)
+    uint32_t cycleUs = micros() - cycleStartUs;
+    cycleTimeSumUs += cycleUs;
+    cycleTimeN++;
+    if (cycleUs > cycleTimeMaxUs) cycleTimeMaxUs = cycleUs;
+
+    // Step response per-cycle log (RPM every cycle while step active)
+    if (stepActive && telem[telemetryTarget].valid) {
+      uint32_t tMs = (micros() - stepStartUs) / 1000;
+      Serial.print("# step t=");
+      Serial.print(tMs);
+      Serial.print("ms ESC");
+      Serial.print(telemetryTarget);
+      Serial.print(" RPM=");
+      Serial.print(telem[telemetryTarget].rpmHz * 30);
+      Serial.print(" Thr_out=");
+      Serial.println(telem[telemetryTarget].outputThrottle * 0.1f, 1);
+    }
+
     // Alternate telemetry target between ESCs each cycle
     telemetryTarget = (telemetryTarget + 1) % NUM_ESCS;
+
+    // === BUS_MODE watchdog ===
+    // If we haven't seen any ESC report BUS_MODE=1 for 2s, resend Restart.
+    // Rate-limit to once every 3s so we don't spam.
+    if ((now - lastBusModeMs) > 2000 && (now - lastRestartMs) > 3000) {
+      Serial.println("# BUS_MODE lost — broadcasting Restart (0xA0)...");
+      sendRestart(0xFF);
+      lastRestartMs = now;
+    }
   }
 
   // === Debug output ===
@@ -452,6 +695,20 @@ void loop() {
     } else if (cmd == "x") {
       Serial.println("# Restarting all ESCs...");
       sendRestart(0xFF);
+    } else if (cmd.startsWith("s ")) {
+      // Step response test: "s 150" slams throttle to +150 for STEP_DURATION_MS
+      stepValue = constrain(cmd.substring(2).toInt(), -THROTTLE_MAX, THROTTLE_MAX);
+      stepStartUs = micros();
+      stepActive = true;
+      Serial.print("# STEP RESPONSE: throttle=");
+      Serial.print(stepValue);
+      Serial.print(" for ");
+      Serial.print(STEP_DURATION_MS);
+      Serial.println("ms");
+    } else if (cmd == "m") {
+      rpmMode = !rpmMode;
+      Serial.print("# RPM closed-loop mode: ");
+      Serial.println(rpmMode ? "ON" : "OFF");
     }
   }
 }


### PR DESCRIPTION
## Summary

- First working two-ESC X.BUS bench test. Both ESCs reliably respond on the shared half-duplex bus at 100 Hz control rate.
- Joystick is the sole input (RC path removed). Arcade steering replaced with full curvatureDrive (WPILib) for safe steering at speed.
- Closed-loop RPM targeting on by default: expo curve → curvatureDrive → first-order lag → P controller → throttle.

## What works

- Protocol handshake verified (0x0F/0xF0 framing, full checksum).
- Startup `Restart` (0xA0) broadcast puts both ESCs into `BUS_MODE`. Watchdog resends if BUS_MODE drops for >2s.
- Telemetry decoded: RPM, bus/phase current, voltage, ESC temp, status bits.
- Step-response command `s <val>` for measuring RPM rise time.
- Effective loop frequency instrumented — ~100 Hz, bus transaction ~4.7 ms avg.

## Control pipeline

```
joystick → deadband → expo → curvatureDrive → wheel speeds
                                                  │
                        ±27,000 RPM static target ┤
                                                  │
                      first-order lag (accel/decel τ)
                                                  │
                        P controller (Kp=0.02) ───┘
                                                  │
                                   throttle → X.BUS
```

## Closes

- Closes #20 — half-duplex bus circuit built & verified
- Closes #21 — X.BUS bench test passes (both ESCs, throttle + telemetry, checksum, status bits, voltage/temp sanity)

## Progress toward

- #8 (dual-loop PID) — outer RPM P loop in place; inner current FF still pending
- #22 (integrate X.BUS into main controller) — working standalone sketch; still need to migrate rc_test.ino

## Test plan

- [x] Two-ESC bus comms at 100 Hz
- [x] BUS_MODE active, throttle commands accepted
- [x] Joystick drives both tracks forward/reverse
- [x] Steering mixes via curvatureDrive
- [x] Closed-loop RPM targeting active by default
- [x] Effective loop Hz reported in debug output
- [ ] Current-ceiling safety cap (future — need machine weight / gear ratio calc)
- [ ] PI upgrade (steady-state error tuning)
- [ ] Migrate rc_test.ino to X.BUS (see #22)

## Role tag

`[C-Builder]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added joystick-based throttle and steering input with exponential curve and deadband scaling
  * Implemented closed-loop RPM control mode for independent per-wheel speed management
  * Introduced curvature-based drive logic with pivot capability and reverse limiting
  * Added runtime diagnostics with step-response testing capability

* **Improvements**
  * Increased control loop frequency from 50 Hz to 100 Hz for faster response times
  * Enhanced telemetry reception and framing with improved timeout handling
  * Added BUS_MODE watchdog for automatic system recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->