### PR TITLE
docs: board as single source of truth - draft-PR-on-start rule (#94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,14 @@ So: **never leave active work as a bare branch with no PR** — it is invisible 
 the board. One commit + a draft PR is enough to make it show. Agents must follow
 this without being asked.
 
+## Firmware Flash — Always Log It
+
+**Every** firmware upload to the digger (production *or* bench/test) gets a row
+appended to `docs/FIRMWARE-UPLOAD-LOG.md`, immediately after the flash — no
+exceptions. Each row records: **date, version, commit SHA, branch + PR #,
+board/port**, and notes covering **what changed** and **what to test**. This is
+the device's flight log; an unlogged flash is treated as not done.
+
 ## People
 
 - **Jason** — RC transmitter operator (safety supervisor)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,25 @@ input: RC transmitter (Jason) and joystick (Malaki/rider). 3-position override
 switch selects who has authority. X.BUS telemetry is streamed to a Wi-Fi
 dashboard (monitoring only).
 
+## Project Board — Single Source of Truth
+
+[Project #1](https://github.com/users/boulaajaj/projects/1) is the **single
+source of truth** for what is pending, in progress, and done. Anything being
+worked on **must** show as **In Progress** on the board.
+
+**The rule: starting work = open a draft PR.** As soon as work begins on an
+issue, open a *draft* PR whose body links the issue (`Closes #N`). A draft PR is
+the earliest GitHub-visible signal, and the board automation keys off it:
+
+- `.github/workflows/board-pr-in-review.yml` → when a PR links an **In Progress**
+  issue, the PR card is added and set to **In Review**.
+- Built-in Project workflows (enabled in the UI) move closed issues / merged PRs
+  to **Done**.
+
+So: **never leave active work as a bare branch with no PR** — it is invisible to
+the board. One commit + a draft PR is enough to make it show. Agents must follow
+this without being asked.
+
 ## People
 
 - **Jason** — RC transmitter operator (safety supervisor)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,12 @@ the earliest GitHub-visible signal, and the board automation keys off it:
 - Built-in Project workflows (enabled in the UI) move closed issues / merged PRs
   to **Done**.
 
+> **Automation limits (so expectations are right):** the In-Review step only
+> fires when the linked closing issue is already **In Progress**, and it is
+> skipped on PRs that don't receive the `PROJECTS_TOKEN` secret (e.g. fork PRs).
+> In those cases set the board status by hand. Setting the issue itself to
+> In Progress is still manual today.
+
 So: **never leave active work as a bare branch with no PR** — it is invisible to
 the board. One commit + a draft PR is enough to make it show. Agents must follow
 this without being asked.
@@ -31,9 +37,12 @@ this without being asked.
 
 **Every** firmware upload to the digger (production *or* bench/test) gets a row
 appended to `docs/FIRMWARE-UPLOAD-LOG.md`, immediately after the flash — no
-exceptions. Each row records: **date, version, commit SHA, branch + PR #,
-board/port**, and notes covering **what changed** and **what to test**. This is
-the device's flight log; an unlogged flash is treated as not done.
+exceptions. The table columns are **Date · Version · SHA · Branch · Board/Port ·
+Notes**; record the **PR #** inside the **Branch** cell (e.g.
+`agent/C-Builder/foo (PR #93)`), and put **what changed** + **what to test** in
+**Notes**. **Version** is the sketch version string carried in the build (e.g.
+`rc_test V7.18`), not a git tag. This is the device's flight log; an unlogged
+flash is treated as not done.
 
 ## People
 


### PR DESCRIPTION
Adds a repo-level rule to CLAUDE.md so it applies in every environment: active work must show In Progress on Project #1, and starting work = open a draft PR (Closes #N). Automation then handles In Review / Done.

Closes #94

Role: `[C-Builder]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance to require starting work with a draft pull request linked to the related issue.
  * Added a new rule to log every firmware flash in a shared upload record, including key details like version, branch, board, and test notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->