### PR TITLE
ci: merged PR -> Done automation + PR<->issue rule (#97)

### DIFF
--- a/.github/workflows/board-merged-pr-done.yml
+++ b/.github/workflows/board-merged-pr-done.yml
@@ -1,0 +1,67 @@
+name: Board · merged PR → Done
+
+# Moves a merged pull request's card to the "Done" column of Project #1 — with no
+# manual step. Companion to board-pr-in-review.yml (which puts issue-linked PRs
+# into In Review). Together: linked PR → In Review on open → Done on merge.
+#
+# Board-hygiene rule: this only moves a PR that is ALREADY on the board (i.e. it
+# went through In Review because it was linked to an In-Progress issue). It never
+# *adds* a PR card — a PR with no linked board issue stays off the board entirely.
+#
+# Token note: the default GITHUB_TOKEN cannot write to a user-owned Project, so
+# this uses the PROJECTS_TOKEN secret. Fork PRs don't receive secrets — the job
+# no-ops gracefully in that case.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  to-done:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+      PROJECT_ID: PVT_kwHOACps0s4Bb533
+      STATUS_FIELD: PVTSSF_lAHOACps0s4Bb533zhWmvVI
+      DONE_OPT: 02f34d03
+      OWNER: ${{ github.repository_owner }}
+      REPO: ${{ github.event.repository.name }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Move merged PR card to Done
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::PROJECTS_TOKEN not available (likely a fork PR). Skipping."
+            exit 0
+          fi
+
+          # Find this PR's EXISTING card on Project #1. Do NOT add it if absent —
+          # the board only tracks PRs that were linked to an In-Progress issue.
+          item_id=$(gh api graphql \
+            -f query='query($owner:String!,$repo:String!,$pr:Int!){
+              repository(owner:$owner,name:$repo){
+                pullRequest(number:$pr){
+                  projectItems(first:20){nodes{id project{id}}}
+                }}}' \
+            -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER" \
+            --jq ".data.repository.pullRequest.projectItems.nodes[] | select(.project.id==\"$PROJECT_ID\") | .id")
+
+          if [ -z "$item_id" ]; then
+            echo "PR #$PR_NUMBER is not on Project #1 (no linked-issue card) — nothing to do."
+            exit 0
+          fi
+
+          gh api graphql \
+            -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){
+              updateProjectV2ItemFieldValue(input:{
+                projectId:$p,itemId:$i,fieldId:$f,
+                value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
+            -f p="$PROJECT_ID" -f i="$item_id" -f f="$STATUS_FIELD" -f o="$DONE_OPT"
+
+          echo "✅ PR #$PR_NUMBER → Done"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,10 @@ source of truth** for what is pending, in progress, and done. Anything being
 worked on **must** show as **In Progress** on the board.
 
 **The rule: starting work = open a draft PR, and every PR gets its own issue.**
-As soon as work begins, open a *draft* PR whose body links its issue (`Closes
-#N`). One PR ↔ one issue — never a PR with no issue (it won't appear on the
-board, by design). A draft PR is the earliest GitHub-visible signal, and the
-board automation keys off it:
+As soon as work begins, open a *draft* PR whose body links its issue with a
+`Closes #N` line. One PR ↔ one issue — never a PR with no issue (it won't appear
+on the board, by design). A draft PR is the earliest GitHub-visible signal, and
+the board automation keys off it:
 
 - `.github/workflows/board-pr-in-review.yml` → when a PR links an **In Progress**
   issue, the PR card is added and set to **In Review**. A PR with no linked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,14 +14,19 @@ dashboard (monitoring only).
 source of truth** for what is pending, in progress, and done. Anything being
 worked on **must** show as **In Progress** on the board.
 
-**The rule: starting work = open a draft PR.** As soon as work begins on an
-issue, open a *draft* PR whose body links the issue (`Closes #N`). A draft PR is
-the earliest GitHub-visible signal, and the board automation keys off it:
+**The rule: starting work = open a draft PR, and every PR gets its own issue.**
+As soon as work begins, open a *draft* PR whose body links its issue (`Closes
+#N`). One PR ↔ one issue — never a PR with no issue (it won't appear on the
+board, by design). A draft PR is the earliest GitHub-visible signal, and the
+board automation keys off it:
 
 - `.github/workflows/board-pr-in-review.yml` → when a PR links an **In Progress**
-  issue, the PR card is added and set to **In Review**.
-- Built-in Project workflows (enabled in the UI) move closed issues / merged PRs
-  to **Done**.
+  issue, the PR card is added and set to **In Review**. A PR with no linked
+  In-Progress issue is left off the board entirely.
+- `.github/workflows/board-merged-pr-done.yml` → when a PR that is already on the
+  board is **merged**, its card moves to **Done** (it never adds a stray card).
+- Built-in Project workflow (enabled in the UI) moves **closed issues** to
+  **Done**.
 
 > **Automation limits (so expectations are right):** the In-Review step only
 > fires when the linked closing issue is already **In Progress**, and it is


### PR DESCRIPTION
Adds `board-merged-pr-done.yml`: when a PR already on Project #1 is **merged**, its card auto-moves to **Done** (never adds a stray card). Fixes merged PRs getting stuck in In Review.

Also documents in CLAUDE.md: every PR gets its own issue; PRs with no In-Progress linked issue stay off the board.

Closes #97

Role: `[C-Builder]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automation to move merged, already-boarded pull requests to the **Done** status on the project board.
  - Updated workflow guidance to require a draft pull request linked to a specific issue before work is started.

- **Bug Fixes**
  - Prevented board updates from creating new project items when a merged pull request was not already tracked.
  - Added a safe fallback for cases where project access is unavailable, so those runs exit cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->