### PR TITLE
docs: fix markdownlint in V8/V9 handoff (MD022/MD032)

### DIFF
--- a/docs/HANDOFF-V8-V9-WIFI-LATENCY-AND-OFFLOAD.md
+++ b/docs/HANDOFF-V8-V9-WIFI-LATENCY-AND-OFFLOAD.md
@@ -7,11 +7,13 @@
 ---
 
 ## Repo
+
 `boulaajaj/Arduino-DiggerSetup` — Arduino UNO R4 WiFi controller for a
 ride-on excavator. Current branch: `claude/restore-xbus-telemetry-36`.
 **PR #50 open** with telemetry + Wi-Fi dashboard work.
 
 ## Standing rules (memory, non-negotiable)
+
 1. **Issue-first workflow** — no code changes / commits / uploads without
    a clear plan, task, goal, AND an open GitHub issue. No issue →
    conversation only.
@@ -23,6 +25,7 @@ ride-on excavator. Current branch: `claude/restore-xbus-telemetry-36`.
 ## What to set up first
 
 **Create a milestone** named **"V8 — Telemetry reliability"** and add to it:
+
 - **#43** — Solder interface board (existing)
 - **#51** — Battery/inactivity beeper (existing)
 - **NEW-A** — Wi-Fi serving latency mitigation (draft below)
@@ -38,10 +41,12 @@ Separately, **draft NEW-B** as V9 future work, no milestone yet.
 **Body:**
 
 ### Problem
+
 Operator reports 2–5 second control delays when iPhone is connected to
 the dashboard over Wi-Fi. Latency is intermittent and unpredictable.
 
 ### Root cause (researched, not speculation)
+
 WiFiS3 calls block on `Modem::passthrough()` with default
 `MODEM_TIMEOUT = 10 000 ms` (`ArduinoCore-renesas/libraries/WiFiS3/src/Modem.h`).
 When the iPhone's TCP receive window stalls (Safari backgrounded, weak
@@ -59,6 +64,7 @@ Community confirmation: forum thread "R4 WiFi slow at serving web pages
 regression); `Links2004/arduinoWebSockets` #909 (freeze on page reload).
 
 ### Gate — hardware first
+
 Operator suspects X.BUS dropouts are mechanical (loose ground / cold
 joint / vibration on the soldered interface board). **Open machine and
 verify all X.BUS solder joints + ground continuity + R1 pull-up before
@@ -66,6 +72,7 @@ any firmware change.** Many symptoms attributed to Wi-Fi may actually be
 X.BUS.
 
 ### Plan (only if hardware checks pass), in order
+
 1. **Set Wi-Fi AP channel = 11** in `beginAP()`. Avoids common 2.4 GHz
    Wi-Fi neighbors. Doesn't help vs RC6GS (FHSS).
 2. **Coalesce SSE writes** — build `": hb\ndata: <json>\n\n"` into one
@@ -78,6 +85,7 @@ X.BUS.
 4. **Only if 1–3 are insufficient**: drop SSE push 10 Hz → 2 Hz.
 
 ### Anti-patterns
+
 - Don't reduce X.BUS poll rate.
 - Don't touch S.BUS path.
 - Don't claim Wi-Fi is the cause until you've measured `wifiUpdate()`
@@ -86,6 +94,7 @@ X.BUS.
   multi-100 ms `dt`.
 
 ### Acceptance
+
 - Drive with phone connected. Input-to-track latency < 300 ms
   consistently.
 - No control regression: FS=0, Lost=0, RC + joystick drive cleanly.
@@ -99,10 +108,12 @@ X.BUS.
 **Body:**
 
 ### Goal
+
 Move all HTTP/SSE serving off the RA4M1 entirely so Wi-Fi load cannot
 perturb control timing.
 
 ### Architecture
+
 - Fork [`arduino/uno-r4-wifi-usb-bridge`](https://github.com/arduino/uno-r4-wifi-usb-bridge)
   (the stock ESP32-S3 bridge firmware).
 - Keep its USB-serial bridge code untouched → `arduino-cli upload` to
@@ -115,6 +126,7 @@ perturb control timing.
   fire-and-forget. No `Modem::passthrough()` waits.
 
 ### Telemetry buffer + replay
+
 - Ring buffer in PSRAM, indexed by sequence number.
 - 10 Hz × 30 min × 32 B = ~576 KB → trivially fits 8 MB PSRAM. 8 MB flash
   holds ~7 hours.
@@ -122,11 +134,13 @@ perturb control timing.
   dropouts. Client (dashboard) detects gap by seq and requests the fill.
 
 ### Build tooling (minimal new burden)
+
 - `arduino-cli core install esp32:esp32`
 - `arduino-cli compile --fqbn esp32:esp32:esp32s3 <sketch>`
 - No PlatformIO, no Arduino IDE, no Docker, no npm.
 
 ### Operational caveat
+
 First flash needs the panel switch (GND + Download pins) per existing
 `docs/WIRING-GUIDE-V8.md`. After that, RA4M1 sketch upload still works.
 Re-flashing the ESP32 (rarely) needs the switch again. ESP32-S3 mask-ROM
@@ -134,11 +148,13 @@ bootloader is unerasable, so even a botched flash is recoverable via
 `espflash`.
 
 ### Triggers (when to start V9)
+
 - NEW-A mitigations don't get latency to acceptable, OR
 - Dashboard needs richer graphics that don't fit RA4M1's 256 KB flash, OR
 - We need session-replay / black-box logging that survives Wi-Fi drops.
 
-### Anti-patterns
+### Anti-patterns (V9)
+
 - Don't go architectural before NEW-A is exhausted.
 - Don't touch the bridge code; only add to it via 2–3 well-defined hook
   points (`setup_app()` from bridge `setup()`, one new AT-command
@@ -147,6 +163,7 @@ bootloader is unerasable, so even a botched flash is recoverable via
 ---
 
 ## Quick reference — source-code citations
+
 (So the next session doesn't have to re-research.)
 
 - `ArduinoCore-renesas/libraries/WiFiS3/src/Modem.h` — `MODEM_TIMEOUT 10000`,


### PR DESCRIPTION
## Summary
The handoff doc (`docs/HANDOFF-V8-V9-WIFI-LATENCY-AND-OFFLOAD.md`, merged via #58) was missing blank lines around headings (MD022) and lists (MD032). Since the `markdownlint` CI lints the whole repo, this turned **every** new PR's check red (e.g. #57, #60).

Fix: add the required blank lines. **Content unchanged.** Verified locally with `markdownlint-cli` against `.markdownlint.json` — whole repo clean.

Merging this first turns CI green on #57 and #60.

Docs only. Role tag: **[C-Builder]**

## Test plan
- [x] `markdownlint '**/*.md'` passes locally (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)