### PR TITLE
chore: guardrails first — .claude/rules + generated-file hook + structure-check fix (#134)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,34 @@
+# Architecture Rules (canonical spec: docs/architecture/ARCHITECTURE-TARGET.md)
+
+These rules govern all production-firmware code. The architecture document is
+canonical; if this file and the doc disagree, the doc wins — fix this file.
+
+## Layers and dependency direction (one-way, no exceptions)
+
+- `.ino` → `application/` only. `application/` → `domain/` + `ports/` +
+  `telemetry/` + `alerts/` + `config/`.
+- `domain/` may include other `domain/` headers and `config/` ONLY. Never
+  `Arduino.h`, `WiFiS3.h`, `Servo.h`, SBUS, X.BUS/GL10 code, `ports/`,
+  `infrastructure/`, or `application/`.
+- `infrastructure/` implements `ports/`; it never includes `domain/` internals
+  or `application/`.
+- `src/generated/` is machine-written. Never edit it by hand — edit the source
+  (e.g. `dashboard/index.html`) and regenerate.
+
+## File policy
+
+- One file = one concept. Soft limit 150 lines, hard limit 250 for
+  human-written source. Never split a file into `Part2`-style fragments to
+  duck the limit — split by responsibility or ask.
+- Banned file names: `Utils`, `Helpers`, `Helper`, `Manager`, `Common`,
+  `Misc`, `Stuff`, `Data`. A `helpers/` folder inside a domain is acceptable
+  only when every file in it names one precise responsibility.
+- Names use the project's ubiquitous language (OutputGate, SafetyDecision,
+  FailsafeReason, BatteryLadder, ThermalStage — see the glossary in the
+  architecture doc), not mechanism words (PwmManager, ErrorCode).
+
+## When you cannot comply
+
+If a change appears to require breaking a dependency rule, stop and say so —
+propose the alternative (new port, moved responsibility) instead of quietly
+violating the boundary.

