### PR TITLE
fix: dashboard battery % uses real LiPo SoC curve (#102)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -449,7 +449,19 @@ let dOutL=1500, dOutR=1500;
 const SMOOTH=0.18;                       // ease factor per frame (higher = snappier)
 function ez(c,t){ return c + (t - c) * SMOOTH; }
 
-function bp(v){return Math.max(0,Math.min(100,((v-9)/(12.6-9))*100))}
+// 3S LiPo state-of-charge from pack voltage. The discharge curve is NON-linear
+// (flat mid-range, steep at the ends), so a straight line over-reads the middle.
+// Lookup table + linear interpolation; 0% anchored at the 10.0 V motor cutoff,
+// 100% at 12.6 V. (Resting curve; under load the pack reads a touch low.)
+function bp(v){
+  const C=[[10.0,0],[10.3,10],[10.6,22],[10.8,30],[11.1,40],[11.4,50],[11.7,65],[12.0,80],[12.3,90],[12.6,100]];
+  if(v<=C[0][0])return 0;
+  if(v>=C[C.length-1][0])return 100;
+  for(let i=1;i<C.length;i++){
+    if(v<C[i][0]){const[a,pa]=C[i-1],[b,pb]=C[i];return pa+(pb-pa)*(v-a)/(b-a);}
+  }
+  return 100;
+}
 function bc(p){return p>50?'linear-gradient(90deg,#0c6,#4f8)':p>25?'linear-gradient(90deg,#fa0,#fc0)':'linear-gradient(90deg,#f44,#f66)'}
 function ndl(id,val,max){const e=document.getElementById(id);
   if(e) e.setAttribute('transform',`rotate(${-135+Math.max(0,Math.min(val/max,1))*270},50,50)`);}

--- a/sketches/rc_test/web_page.h
+++ b/sketches/rc_test/web_page.h
@@ -450,7 +450,15 @@ let dOutL=1500, dOutR=1500;
 const SMOOTH=0.18;                       // ease factor per frame (higher = snappier)
 function ez(c,t){ return c + (t - c) * SMOOTH; }
 
-function bp(v){return Math.max(0,Math.min(100,((v-9)/(12.6-9))*100))}
+function bp(v){
+  const C=[[10.0,0],[10.3,10],[10.6,22],[10.8,30],[11.1,40],[11.4,50],[11.7,65],[12.0,80],[12.3,90],[12.6,100]];
+  if(v<=C[0][0])return 0;
+  if(v>=C[C.length-1][0])return 100;
+  for(let i=1;i<C.length;i++){
+    if(v<C[i][0]){const[a,pa]=C[i-1],[b,pb]=C[i];return pa+(pb-pa)*(v-a)/(b-a);}
+  }
+  return 100;
+}
 function bc(p){return p>50?'linear-gradient(90deg,#0c6,#4f8)':p>25?'linear-gradient(90deg,#fa0,#fc0)':'linear-gradient(90deg,#f44,#f66)'}
 function ndl(id,val,max){const e=document.getElementById(id);
   if(e) e.setAttribute('transform',`rotate(${-135+Math.max(0,Math.min(val/max,1))*270},50,50)`);}

--- a/tools/ui-test-batt.mjs
+++ b/tools/ui-test-batt.mjs
@@ -1,0 +1,31 @@
+// Local test for the battery % curve (bp()). Injects mock pack voltages via the
+// dashboard's own applyData() and reads back the displayed %, so the SoC fix can
+// be verified WITHOUT flashing.  node tools/ui-test-batt.mjs
+import { chromium } from 'playwright';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const page_url = 'file://' + resolve(root, 'dashboard/index.html');
+
+const frame = (volts) => ({ t: 0, seq: 1, gear: 1, mode: 0, fs: 0, lost: 0, outL: 1500, outR: 1500,
+  e0: { ok: 1, age: 50, rpm: 0, cur: 0, v: Math.round(volts * 10), tE: 30, tM: 25 },
+  e1: { ok: 1, age: 50, rpm: 0, cur: 0, v: Math.round(volts * 10), tE: 30, tM: 25 } });
+
+// [pack V, old linear %, expected curve %]
+const cases = [[12.6,'100','100'],[12.0,'83','80'],[11.4,'67','50'],[11.1,'58','40'],[10.6,'44','22'],[10.0,'28','0']];
+
+const browser = await chromium.launch({ channel: 'chrome' });
+const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+await page.goto(page_url, { waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(300);
+
+console.log('pack V | old(linear) | expect(curve) | actual');
+for (const [v, oldp, exp] of cases) {
+  // inject repeatedly so the eased display value settles on the target
+  for (let i = 0; i < 30; i++) { await page.evaluate((d) => window.applyData(d), frame(v)); await page.waitForTimeout(20); }
+  await page.waitForTimeout(200);
+  const pct = await page.evaluate(() => document.getElementById('batLPct').textContent);
+  console.log(`${v.toFixed(1)}V |     ${oldp}%     |     ~${exp}%     |   ${pct}`);
+}
+await browser.close();


### PR DESCRIPTION
Replaces the linear 9.0-12.6V battery-% map with a 3S LiPo SoC lookup table + interpolation, 0% anchored at the 10.0V cutoff.

| Pack V | Was (linear) | Now (curve) |
|---|---|---|
| 11.4 V | 67% | 50% |
| 10.6 V | 44% | 22% |
| 10.0 V | 28% | 0% |

Mirrored to web_page.h; verified locally with mock voltages (tools/ui-test-batt.mjs). No firmware logic change — reflash to update the embedded page after merge.

Closes #102

Role: `[C-Builder]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)