### PR TITLE
docs: Phase A target architecture — ARCHITECTURE-TARGET.md + ADR-0001 (#128)

### DIFF
--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -634,10 +634,10 @@ Permanent cure remains #55 (offload Wi-Fi to the ESP32-S3). Diagnostic method
 ## 2026-07-05 — Adopt domain-oriented target architecture (epic #116, ADR-0001)
 
 Decided: migrate the production firmware to a layered, domain-oriented
-structure under `sketches/dual_track_control/src/` — `application/` /
-`domain/` (drive, operator_input, battery, thermal, safety) / `ports/` /
-`infrastructure/` (arduino, radiolink, xc, network) / `telemetry/` / `alerts/`
-/ `config/` / `generated/`. Full spec: `docs/architecture/ARCHITECTURE-TARGET.md`.
+structure under `sketches/dual_track_control/src/` with these layers:
+`application/`, `domain/` (drive, operator_input, battery, thermal, safety),
+`ports/`, `infrastructure/` (arduino, radiolink, xc, network), `telemetry/`,
+`alerts/`, `config/`, `generated/`. Full spec: `docs/architecture/ARCHITECTURE-TARGET.md`.
 Key rules: pure domain (no Arduino includes, no mutable namespace-scope state,
 time as parameter), one owner per state, ports with link-time substitution
 (virtuals only for genuine runtime swapping), observers read an immutable
@@ -664,4 +664,5 @@ bench tests. Every refactor PR must (a) compile locally via arduino-cli before
 push, (b) preserve behavior via characterization/host tests (#47), (c) change
 no control-path behavior. Physical checks accumulate in
 `docs/architecture/BENCH-VERIFICATION-DEFERRED.md`; one bench pass runs the
-whole checklist when hardware returns, then is logged in FIRMWARE-UPLOAD-LOG.
+whole checklist when hardware returns, then is logged in
+`docs/FIRMWARE-UPLOAD-LOG.md`.

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -630,3 +630,38 @@ reconnect can be accepted. Add a stale-SSE guard (no successful write for ~3 s �
 stop) and, as a fallback only if testing still shows wedges, a server/AP recycle.
 Permanent cure remains #55 (offload Wi-Fi to the ESP32-S3). Diagnostic method
 (serial `clients_seq` watch) is reusable for verification.
+
+## 2026-07-05 — Adopt domain-oriented target architecture (epic #116, ADR-0001)
+
+Decided: migrate the production firmware to a layered, domain-oriented
+structure under `sketches/dual_track_control/src/` — `application/` /
+`domain/` (drive, operator_input, battery, thermal, safety) / `ports/` /
+`infrastructure/` (arduino, radiolink, xc, network) / `telemetry/` / `alerts/`
+/ `config/` / `generated/`. Full spec: `docs/architecture/ARCHITECTURE-TARGET.md`.
+Key rules: pure domain (no Arduino includes, no mutable namespace-scope state,
+time as parameter), one owner per state, ports with link-time substitution
+(virtuals only for genuine runtime swapping), observers read an immutable
+per-cycle SystemSnapshot. File policy ≤150 lines soft / 250 hard, generic
+names (Utils/Helpers/Manager/…) banned. CI fitness functions (#129) will
+enforce. Rationale + rejected alternatives: ADR-0001.
+
+Compile feasibility PROVEN before adoption: spike sketch with nested
+`src/{application,domain,ports,infrastructure}` compiled clean on
+`arduino:renesas_uno:unor4wifi` (arduino-cli 1.4.1), domain file with zero
+Arduino includes. Arduino sketch spec compiles `src/` recursively.
+
+## 2026-07-05 — Production sketch to be renamed rc_test → dual_track_control (#118)
+
+Operator-chosen name; reflects that the firmware is a generic dual-track/tank
+drive controller (no hydraulics/attachment control). Directory stays
+lowercase_snake_case per structure-check CI; PascalCase reserved for C++ type
+names inside src/.
+
+## 2026-07-05 — Refactor verification strategy while hardware is unavailable
+
+No machine access for the duration of the #116 remediation: no flashing, no
+bench tests. Every refactor PR must (a) compile locally via arduino-cli before
+push, (b) preserve behavior via characterization/host tests (#47), (c) change
+no control-path behavior. Physical checks accumulate in
+`docs/architecture/BENCH-VERIFICATION-DEFERRED.md`; one bench pass runs the
+whole checklist when hardware returns, then is logged in FIRMWARE-UPLOAD-LOG.

--- a/docs/architecture/ARCHITECTURE-TARGET.md
+++ b/docs/architecture/ARCHITECTURE-TARGET.md
@@ -59,7 +59,9 @@ sketches/dual_track_control/
     │       ├── SafetySupervisor.h/.cpp   (battery + thermal + RC freshness → decision)
     │       └── OutputGate.h/.cpp         (ACTIVE/HOLD/CUT state machine, ease-out ramp)
     │
-    ├── ports/                    ← tiny headers; domain-side contracts for hardware
+    ├── ports/                    ← tiny headers; hardware contracts consumed by
+    │                               application/ — they speak domain types, but
+    │                               domain/ itself never includes them
     │   ├── ClockPort.h           (now µs/ms)
     │   ├── RcInputPort.h         (channels + freshness)
     │   ├── JoystickPort.h        (raw ADC pair)

--- a/docs/architecture/ARCHITECTURE-TARGET.md
+++ b/docs/architecture/ARCHITECTURE-TARGET.md
@@ -1,0 +1,265 @@
+# Target Architecture — Dual Track Control
+
+**Status:** adopted 2026-07-05 (epic #116, issue #128, ADR-0001)
+**Applies to:** the production firmware, migrating from `sketches/rc_test/` to
+`sketches/dual_track_control/` (rename tracked in #118)
+
+This document is the contract for the Phase D refactor (#117, #130, #132) and
+the rulebook the CI architecture fitness functions (#129) enforce. Bench
+sketches (`sketches/*_test/`, `hw_diagnostic`, …) are exempt — they are
+throwaway bring-up tools by design.
+
+---
+
+## 1. Why this architecture
+
+The firmware has two jobs: drive a real machine safely, and demonstrate how a
+growing, safety-aware, multi-domain embedded system is engineered. The current
+single 1606-line `.ino` works, but its `[MODULE]` comment sections are
+navigation, not boundaries — nothing stops a Wi-Fi function from reading a
+safety latch directly, and none of the control math can run off-target.
+
+The target: **domain logic that could run on a laptop, hardware access behind
+explicit ports, one owner per piece of state, and a composition root that reads
+like the signal-flow diagram.**
+
+## 2. Target tree
+
+```text
+sketches/dual_track_control/
+├── dual_track_control.ino        ← composition root ONLY (~20-30 lines)
+└── src/
+    ├── application/              ← orchestration: wires domains + ports, owns the cycle
+    │   ├── FirmwareApp.h/.cpp    ← setup()/tick() entry, owns module instances
+    │   ├── ControlCycle.h/.cpp   ← one pass: read → decide → gate → write → observe
+    │   └── SystemSnapshot.h      ← immutable per-cycle state for observers (#132)
+    │
+    ├── domain/                   ← pure logic. NO Arduino/hardware includes. Host-compilable.
+    │   ├── drive/
+    │   │   ├── DriveTypes.h              (DriveIntent, TrackCommand, WheelSpeeds)
+    │   │   ├── CurvatureDrive.h/.cpp     (curvature mix + desaturation)
+    │   │   ├── PivotPolicy.h/.cpp        (pivot cap, blend band, throttle taper)
+    │   │   ├── GearPolicy.h/.cpp         (gear scale, per-gear caps, reverse cap)
+    │   │   └── CommandMixer.h/.cpp       (max/oppose RC+joystick combine)
+    │   ├── operator_input/
+    │   │   ├── InputTypes.h              (OperatorInput, normalized axes)
+    │   │   ├── DeadbandPolicy.h/.cpp
+    │   │   ├── ExpoCurve.h/.cpp
+    │   │   └── InputNormalization.h/.cpp (raw→[-1,1], gains, polarity)
+    │   ├── battery/
+    │   │   ├── BatteryTypes.h            (BatteryReading, BatteryStatus)
+    │   │   ├── VoltagePlausibility.h/.cpp(validity + worst-of-two — ONE implementation)
+    │   │   └── BatteryLadder.h/.cpp      (Eco lock, low-V alarm level, cutoff, boot gate)
+    │   ├── thermal/
+    │   │   ├── ThermalTypes.h            (ThermalReading, ThermalStage)
+    │   │   ├── ThermalHysteresis.h/.cpp  (one stage: on/off thresholds + trip debounce)
+    │   │   └── ThermalDerating.h/.cpp    (warn / eco / cut staging off hottest sensor)
+    │   └── safety/
+    │       ├── SafetyTypes.h             (SafetyInputs, SafetyDecision, FailsafeReason)
+    │       ├── SafetySupervisor.h/.cpp   (battery + thermal + RC freshness → decision)
+    │       └── OutputGate.h/.cpp         (ACTIVE/HOLD/CUT state machine, ease-out ramp)
+    │
+    ├── ports/                    ← tiny headers; domain-side contracts for hardware
+    │   ├── ClockPort.h           (now µs/ms)
+    │   ├── RcInputPort.h         (channels + freshness)
+    │   ├── JoystickPort.h        (raw ADC pair)
+    │   ├── EscOutputPort.h       (µs per track; attach/detach)
+    │   ├── TelemetrySource.h     (EscTelem per ESC)
+    │   ├── TelemetrySink.h       (SystemSnapshot out)
+    │   └── AlertOutputPort.h     (piezo on/off)
+    │
+    ├── infrastructure/           ← the ONLY layer that includes hardware libraries
+    │   ├── arduino/              (ArduinoClock, PwmEscAdapter, PiezoAdapter, AdcJoystickAdapter, WatchdogAdapter)
+    │   ├── radiolink/            (SbusReceiverAdapter — sbus lib + inverted-UART detail)
+    │   ├── xc/                   (XbusTelemetryAdapter — 0x10 poller, framing, checksum)
+    │   └── network/              (WifiService, DashboardServer, SseStream — non-blocking rules live here)
+    │
+    ├── telemetry/                ← observers: encode SystemSnapshot for sinks
+    │   ├── TelemetryScaling.h    (×10 integer scaling — ONE implementation)
+    │   ├── JsonEncoder.h/.cpp    (SSE //data payload)
+    │   └── CsvEncoder.h/.cpp     (USB debug stream)
+    │
+    ├── alerts/                   ← beep vocabulary + priority (domain-ish, no hardware)
+    │   ├── AlertTypes.h          (AlertView, patterns)
+    │   ├── AlertPolicy.h/.cpp    (priority: thermal-cut > low-V > thermal-warn > inactivity)
+    │   └── PatternPlayer.h/.cpp  (non-blocking on/off sequencing)
+    │
+    ├── config/                   ← ALL tunables, grouped by domain (replaces [CONFIG])
+    │   ├── DriveConfig.h  SafetyConfig.h  BatteryConfig.h  ThermalConfig.h
+    │   ├── InputConfig.h  TelemetryConfig.h  WifiConfig.h  AlertConfig.h
+    │   ├── Pins.h                (every pin assignment in one file)
+    │   └── BuildInfo.h           (FIRMWARE_VERSION — single source of truth, #124)
+    │
+    └── generated/                ← machine-written only; never hand-edited (#120)
+        └── web_page.h
+```
+
+`tests/` (host-side, #47/#131) lives at repo root, mirroring `domain/`
+subfolders plus `characterization/` and `invariants/`.
+
+## 3. Layers and dependency rules
+
+| Layer | May depend on | Must NOT depend on |
+| --- | --- | --- |
+| `domain/` | other `domain/` headers, `config/` | `Arduino.h`, `WiFiS3.h`, `Servo.h`, SBUS lib, X.BUS/GL10 code, `ports/`, `infrastructure/`, `application/` |
+| `ports/` | plain types from `domain/` | any hardware library |
+| `application/` | `domain/`, `ports/`, `telemetry/`, `alerts/`, `config/` | `infrastructure/` internals (talks through ports) |
+| `infrastructure/` | `ports/`, hardware libraries, `config/` | `domain/` internals (plain types via ports only), `application/` |
+| `telemetry/`, `alerts/` | `application/SystemSnapshot.h`, `domain/` types, `config/` | hardware libraries, domain *internals* (mutable state) |
+| `generated/` | — | hand edits |
+| `.ino` | `application/` only | everything else |
+
+Three non-negotiables, enforced by #129:
+
+1. **`domain/` compiles on the host** with no Arduino includes.
+2. **No namespace-scope mutable state in `domain/`.** Modules own state via
+   structs passed explicitly (or objects held by `application/`).
+3. **Time is a parameter.** Domain code never calls `millis()`/`micros()`;
+   `ControlCycle` reads `ClockPort` once per pass and passes `now` down.
+
+## 4. Control flow (one cycle)
+
+```text
+   SbusReceiverAdapter   AdcJoystickAdapter        XbusTelemetryAdapter
+        │ RcInputPort         │ JoystickPort             │ TelemetrySource
+        ▼                     ▼                          ▼
+   ┌────────────────────────────────┐            ┌───────────────────┐
+   │ operator_input:                │            │ battery:          │
+   │ normalize → deadband → expo →  │            │ plausibility →    │
+   │ gains → OperatorInput          │            │ ladder            │
+   └───────────────┬────────────────┘            │ thermal:          │
+                   ▼                             │ hysteresis stages │
+   ┌────────────────────────────────┐            └─────────┬─────────┘
+   │ drive: CommandMixer →          │                      │
+   │ GearPolicy → PivotPolicy →     │                      ▼
+   │ CurvatureDrive → TrackCommand  │            ┌───────────────────┐
+   └───────────────┬────────────────┘            │ safety:           │
+                   │       proposed command      │ SafetySupervisor  │
+                   └──────────────┬──────────────┤ → SafetyDecision  │
+                                  ▼              └───────────────────┘
+                        ┌───────────────────┐
+                        │ safety:OutputGate │  ACTIVE / HOLD(ease) / CUT
+                        └─────────┬─────────┘
+                                  ▼ approved µs
+                        ┌───────────────────┐
+                        │ EscOutputPort →   │
+                        │ PwmEscAdapter     │
+                        └───────────────────┘
+
+   ControlCycle then builds ONE immutable SystemSnapshot and hands it read-only to:
+      telemetry/JsonEncoder → SSE/dashboard      (monitoring only — permanent rule)
+      telemetry/CsvEncoder  → USB debug
+      alerts/AlertPolicy    → PatternPlayer → AlertOutputPort (piezo)
+```
+
+The permanent safety rules are unchanged by this refactor: **open-loop control**
+(telemetry never feeds throttle), **no control input over Wi-Fi, ever**, and the
+watchdog refresh stays exactly once per cycle, after the control path.
+
+## 5. State ownership
+
+**One domain owns its state; no other domain writes it.** The concrete sins
+this outlaws (all present in `rc_test.ino` today):
+
+- `[SAFETY]` writing `[ALERT]`'s `lowVoltLatched` → instead `SafetyDecision`
+  carries `alarmRequested`; `AlertPolicy` reads it and owns its own latch.
+- `curvatureDrive()` silently reading the `currentGear` global → gear is a
+  field of the input it receives.
+- Wi-Fi/debug scraping ~30 globals → observers read `SystemSnapshot` only.
+
+`SystemSnapshot` (#132) is built once per cycle by `application/` and passed
+`const&` to every observer. Observers cannot write, and cannot see two
+different cycles in one frame.
+
+## 6. File and naming policy
+
+- **Soft limit 150 lines** per human-written source file (one screenful);
+  **hard CI fail at 250**; exemptions in `.architecture-allowlist` with a
+  written reason (generated files, lookup tables).
+- One file = one concept. Splitting `Foo.cpp` into `FooPart2.cpp` to duck the
+  limit is a review reject — split by *responsibility* or don't split.
+- Sketch/dir names `lowercase_snake_case` (structure-check CI). C++ types
+  `PascalCase`, functions `camelCase`, constants `UPPER_SNAKE_CASE`, pins
+  `PIN_*` (unchanged from today's rules).
+- **Banned file names:** `Utils`, `Helpers`, `Helper`, `Manager`, `Common`,
+  `Misc`, `Stuff`, `Data`. A `helpers/` *folder* inside a domain is allowed
+  only when every file in it names one precise responsibility
+  (e.g. `drive/helpers/Smoothstep.h`) — never a grab-bag file.
+- Domain language over mechanism language: `OutputGate`, not `PwmManager`;
+  `FailsafeReason`, not `ErrorCode`.
+
+## 7. Ports & adapters strategy
+
+Ports are **small headers** owned by the consuming side; adapters implement
+them in `infrastructure/`. Preference order:
+
+1. **Link-time substitution** (default): the firmware build links the Arduino
+   adapter, the host test build links a fake. Zero runtime cost, no vtables.
+2. **Virtual interfaces** only where implementations genuinely swap at runtime
+   (none identified today).
+
+No Arduino type may appear in a port signature — ports speak `domain/` types
+and primitives.
+
+## 8. Ubiquitous language
+
+| Term | Meaning |
+| --- | --- |
+| `OperatorInput` | Normalized post-shaping axis pair from one input source |
+| `DriveIntent` | Mixed, gear-capped command before safety review |
+| `TrackCommand` | Per-track normalized output (−1..+1) |
+| `ServoOutput` | Per-track µs (1000–2000) |
+| `SafetyDecision` | Supervisor verdict: allow / ease-to-stop / cut + `FailsafeReason` |
+| `FailsafeReason` | Why drive is denied: RC_STALE, BATTERY_CUTOFF, THERMAL_CUT, BOOT_GATE |
+| `BatteryLadder` | Staged response: Eco-lock 10.8 V → alarm 10.5 V → cutoff 10.0 V |
+| `ThermalStage` | NORMAL / WARN (80°) / ECO (90°) / CUT (95°), hysteresis releases |
+| `OutputGate` | ACTIVE / HOLD (ease to neutral) / CUT (no pulses) state machine |
+| `SystemSnapshot` | Immutable per-cycle state for observers |
+| `Gear` | Eco / Normal / Boost average-speed cap |
+
+## 9. Migration plan (Phase D, #117)
+
+Smallest, purest logic first — the pattern is proven before the propulsion
+path moves:
+
+1. `VoltagePlausibility`
+2. `BatteryLadder`
+3. `ThermalHysteresis` / `ThermalDerating`
+4. `TelemetryScaling` + encoders
+5. `operator_input/`
+6. `CurvatureDrive`
+7. `PivotPolicy` / `GearPolicy`
+8. `SafetySupervisor`
+9. `OutputGate`
+10. `infrastructure/` adapters
+11. `FirmwareApp` + composition-root `.ino`
+
+**Rules for every migration PR** (operating constraints locked 2026-07-05):
+
+- Behavior-preserving only; characterization tests (#47) green before/after.
+- `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi` locally **before
+  every push** — structure problems surface at step 1, not step 10.
+- **No hardware available:** no flashing, no bench tests. Compile plus host
+  tests plus review are the verification. Each PR appends any physical checks it would
+  have run to `docs/architecture/BENCH-VERIFICATION-DEFERRED.md`; one bench
+  pass executes that whole checklist when the machine returns.
+- One extraction step per PR, own issue, draft PR from the first commit
+  (board rules unchanged).
+
+## 10. Enforcement
+
+Rules in this document are enforced by the CI architecture fitness functions
+(#129): forbidden includes, layer direction, file-size policy, banned names,
+no mutable domain globals, generated-file drift, version SSOT. Until #129
+lands they are review-enforced.
+
+## 11. Testing strategy (summary — details in #47/#131)
+
+| Level | What | Where |
+| --- | --- | --- |
+| 1 Pure domain | curvature, expo, deadband, gear/reverse caps, plausibility | `tests/<domain>/` |
+| 2 State transitions | ladder debounce/latch, thermal hysteresis, output gate, explicit `now` | `tests/<domain>/` |
+| 3 Characterization | current firmware behavior captured BEFORE refactor | `tests/characterization/` |
+| 4 Invariants + faults | outputs bounded, stale-RC ⇒ neutral, cutoff dominates, monotone derating | `tests/invariants/` (#131) |
+| 5 Adapters | S.BUS decode, X.BUS framing/checksum, JSON/CSV encoding | `tests/` |
+| 6 Bench (deferred) | physical behavior per BENCH-VERIFICATION-DEFERRED.md | hardware, when available |

--- a/docs/architecture/ARCHITECTURE-TARGET.md
+++ b/docs/architecture/ARCHITECTURE-TARGET.md
@@ -105,11 +105,18 @@ subfolders plus `characterization/` and `invariants/`.
 | --- | --- | --- |
 | `domain/` | other `domain/` headers, `config/` | `Arduino.h`, `WiFiS3.h`, `Servo.h`, SBUS lib, X.BUS/GL10 code, `ports/`, `infrastructure/`, `application/` |
 | `ports/` | plain types from `domain/` | any hardware library |
-| `application/` | `domain/`, `ports/`, `telemetry/`, `alerts/`, `config/` | `infrastructure/` internals (talks through ports) |
+| `application/` (incl. its observer submodules `telemetry/`, `alerts/`) | `domain/`, `ports/`, `config/` | `infrastructure/` internals (talks through ports) |
 | `infrastructure/` | `ports/`, hardware libraries, `config/` | `domain/` internals (plain types via ports only), `application/` |
-| `telemetry/`, `alerts/` | `application/SystemSnapshot.h`, `domain/` types, `config/` | hardware libraries, domain *internals* (mutable state) |
+| `telemetry/`, `alerts/` (observer ring of the application layer) | `application/SystemSnapshot.h` ONLY from application/, plus `domain/` types, `config/` | hardware libraries, any other `application/` header, domain *internals* (mutable state) |
 | `generated/` | — | hand edits |
 | `.ino` | `application/` only | everything else |
+
+`telemetry/` and `alerts/` are part of the **application layer** (its observer
+ring), not a separate layer — so application orchestration calling them is
+within-layer, not a cross-layer cycle. At file level the graph stays acyclic:
+`SystemSnapshot.h` includes nothing from `telemetry/` or `alerts/`, and those
+folders may include no `application/` header except `SystemSnapshot.h`. The
+fitness checks (#129) enforce exactly that file-level rule.
 
 Three non-negotiables, enforced by #129:
 

--- a/docs/architecture/BENCH-VERIFICATION-DEFERRED.md
+++ b/docs/architecture/BENCH-VERIFICATION-DEFERRED.md
@@ -1,0 +1,28 @@
+# Deferred Bench Verification — epic #116 refactor
+
+No hardware is available during the architecture remediation (constraint locked
+2026-07-05), so refactor PRs are verified by compile + host tests + review
+only. **Every PR that would normally get a bench check appends its physical
+checks here.** When the machine is available again, run this entire checklist
+in one session, then log the flash in `docs/FIRMWARE-UPLOAD-LOG.md` as usual.
+
+> Rule: an item is only removed once it has been physically verified and the
+> result noted. If any item fails, the refactor PR that added it is the first
+> suspect.
+
+## Standing checks (run regardless of which PRs merged)
+
+- [ ] Stick→track response identical to V7.34 baseline in all 3 gears, forward/reverse/pivot (feel + serial CSV compare)
+- [ ] RC-loss failsafe: ease to neutral, then no pulses; ESCs beep; recovery on signal return
+- [ ] Battery ladder on bench supply: Eco-lock ~10.8 V (15 s), alarm 10.5 V, cutoff 10.0 V latched
+- [ ] Thermal stages (heat gun / simulated): trill ≥80 °C, Eco ≥90 °C, cut ≥95 °C, auto-recovery + restored flourish
+- [ ] Wi-Fi dashboard: connects, SSE at ~5 Hz, page load doesn't perturb control (watchdog silent)
+- [ ] Horn, Wi-Fi-ready beep, inactivity alarm patterns unchanged
+- [ ] Loop rate still ~20 kHz idle (serial banner / measurement)
+
+## Per-PR additions
+
+Append rows below as PRs merge.
+
+| Date | PR | What to verify physically |
+| --- | --- | --- |

--- a/docs/architecture/adr/0001-domain-oriented-firmware-architecture.md
+++ b/docs/architecture/adr/0001-domain-oriented-firmware-architecture.md
@@ -1,0 +1,72 @@
+# ADR-0001: Domain-oriented firmware architecture with enforced boundaries
+
+**Status:** Accepted · 2026-07-05 · epic #116, issue #128
+
+## Context
+
+The production firmware is a single 1606-line `.ino` organized by `[MODULE]`
+comment sections. It works and is well-documented, but:
+
+- Comment sections are not boundaries — any function can read or write any of
+  ~40 file-scope globals (e.g. the `[SAFETY]` module writes the `[ALERT]`
+  module's `lowVoltLatched`; `curvatureDrive()` reads the `currentGear` global
+  behind its parameter list).
+- None of the control math can compile off-target, so there are no host tests
+  on a safety-relevant propulsion path (issue #47 is blocked on this).
+- The repo's own rule ("split at ~500 lines") and review guidance ("flag
+  global state mutation") cannot be followed inside one `.ino`.
+- The repository doubles as a portfolio demonstrating enterprise engineering
+  practice; the architecture itself is a deliverable.
+
+A real incident motivates the boundary discipline: a blocking ~33 KB Wi-Fi
+page send froze `loop()` while the ESCs held the last throttle (#69). The fix
+(incremental serving + watchdog) worked, but nothing structural prevents the
+next accidental coupling between serving and control.
+
+## Decision
+
+Adopt the layered, domain-oriented architecture specified in
+[`ARCHITECTURE-TARGET.md`](../ARCHITECTURE-TARGET.md):
+
+1. **Layers with one-way dependencies:** `.ino` → `application/` →
+   `domain/` + `ports/`; `infrastructure/` implements ports; observers read an
+   immutable `SystemSnapshot`.
+2. **Pure domain:** no Arduino/hardware includes, no namespace-scope mutable
+   state, time passed as a parameter — every domain rule host-testable.
+3. **Ports & adapters** with link-time substitution preferred over virtual
+   interfaces (zero runtime cost on the 48 MHz RA4M1).
+4. **One owner per piece of state;** cross-domain communication through
+   returned decision/status types, never sideways writes.
+5. **File policy:** ≤150 lines soft / 250 hard, allowlisted exceptions;
+   generic names (`Utils`, `Helpers`, `Manager`, …) banned.
+6. **CI-enforced:** architecture fitness functions (#129) fail the build on
+   forbidden includes, layer violations, oversized files, banned names,
+   mutable domain globals, and generated-file drift.
+
+Migration is behavior-preserving, smallest-pure-logic-first (#117), protected
+by characterization tests (#47) and safety invariants (#131), with a local
+`arduino-cli` compile before every push. While no hardware is available,
+physical checks accumulate in `BENCH-VERIFICATION-DEFERRED.md` for one bench
+pass later.
+
+## Consequences
+
+**Positive:** propulsion math testable on a laptop with deterministic time;
+state ownership explicit; the #69 class of coupling becomes a CI failure, not
+a field discovery; new domains (e.g. future attachments) get an obvious home;
+the repo demonstrates architecture governance, not just architecture diagrams.
+
+**Negative / accepted costs:** more files and folders than a hobby sketch
+needs (deliberate — showcase is a stated goal); some indirection when tracing
+a value from stick to ESC (mitigated by the control-flow diagram and naming);
+migration effort spread over ~11 PRs; contributors must learn the dependency
+rules (enforced by CI, documented in CONTRIBUTING.md, #126).
+
+**Rejected alternatives:**
+
+- *Flat `.h/.cpp` pairs per `[MODULE]`* (original #117): reproduces the same
+  coupling with more files; no host-testability guarantee.
+- *Virtual-interface hexagonal everywhere:* unnecessary runtime indirection;
+  link-time seams give the same inversion for free.
+- *Full RTOS / event-driven rewrite:* out of scope; the superloop is simple,
+  proven, and appropriate at ~20 kHz.


### PR DESCRIPTION
## Summary

Phase A of epic #116 — the target architecture, written down before any code moves:

- **`docs/architecture/ARCHITECTURE-TARGET.md`** — layered target tree under `sketches/dual_track_control/src/` (application / domain / ports / infrastructure / telemetry / alerts / config / generated), one-way dependency rules, state-ownership model + SystemSnapshot, control-flow diagram, ubiquitous-language glossary, 150/250 file policy with banned generic names, ports/adapters via link-time seams, 11-step behavior-preserving migration order
- **`docs/architecture/adr/0001-domain-oriented-firmware-architecture.md`** — decision, consequences, rejected alternatives (first ADR)
- **`docs/architecture/BENCH-VERIFICATION-DEFERRED.md`** — the checklist that accumulates physical checks while no hardware is available
- **`docs/DECISION-LOG.md`** — three entries: architecture adoption, `rc_test` → `dual_track_control` rename decision, no-hardware verification strategy

**Role tag:** `[C-Builder]`

Docs only — zero firmware changes.

## Test plan

- [x] Layout compile-proven before adoption: spike sketch with nested `src/{application,domain,ports,infrastructure}` compiled clean on `arduino:renesas_uno:unor4wifi` (arduino-cli 1.4.1), domain file with zero Arduino includes
- [x] `markdownlint` clean locally with repo config
- [ ] CI green (markdownlint job; no sketch touched so compile matrix unaffected)
- [ ] Review of the architecture itself — this doc is the contract for #117/#129/#130/#132, so operator sign-off IS the test

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)