--- a/.claude/rules/dashboard.md
+++ b/.claude/rules/dashboard.md
@@ -1,0 +1,22 @@
+---
+paths:
+  - "dashboard/**"
+  - "sketches/**/web_page.h"
+  - "tools/ui-test*.mjs"
+---
+
+# Dashboard Rules
+
+- **`dashboard/index.html` is the source; `web_page.h` is the mirror.** Any
+  change to one must land in the other in the same PR. (Until the generator
+  from issue #120 exists, the mirror is maintained by hand — after #120,
+  `web_page.h` moves to `src/generated/` and is never hand-edited.)
+- **Test UI changes locally before any flash**: run the Playwright harness
+  (`tools/ui-test*.mjs`) with mock data and check the screenshots. Never make
+  the operator tether to the machine to verify a UI change.
+- **Monitoring only — permanent rule.** The dashboard never gains a control
+  input; no code path from Wi-Fi to motor output, ever.
+- **Serving must never block the control loop**: one bounded modem operation
+  per loop pass, incremental page chunks, bounded timeouts (the #69 incident
+  — a blocking page send while ESCs held throttle — is why).
+- Page budget: served dashboard ≤ 100 KB (epic #81).

--- a/.claude/rules/firmware-realtime.md
+++ b/.claude/rules/firmware-realtime.md
@@ -1,0 +1,31 @@
+---
+paths:
+  - "sketches/**"
+---
+
+# Real-Time Firmware Rules
+
+- **No blocking calls in the control loop**: no `delay()`, no `pulseIn()`, no
+  unbounded `while`. Non-blocking state machines only.
+- **`constrain()` at every servo output boundary** — nothing reaches
+  `writeMicroseconds()` outside 1000–2000 µs.
+- **Float literals carry `f`** (`1.0f`, not `1.0`) — `double` is
+  software-emulated on the RA4M1.
+- **All tunables live in config** (today `[CONFIG]`, target `src/config/`).
+  No magic numbers at point of use.
+- **Per-channel failsafe**: any new input path gets an independent timeout
+  that returns to neutral (SVC = 1500).
+- **Watchdog refresh stays exactly once per loop pass**, after the control
+  path is serviced — never add a second refresh point.
+- **Permanent safety invariants** (never relax, never "temporarily" bypass):
+  open-loop control (telemetry never feeds throttle), no control input over
+  Wi-Fi, no `SoftwareSerial` for telemetry.
+
+## Build & verification discipline (while hardware is unavailable)
+
+- Compile locally before every push:
+  `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/<sketch>`
+- **No flashing, no bench claims.** Physical checks a change would need go
+  into `docs/architecture/BENCH-VERIFICATION-DEFERRED.md`.
+- Refactor PRs are behavior-preserving: no control-path behavior change,
+  characterization tests green before and after.

--- a/.claude/rules/naming.md
+++ b/.claude/rules/naming.md
@@ -1,0 +1,33 @@
+# Naming Rules — self-documenting, full words
+
+Code must read without a decoder ring. **Default: complete English words for
+every identifier** — types, functions, variables, files, folders.
+
+- `telemetry`, not `telem`. `hardware`, not `hw`. `joystick`, not `joy`.
+  `command`, not `cmd`. `temperature`, not `temp` (ambiguous with
+  "temporary"). `previous`, not `prev`. `button`, not `btn`.
+- Applies to NEW and MOVED code. Do not mass-rename untouched legacy code —
+  names are fixed as each file is extracted during the Phase D migration.
+
+## Permitted exceptions (closed list — extending it requires operator sign-off)
+
+1. **Universal domain acronyms**, uppercase per convention: `PWM`, `ADC`,
+   `ESC`, `RC`, `RPM`, `SBUS`, `XBUS`, `JSON`, `HTTP`, `SSE`, `CSV`, `URL`,
+   `ID`, `WiFi`, `LiPo`, `AP`, `WDT`. These are clearer than their expansions
+   (`pulseWidthModulation` self-documents worse than `PWM`).
+2. **Unit suffixes** on quantities: `Ms`, `Us` (microseconds), `V`, `A`,
+   `Hz`, `C` (Celsius) — e.g. `lastGoodMs`, `cutoffThresholdV`. The unit IS
+   the documentation.
+3. **Loop indices** `i`/`j` in scopes shorter than ~5 lines.
+4. **Wire-format keys** (SSE/JSON payload, CSV columns): compact keys are a
+   deliberate bandwidth decision on the 448-byte SSE frame budget, not
+   naming — keep them short and document the mapping next to the encoder.
+5. **`config`** as the conventional name for the tunables layer.
+
+## Why identifier length is free (and where brevity actually matters)
+
+Identifiers are compile-time only — they cost zero flash and zero RAM in the
+binary. Never justify an abbreviation with "Arduino memory limits." The only
+places byte-length matters are string literals (debug prints, JSON keys,
+HTML), which is exactly why exception 4 exists for wire formats and why the
+identifier rule has no space-based escape hatch.

--- a/.claude/rules/naming.md
+++ b/.claude/rules/naming.md
@@ -11,7 +11,7 @@ every identifier** — types, functions, variables, files, folders.
 
 ## Permitted exceptions (closed list — extending it requires operator sign-off)
 
-1. **Universal domain acronyms**, uppercase per convention: `PWM`, `ADC`,
+1. **Universal domain acronyms**, cased per each term's own convention: `PWM`, `ADC`,
    `ESC`, `RC`, `RPM`, `SBUS`, `XBUS`, `JSON`, `HTTP`, `SSE`, `CSV`, `URL`,
    `ID`, `WiFi`, `LiPo`, `AP`, `WDT`. These are clearer than their expansions
    (`pulseWidthModulation` self-documents worse than `PWM`).

--- a/.claude/rules/naming.md
+++ b/.claude/rules/naming.md
@@ -11,7 +11,7 @@ every identifier** — types, functions, variables, files, folders.
 
 ## Permitted exceptions (closed list — extending it requires operator sign-off)
 
-1. **Universal domain acronyms**, cased per each term's own convention: `PWM`, `ADC`,
+1. **Universal domain acronyms**, cased according to each term's convention: `PWM`, `ADC`,
    `ESC`, `RC`, `RPM`, `SBUS`, `XBUS`, `JSON`, `HTTP`, `SSE`, `CSV`, `URL`,
    `ID`, `WiFi`, `LiPo`, `AP`, `WDT`. These are clearer than their expansions
    (`pulseWidthModulation` self-documents worse than `PWM`).

--- a/.claude/rules/naming.md
+++ b/.claude/rules/naming.md
@@ -24,6 +24,21 @@ every identifier** — types, functions, variables, files, folders.
    naming — keep them short and document the mapping next to the encoder.
 5. **`config`** as the conventional name for the tunables layer.
 
+## White-label rule — branding is data, not code
+
+This platform is generic: it must be buildable for any vehicle, any rider, any
+slogan. Therefore:
+
+- **No person or brand names** in code identifiers, file/folder names, issue
+  and board titles, or architecture documents. "Malaki SuperTracks" is one
+  *skin* of the dashboard, not the platform's name — the platform is
+  Dual Track Control.
+- Product branding (display name, subtitle/slogan, logo/badge, accent colors)
+  lives in **one configuration block** in the dashboard source so it can be
+  swapped without touching logic (issue #136).
+- People's names are fine where they document reality (operator guide, wiring
+  history, decision log) — that is documentation, not branding.
+
 ## Why identifier length is free (and where brevity actually matters)
 
 Identifiers are compile-time only — they cost zero flash and zero RAM in the

--- a/.claude/rules/state-ownership.md
+++ b/.claude/rules/state-ownership.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "sketches/**"
+---
+
+# State Ownership Rules
+
+- **One domain owns each piece of state; no other domain writes it.**
+  Cross-domain communication happens through returned decision/status types
+  (`SafetyDecision`, `BatteryStatus`), never by reaching into another
+  module's variables. (Historical example of the sin: `[SAFETY]` writing
+  `[ALERT]`'s `lowVoltLatched`.)
+- **No namespace-scope mutable state in `domain/` code.** Module state lives
+  in structs owned by the module and held by the application layer.
+- **Dependencies are visible in the signature.** A function uses only what it
+  receives — no hidden reads of globals behind a parameter list (historical
+  example: `curvatureDrive()` taking `gearScale` but secretly reading the
+  `currentGear` global).
+- **Time is a parameter.** Domain code never calls `millis()`/`micros()`;
+  the control cycle reads the clock once per pass and passes `now` down.
+  This is what makes debounce/hysteresis/latch logic host-testable.
+- **Observers are read-only.** Telemetry, dashboard, and debug output consume
+  the immutable per-cycle `SystemSnapshot` — they never read domain internals
+  and never write anything.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -5,6 +5,9 @@
 - **Starting work = draft PR.** Branch `agent/<role-tag>/<description>`, one
   PR ↔ one issue, body contains `Closes #N` + summary + role tag + test plan.
   Active work must show In Progress on Project #1.
+- **One open PR at a time** (operator rule, 2026-07-05). Do not start the next
+  work item until the current PR is merged or closed — no parallel PRs, no
+  merge-order dependencies to keep track of.
 - **Behavior-preserving refactors only** during epic #116 Phase D: no logic
   changes mixed into structural PRs; characterization tests green before and
   after; local `arduino-cli` compile before every push.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,19 @@
+# Workflow Rules (agent-enforced)
+
+- **Issue first, always.** No code changes, commits, or uploads without an
+  open GitHub issue the work attaches to. No issue → conversation only.
+- **Starting work = draft PR.** Branch `agent/<role-tag>/<description>`, one
+  PR ↔ one issue, body contains `Closes #N` + summary + role tag + test plan.
+  Active work must show In Progress on Project #1.
+- **Behavior-preserving refactors only** during epic #116 Phase D: no logic
+  changes mixed into structural PRs; characterization tests green before and
+  after; local `arduino-cli` compile before every push.
+- **Decisions get logged** in `docs/DECISION-LOG.md` as they are made (terse:
+  date, what, why). Physical checks we cannot run (no hardware) go to
+  `docs/architecture/BENCH-VERIFICATION-DEFERRED.md`.
+- **Every firmware flash** (when hardware returns) gets a row in
+  `docs/FIRMWARE-UPLOAD-LOG.md` immediately — an unlogged flash is treated as
+  not done.
+- **Review threads**: push the fix first, reply with the commit SHA and
+  reasoning, then resolve. Never resolve before pushing. Engage the operator
+  before applying review-bot suggestions to safety-relevant code.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,6 +42,11 @@
             "type": "command",
             "command": "cat <<'HOOK_EOF'\n[DECISION-LOG WRITE GUARD]\nThis fires after EVERY Write/Edit — act ONLY if the target file is docs/DECISION-LOG.md (otherwise do nothing). If writing to the decision log, verify:\n1. Every line contains ONLY technical facts (circuit, firmware, protocol, hardware)\n2. NO personal information, names (except component/product names), email addresses, or conversation tone\n3. NO subjective commentary — only what was built, tested, measured, or decided\n4. Entries are dated and terse (one line per fact when possible)\nIf any line fails these checks, remove it before writing.\nHOOK_EOF",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "cat <<'HOOK_EOF'\n[GENERATED-FILE GUARD]\nThis fires after EVERY Write/Edit — act ONLY if the target file is web_page.h or lives under a src/generated/ directory (otherwise do nothing and say nothing).\n- web_page.h (until issue #120's generator lands): a hand-edit is allowed ONLY if the same PR applies the identical change to dashboard/index.html — verify the mirror is in sync before finishing the task, and say so explicitly.\n- src/generated/** (after #120): hand-edits are FORBIDDEN. Revert the edit, change the source (dashboard/index.html) instead, and regenerate.\nHOOK_EOF",
+            "timeout": 5000
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,7 +45,7 @@
           },
           {
             "type": "command",
-            "command": "cat <<'HOOK_EOF'\n[GENERATED-FILE GUARD]\nThis fires after EVERY Write/Edit — act ONLY if the target file is web_page.h or lives under a src/generated/ directory (otherwise do nothing and say nothing).\n- web_page.h (until issue #120's generator lands): a hand-edit is allowed ONLY if the same PR applies the identical change to dashboard/index.html — verify the mirror is in sync before finishing the task, and say so explicitly.\n- src/generated/** (after #120): hand-edits are FORBIDDEN. Revert the edit, change the source (dashboard/index.html) instead, and regenerate.\nHOOK_EOF",
+            "command": "cat <<'HOOK_EOF'\n[GENERATED-FILE GUARD]\nThis fires after EVERY Write/Edit — act ONLY if the target file's path ends with web_page.h (any location, e.g. sketches/rc_test/web_page.h) or contains a src/generated/ directory segment (otherwise do nothing and say nothing).\n- web_page.h (until issue #120's generator lands): a hand-edit is allowed ONLY if the same PR applies the identical change to dashboard/index.html — verify the mirror is in sync before finishing the task, and say so explicitly.\n- src/generated/** (after #120): hand-edits are FORBIDDEN. Revert the edit, change the source (dashboard/index.html) instead, and regenerate.\nHOOK_EOF",
             "timeout": 5000
           }
         ]

--- a/.github/workflows/structure-check.yml
+++ b/.github/workflows/structure-check.yml
@@ -68,13 +68,15 @@ jobs:
             fi
           done < <(find . -name '*.py' -not -path './.git/*' -not -path './node_modules/*')
 
-          # Check: .md files only in root, docs/ (any depth), or .github/ (any depth)
+          # Check: .md files only in root, docs/ (any depth), .github/ (any depth),
+          # or .claude/ (any depth — agent rules/skills live there, issue #134)
           while IFS= read -r f; do
             nf="${f#./}"
             dir=$(dirname "$nf")
             if [ "$dir" != "." ] &&
                [ "$dir" != "docs" ] && [[ "$dir" != docs/* ]] &&
-               [ "$dir" != ".github" ] && [[ "$dir" != .github/* ]]; then
+               [ "$dir" != ".github" ] && [[ "$dir" != .github/* ]] &&
+               [ "$dir" != ".claude" ] && [[ "$dir" != .claude/* ]]; then
               echo "ERROR: Markdown file in unexpected location: $f"
               errors=$((errors + 1))
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ node_modules/
 
 # Screenshot artifacts
 .shots/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,16 @@ monitor.py                               — Simple serial monitor
 
 ## Coding Rules
 
+> **Rule system (epic #116):** detailed, path-scoped rules live in
+> `.claude/rules/` (architecture, naming, state ownership, real-time firmware,
+> dashboard, workflow) and the canonical architecture spec is
+> `docs/architecture/ARCHITECTURE-TARGET.md` (+ ADRs in
+> `docs/architecture/adr/`). Those files win over the summaries below; this
+> section stays as the quick reference. While the epic #116 migration runs:
+> refactors are behavior-preserving, compile locally before every push, and
+> no hardware is available — physical checks go to
+> `docs/architecture/BENCH-VERIFICATION-DEFERRED.md`.
+
 ### Architecture
 
 - All code in `rc_test.ino` is organized in `[MODULE]` sections — search `[NAME]` to jump


### PR DESCRIPTION
## Summary

Pre-refactor guardrail set (Phase A companion, split from #127) so all epic #116 refactor work is generated under the rules:

- **`.claude/rules/`** — `architecture.md` (layers, dependency direction, file policy, banned names), `naming.md` (full words, closed exception list — see note below), `state-ownership.md`, `firmware-realtime.md`, `dashboard.md`, `workflow.md`; firmware/dashboard rules are path-scoped via `paths` frontmatter
- **Generated-file hook** (`.claude/settings.json`) — flags direct `web_page.h` edits (must sync the `dashboard/index.html` mirror until #120's generator lands; forbidden entirely for future `src/generated/`)
- **structure-check.yml** — allows `.md` under `.claude/` (previously would fail CI for this very folder)
- **CLAUDE.md** — pointer section: rules live in `.claude/rules/`, canonical spec in `docs/architecture/`; summaries below it stay as quick reference

**Naming-rule note for review:** identifiers use complete words (telemetry not telem, hardware not hw) EXCEPT a closed list: universal acronyms (PWM/ADC/ESC/RC/SBUS/…), unit suffixes (Ms/Us/V/A/Hz/C), tiny-scope loop indices, and compact wire-format keys (SSE frame budget). Identifier length costs zero flash/RAM — abbreviations get no memory-based excuse.

**Role tag:** `[C-Builder]`

## Test plan

- [x] markdownlint clean locally (repo config)
- [x] `.claude/settings.json` validates as JSON
- [x] No firmware source touched — compile matrix unaffected
- [ ] structure-check CI green with the new `.claude/rules/` folder (the workflow change itself is exercised by this PR)
- [ ] Operator review of the naming exception list — it deliberately deviates from a blanket no-abbreviations rule

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project guidance covering architecture, real-time safety, state ownership, naming, dashboard behavior, and workflow expectations.
  * Clarified where canonical rules live and how they should be followed during development.

* **Chores**
  * Updated validation so project rules documentation under the new guidelines directory is allowed.
  * Ignored local Claude settings from version control.
  * Added safeguards to prevent accidental edits to generated or mirrored files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->