### PR TITLE
Karpathy method: behavior-preservation covenant on every agent surface (#53)

### DIFF
--- a/.claude/rules/behavior-preservation.md
+++ b/.claude/rules/behavior-preservation.md
@@ -1,0 +1,64 @@
+# Behavior-Preservation Covenant (epic #116 — highest-priority rule)
+
+**Operator's words (2026-07-06):** "organizing, refactoring and improving the
+code should never ever, ever cause change of controls or change of behavior
+unless we explicitly discuss it. … We're not messing with the timing, the
+behavior, the parameters. Nothing should be touched. Everything that was
+handling inputs and outputs should remain exactly the same. If we upload the
+firmware again, I would like the machine to perform exactly like it used to
+perform before."
+
+The firmware is field-tuned on a real machine with a child rider. The entire
+value of epic #116 is a better-organized firmware that drives IDENTICALLY.
+
+## The rule
+
+1. **Organization PRs change ZERO observable behavior.** No timing changes, no
+   parameter/constant value changes, no input or output handling changes, no
+   control-flow reordering that alters outputs, no "while I'm here"
+   improvements. Moving code, renaming, splitting files — nothing else.
+2. **Flash-equivalence is the acceptance bar.** Firmware flashed after a
+   refactor must make the machine perform exactly as before. Enforced by:
+   characterization + invariant suites green (they compile the REAL firmware),
+   local `arduino-cli` compile before every push, and one bench
+   re-verification pass when hardware returns
+   (`docs/architecture/BENCH-VERIFICATION-DEFERRED.md`).
+3. **Test expectations are behavior law.** Changing an expected value —
+   including float32 rounding points (forced-Eco = 1825 µs because
+   `0.65f*500.0f` rounds UP to exactly `325.0f`), exact-zero compares, and
+   hysteresis holds (Eco correctly HOLDS at 85 °C inside the 90/80 band) —
+   requires its own issue + operator sign-off BEFORE any code.
+
+## When something looks wrong: severity triage, not dogma
+
+The covenant forbids SILENT changes, not fixes (operator: "be pragmatic — not
+fixing something blatantly crazy is NOT the goal").
+
+- **Blatantly dangerous** (rider harm, runaway, ignored cutoff): raise to the
+  operator IMMEDIATELY and fix promptly in its OWN dedicated fix PR — safety
+  outranks the covenant. Never park a genuine hazard behind
+  "behavior-preserving".
+- **Real but bounded/latent** (e.g. the NaN plausibility gap, the ≤10 ms
+  gear-upshift reverse transient — see `docs/SAFETY.md` known gaps): lock
+  current behavior in a `// FINDING` test, file the issue, fix when the
+  operator prioritizes.
+- **Odd-looking but intended** (hysteresis holds, fail-open boot gate,
+  average-based caps): leave alone — it is law. `docs/SAFETY.md` and
+  `docs/DECISION-LOG.md` record which is which.
+
+**The constant in all three:** a behavior fix must be visible, discussed,
+deliberate, and have its OWN GitHub issue — created BEFORE the fix —
+describing WHAT changes, WHY, and HOW. A behavior fix can NEVER be included
+inside any other PR, and NEVER applied as a PR-review correction — no
+exceptions. Urgency changes how FAST the issue + dedicated PR happen (a
+dangerous find = same day), never the path.
+
+## Review-comment handling
+
+Never apply a reviewer's (human or bot) committable suggestion that changes
+behavior, constants, defaults, feature flags, or test expectations. Verify
+numeric claims empirically against the real code before agreeing (precedent:
+a bot's "1824 µs" claim was refuted by an on-firmware probe — the suggestion
+would have turned the green suite red). If a review comment surfaces a
+genuine behavior defect: reply "acknowledged — needs its own issue", get the
+issue created, resolve the thread pointing at it, and fix in a dedicated PR.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,77 @@
+# CodeRabbit review configuration.
+#
+# EPIC #116 SCOPE (TEMPORARY): the sections marked [epic #116] steer reviews
+# during the architecture-remediation program (organize code, split files,
+# domain-driven design, doc-code sync, meaningful tests) under a strict
+# behavior-preservation covenant. Relax/remove those sections when epic #116
+# completes — tracked in the epic's definition of done.
+language: en-US
+
+tone_instructions: >-
+  Safety-critical child-ridden vehicle, mid behavior-preserving refactor
+  (epic #116). Never suggest changes to behavior, timing, parameters, or
+  test expectations; propose follow-up issues instead. Verify numeric
+  claims against the code first.
+
+reviews:
+  path_instructions:
+    - path: "**"
+      instructions: >-
+        [epic #116 — behavior-preservation covenant] This repo is mid
+        refactor whose ONLY goals are: organize code, split large files,
+        follow domain-driven design (docs/architecture/ARCHITECTURE-TARGET.md),
+        keep documentation synchronized with code, and keep tests readable and
+        meaningful. Organization must change NOTHING observable: no timing,
+        no parameter or constant values, no input/output handling, no control
+        flow that alters outputs. Do NOT suggest behavior changes, constant
+        retunes, or "simplifications" that alter what the firmware does — even
+        when the current behavior looks wrong. If you believe you found a REAL
+        defect, describe it as an observation and recommend filing a follow-up
+        issue; do not provide a committable suggestion that changes behavior.
+        SEVERITY MATTERS: if a suspected defect looks SAFETY-CRITICAL (rider
+        harm, runaway, ignored cutoff), flag it as a prominent potential_issue
+        and say explicitly it needs its own GitHub issue (what/why/how) and an
+        immediate dedicated fix PR — do not soften it to fit the covenant; the
+        covenant forbids silent changes, not fixes. Behavior fixes NEVER enter
+        a PR via review corrections.
+        Before claiming a numeric expectation is wrong, verify it against the
+        actual code including float32 rounding (precedent: forced-Eco output is
+        1825 us because 0.65f*500.0f rounds UP to exactly 325.0f — a suggested
+        "fix" to 1824 was refuted by an on-firmware probe).
+        Known INTENTIONAL behaviors — never flag as bugs: thermal stages hold
+        anywhere inside their hysteresis bands (warn 80/78, eco 90/80,
+        cut 95/75 C — e.g. eco correctly HOLDS at 85 C); telemetry dropout
+        freezes the safety ladders (no trip, no release); the battery boot
+        gate fails OPEN after 3 s (telemetry-optional driving); gear/reverse
+        caps bound the AVERAGE track speed and single tracks legitimately
+        exceed them in turns (#72/#113); battery cutoff latches until power
+        cycle while thermal cut auto-recovers; alarms are sound-only.
+        DO actively review for: real code-move errors (dropped, duplicated, or
+        reordered logic during extraction), dependency-rule violations
+        (.claude/rules/architecture.md), naming-rule violations
+        (.claude/rules/naming.md — full words), file-size policy (150 soft /
+        250 hard), and documentation that drifted from the code — those are
+        exactly the review comments this program needs.
+    - path: "sketches/**"
+      instructions: >-
+        [epic #116] Production firmware behavior is LAW during the refactor.
+        Structural review only: verify moved code is byte-equivalent in
+        effect, includes/layers follow the architecture rules, and nothing
+        "extra" snuck into a move. Any behavior, timing, or parameter concern
+        becomes an issue recommendation, never a committable suggestion.
+    - path: "tests/**"
+      instructions: >-
+        [epic #116] Test EXPECTATIONS are behavior law: changing an expected
+        value requires its own issue + operator sign-off first — never suggest
+        editing an expectation to "correct" it. Welcome suggestions:
+        readability, meaningful scenario coverage (tests should exercise
+        situations that can actually occur in the field, with meaningfulness
+        guards proving the dangerous input had authority), and STRENGTHENING
+        assertions — provided the suite stays green against the unmodified
+        firmware.
+    - path: "docs/**"
+      instructions: >-
+        [epic #116] Doc-code synchronization is a first-class review goal:
+        flag any constant, threshold, pin, file path, or behavior description
+        that no longer matches the code. Do not propose changing the CODE to
+        match stale docs — docs follow code.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,43 @@
 # Copilot Code Review Instructions — Arduino Digger Controller
 
+## ⚠️ Current program: epic #116 — behavior-preservation covenant (TEMPORARY until epic completes)
+
+The repo is mid architecture-remediation: organize code, split large files,
+domain-driven design, doc-code sync, readable and meaningful tests. During
+this program, organization must change NOTHING observable — no behavior, no
+timing, no parameter/constant values, no input/output handling. Firmware
+flashed after a refactor must make the machine perform exactly as before.
+
+- Do NOT suggest behavior changes, constant retunes, or simplifications that
+  alter what the firmware does — even where current behavior looks wrong.
+  Suspected real defects: describe as an observation + recommend a follow-up
+  issue instead of a code suggestion. If it looks SAFETY-CRITICAL (rider harm,
+  runaway, ignored cutoff), flag it prominently — it needs its own issue and
+  an immediate dedicated fix PR, never a review-correction commit.
+- Test expectations are behavior law — changing one requires an issue +
+  operator sign-off first. Never suggest editing an expectation to "fix" it;
+  verify numeric claims against the code (incl. float32 rounding — forced-Eco
+  output is 1825 µs because `0.65f*500.0f` rounds UP to exactly `325.0f`).
+- Intentional behaviors — do not flag: thermal-stage hysteresis holds (e.g.
+  eco holds at 85 °C in the 90/80 band); telemetry dropout freezes ladders;
+  battery boot gate fails OPEN at 3 s; gear/reverse caps bound the AVERAGE
+  track speed (per-track turn headroom is by design); battery cutoff latches
+  until power-cycle while thermal cut auto-recovers; alarms are sound-only.
+- DO flag: code-move errors (dropped/duplicated/reordered logic), dependency
+  and naming rule violations (`.claude/rules/`), files past the 150/250-line
+  policy, and documentation drifted from code.
+
+## Working Agreement (four principles — mirrors CLAUDE.md, #53)
+
+1. **Think before coding**: safety-relevant ambiguity (pins, ESC parameters,
+   caps, timing) is a question, never a guess.
+2. **Simplicity first**: no speculative features or one-caller abstractions.
+3. **Surgical changes**: one intent per diff — no reformatting/renaming
+   drive-bys on lines the task didn't require.
+4. **Goal-driven**: a change is done when the host suite
+   (characterization + invariants), local `arduino-cli` compile, and all CI
+   workflows are green with zero unauthorized behavior change.
+
 ## Project Context
 Arduino UNO R4 WiFi (Renesas RA4M1, 32-bit ARM Cortex-M4, 48MHz; ESP32-S3 Wi-Fi coprocessor) controlling a ride-on excavator.
 Safety-critical: code errors can cause a 50lb machine with a child riding it to behave unexpectedly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,42 @@ input: RC transmitter (Jason) and joystick (Malaki/rider). 3-position override
 switch selects who has authority. X.BUS telemetry is streamed to a Wi-Fi
 dashboard (monitoring only).
 
+## Working Agreement (#53 — the Karpathy method, adapted)
+
+Behavioral guardrails for every agent working in this repo. The
+**behavior-preservation covenant** (`.claude/rules/behavior-preservation.md`)
+sits above all four: during epic #116, organization changes NOTHING observable
+— firmware flashed after a refactor must drive exactly as before.
+
+1. **Think before coding — never guess on safety-relevant ambiguity.**
+   Ambiguity on pin assignments, ESC parameters, safety caps/thresholds, or
+   timing → stop and ask. Before any XC-Link / ESC parameter suggestion, run
+   the command-path checklist (see "ESC / motor configuration changes" below)
+   — that checklist IS this principle for our domain. State assumptions
+   explicitly; push back on needless complexity instead of silently building it.
+2. **Simplicity first.** Senior-engineer default: no speculative features, no
+   abstraction for one caller, 100 lines over 1000. The file policy (150
+   soft / 250 hard, `.claude/rules/architecture.md`) is the mechanical
+   backstop, not the goal.
+3. **Surgical changes.** Touch only what the task needs: no reformatting, no
+   renaming, no drive-by "improvements" to code the diff didn't have to
+   visit. Naming fixes happen when a file is extracted/moved (per
+   `.claude/rules/naming.md`), never as ride-alongs. A reviewer should be
+   able to read the diff and see exactly one intent.
+4. **Goal-driven execution — hand the agent the goal + the gate, not steps.**
+   The standing, verifiable success criteria for any firmware-touching change:
+   - host suite green: `wsl -e make -C tests run` (characterization +
+     invariants — compiles the REAL `rc_test.ino`; also CI `unit-tests.yml`)
+   - compiles clean locally:
+     `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test`
+   - CI green: `arduino-ci.yml`, `lint.yml`, `static-analysis.yml`,
+     `code-quality.yml`, `structure-check.yml`, `unit-tests.yml`
+   - no blocking calls in `loop()` (`delay()`, `pulseIn()`, unbounded `while`)
+   - zero behavior change unless the task's own issue explicitly authorizes it
+
+   An agent that satisfies the gate is done; an agent that can't must say why
+   — see `docs/AGENT-EXAMPLES.md` for good/bad task-framing pairs.
+
 ## Project Board — Single Source of Truth
 
 [Project #1](https://github.com/users/boulaajaj/projects/1) is the **single
@@ -240,6 +276,7 @@ and the Arduino-side filter was double-smoothing the stream (operator felt
 - [x] Field test at reduced power
 - [x] Host characterization suite + commit test gate (#47 — epic #116 Phase B)
 - [x] Safety invariants + fault-injection suite, docs/SAFETY.md registry (#131 — epic #116 Phase B)
+- [x] Karpathy method + behavior-preservation covenant on every agent surface (#53)
 - [ ] Wi-Fi serving latency mitigation (issue #54 — hardware-gated)
 - [ ] Track-speed asymmetry investigation — per-ESC throttle calibration
 - [ ] Low-battery motor cutoff (issue #65 — alarm is sound-only today)
@@ -267,6 +304,7 @@ docs/MISSION.md                          — Project design philosophy (smoothne
 docs/DECISION-LOG.md                     — Technical decision log
 docs/TESTING.md                          — Host characterization + invariants suites + commit gate (#47, #131)
 docs/SAFETY.md                           — Safety-invariant registry: propulsion-path invariants + test links (#131)
+docs/AGENT-EXAMPLES.md                   — Good/bad task-execution pairs for AI agents (#53, real precedents)
 tests/                                   — Host test harness: stub Arduino env + doctest suites (characterization/ + invariants/)
 .githooks/pre-commit                     — Commit-time test gate (activate: git config core.hooksPath .githooks)
 live_plot.py                             — Real-time matplotlib monitor

--- a/docs/AGENT-EXAMPLES.md
+++ b/docs/AGENT-EXAMPLES.md
@@ -1,0 +1,94 @@
+# Agent Examples — good/bad pairs for embedded work (#53)
+
+Concrete good/bad task executions for AI agents in this repo. Every pair is
+either a real event from this project's history or the project's canonical
+checklist applied. The Working Agreement (CLAUDE.md) states the principles;
+this file shows what following — and violating — them looks like.
+
+## 1. ESC parameter change — think before coding (real: Max Reverse Force)
+
+**Task:** "Pivot turns feel weak — is there an ESC setting for that?"
+
+**Bad:** Agent looks up the GL10 manual, sees `Max Reverse Force` defaults to
+50%, and answers "set it to 100% for stronger reverse". No analysis of what
+the firmware actually commands. (Also bad in the other direction: recommending
+the 50% default "for safety" — which would silently deliver −27.5% on the
+reverse track during a ±55% pivot and collapse the pivot differential.)
+
+**Good:** Agent runs the command-path checklist (CLAUDE.md "ESC / motor
+configuration changes"): lists every path that drives each motor (RC throttle,
+pivot/curvature, joystick, gear scaling, override mixer), computes the
+per-direction min/max each path can produce (pivot at high gear commands one
+track to −55%), verifies the proposed value clips none of them, and hands over
+the value WITH the cross-impact analysis: "`Max Reverse Force = 100%` — the
+factory 50% would halve the reverse track in pivot mode and break the
+differential."
+
+## 2. Reviewer claims a test expectation is wrong — verify, don't apply (real: PR #138)
+
+**Task:** CodeRabbit posts a committable suggestion: "forced-Eco full-forward
+truncates to 1824 µs, not 1825 — fix the assertion."
+
+**Bad:** Agent applies the suggestion because the reviewer's float-truncation
+reasoning sounds plausible. The green suite turns red — the "fix" changed a
+behavior-law expectation to a wrong value.
+
+**Good (what actually happened, 2026-07-06):** Agent treats the numeric claim
+as unverified, compiles a probe against the real firmware, and finds
+`0.65f * 500.0f` rounds UP to exactly `325.0f` → 1825 µs. It declines the
+suggestion, replies on the thread with the probe evidence, and resolves the
+thread. The suite stays green and the wrong claim is now documented for the
+next reviewer.
+
+## 3. A real defect found mid-PR — lock + issue, never an inline fix (real: PR #138)
+
+**Task:** While writing invariant tests, the agent discovers NaN pack voltage
+passes the [6, 13] V plausibility band, with slot-asymmetric consequences.
+
+**Bad:** Agent "fixes" `worstPackVoltage()` in the same PR — it's two lines,
+the tests are right there, and it's clearly a defect. Now a test-suite PR
+silently changed safety-ladder behavior nobody discussed, reviewed as such,
+or bench-verified.
+
+**Good (what actually happened, 2026-07-06):** Agent locks the CURRENT
+behavior in `// #131 FINDING:` test cases (so any accidental change trips the
+suite), documents the gap in `docs/SAFETY.md` known-gaps with reachability
+analysis (unreachable today — X.BUS voltages parse from uint16), and drafts a
+dedicated follow-up issue describing what/why/how. The fix happens in its own
+PR when the operator prioritizes it. Same pattern for the ≤10 ms gear-upshift
+reverse transient found in the same session.
+
+## 4. Vague symptom report — surgical diff, failing test first
+
+**Task:** "Steering feels inverted when pivoting — fix the steering."
+
+**Bad:** Agent rewrites `curvatureDrive()` "more clearly" while in there —
+renames variables, reorders the blend logic, retunes `PIVOT_SPEED_CAP` because
+60% "seemed low". The diff mixes a possible polarity fix with three unrelated
+behavior changes, none test-locked, none discussed.
+
+**Good:** Agent first reproduces the claim as a failing characterization
+assertion (host suite drives the real mixer with a pivot-mode input and
+asserts the expected track signs). If the assertion fails → genuine defect →
+its own issue (what/why/how), then a minimal fix touching only the sign
+error, with the new test proving it. If the assertion passes → the firmware
+is correct; investigate wiring/transmitter config instead and say so. Either
+way the diff carries exactly one intent.
+
+## 5. Refactor task framing — hand the goal + the gate, not steps
+
+**Task (operator to agent):** extract the `[TELEMETRY]` module during Phase D.
+
+**Bad framing:** "First create `telemetry/XbusPoller.h`, then move lines
+812–1040, then update the includes, then…" — a step list the agent follows
+blindly; when step 3 doesn't compile it improvises, and nobody defined what
+"done" means.
+
+**Good framing:** "Goal: `[TELEMETRY]` lives in `src/telemetry/` per
+ARCHITECTURE-TARGET.md §6, files ≤150 lines, dependency rules hold. Gate:
+`wsl -e make -C tests run` green (unchanged expectations), local
+`arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test`
+clean, all CI workflows green, zero behavior change." The agent self-corrects
+against the gate in a loop and stops when it passes — or reports precisely
+which gate it cannot satisfy and why (per `.claude/rules/architecture.md`,
+proposing an alternative instead of quietly violating a boundary).

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,37 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-06 — Karpathy method adopted repo-wide; #53 re-prioritized FIRST; behavior-preservation covenant codified
+
+- **Reprioritization (operator):** #53 moves from Phase E to NOW — before any
+  Phase C/D refactoring. Rationale: the guardrails must exist before the
+  code-moving starts, or the refactor risks destroying the field-tuned
+  behavior it exists to preserve.
+- **The covenant (operator, verbatim):** "organizing, refactoring and
+  improving the code should never ever, ever cause change of controls or
+  change of behavior unless we explicitly discuss it … we're not messing with
+  the timing, the behavior, the parameters. Nothing should be touched.
+  Everything that was handling inputs and outputs should remain exactly the
+  same … if we upload the firmware again, I would like the machine to perform
+  exactly like it used to perform before." Codified as
+  `.claude/rules/behavior-preservation.md` (highest-priority rule).
+- **Pragmatism amendment (operator):** severity triage, not dogma — blatantly
+  dangerous findings get raised immediately and fixed in their own dedicated
+  PR (safety outranks the covenant); bounded/latent findings get locked in
+  tests + a follow-up issue; odd-but-intended behavior is law.
+- **Fix protocol (operator, final form):** a behavior fix must be visible,
+  discussed, deliberate, and have its OWN GitHub issue (what/why/how) created
+  BEFORE the fix; never inside any other PR, never as a PR-review correction
+  — no exceptions.
+- **Surfaces:** CLAUDE.md Working Agreement (4 principles + goal-and-gate
+  pattern wired to the real CI workflows), `.coderabbit.yaml` (NEW —
+  epic-scoped path_instructions so bot reviews stop proposing behavior
+  changes; TEMPORARY, relax at epic end), `.github/copilot-instructions.md`
+  covenant section + principle mirror, `docs/AGENT-EXAMPLES.md` (5 good/bad
+  pairs from real project history: Max-Reverse-Force checklist, the 1825 µs
+  probe refutation, the NaN gap lock-don't-fix, failing-test-first, goal+gate
+  framing).
+
 ## 2026-07-06 — Safety-invariant + fault-injection suite; two firmware gaps found and locked (#131)
 
 - **Suite:** `tests/invariants/` — 6 property suites (35 test cases, ~800


### PR DESCRIPTION
Closes #53

## Summary

Adopts the Karpathy method (AI-agent behavioral guardrails) on **every agent
surface**, re-prioritized by the operator to land FIRST — before any Phase C/D
refactoring — and recentered on the **behavior-preservation covenant**:
organization changes NOTHING observable; firmware flashed after a refactor
must drive exactly as before.

**Role tag:** `[C-Builder]`

| Surface | What landed |
| --- | --- |
| `.coderabbit.yaml` (NEW, first commit) | Epic-scoped path_instructions: behavior/timing/parameter/test-expectation changes are never committable suggestions; safety-critical suspicions flagged prominently for their own issue + dedicated fix PR; intentional-behaviors list; 1825 µs probe precedent. **First commit deliberately, so CodeRabbit reviews this very PR under it.** Marked TEMPORARY — relax at epic #116 completion. |
| `.claude/rules/behavior-preservation.md` (NEW) | The covenant as the highest-priority rule: operator's verbatim words, flash-equivalence bar, severity triage (dangerous → immediate dedicated fix PR; bounded → lock + issue; intended → law), and the fix protocol (own issue BEFORE the fix, never inside another PR, never as a review correction). |
| `CLAUDE.md` | New **Working Agreement** section — the 4 principles tailored to this domain (safety-parameter ambiguity → ask; simplicity; surgical diffs; goal + gate) with the standing verifiable gate wired to the real workflows (`unit-tests.yml`, `arduino-ci.yml`, `lint.yml`, `static-analysis.yml`, `code-quality.yml`, `structure-check.yml`, local arduino-cli compile, host suite). File-map + status rows updated. |
| `.github/copilot-instructions.md` | Epic covenant section + a 4-principle mirror, so Copilot review comments align with Claude's rules (no drift). |
| `docs/AGENT-EXAMPLES.md` (NEW) | 5 embedded-specific good/bad pairs, all from real project history: Max-Reverse-Force command-path checklist, the 1824-vs-1825 probe refutation (PR #138), the NaN-gap lock-don't-fix (PR #138), failing-test-first for vague symptoms, goal+gate task framing. |
| `docs/DECISION-LOG.md` | 2026-07-06 entry recording the reprioritization, the covenant verbatim, the pragmatism amendment, and the fix protocol. |

### Acceptance criteria mapping (from #53)

- [x] `CLAUDE.md` contains an explicit four-principle Working Agreement section
- [x] `copilot-instructions.md` mirrors it
- [x] Documented "goal + CI gate" pattern referencing the real workflows (Working Agreement §4; the issue's original list predates the UNO R4 WiFi migration — gate references current reality: `unor4wifi` FQBN + `unit-tests.yml`)
- [x] `docs/AGENT-EXAMPLES.md` with ≥ 3 embedded good/bad pairs (5 shipped)
- [ ] **Smoke test** — one task run start-to-finish under the new rules. Proposal: this PR runs under them (issue-first, one open PR, surgical docs/config-only diff, CI gate), and the first Phase C task (**#129**) serves as the full code-touching smoke test; operator checks this box after judging either sufficient.

Note: #53's "Blocked by #52" dependency is satisfied — #52 is closed.

## Test plan

- Docs/config-only diff — **zero firmware bytes touched** (`git diff --stat main` shows no `sketches/` or `tests/` changes)
- Host suite unaffected; CI must stay fully green (`unit-tests`, `arduino-ci`, `lint`, `static-analysis`, `code-quality`, `structure-check`)
- CodeRabbit review of this PR is itself a live test of `.coderabbit.yaml` — expected: structural/doc-sync comments only, no behavior-change suggestions
- `.claude/settings.json` checked for conflicts: none (no rules overlap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and updated guidance for working with the project, including clearer expectations for safe changes, review practices, and how to handle potential behavior changes.
  * Published new reference examples showing preferred vs. discouraged approaches for common development scenarios.
  * Added a decision log entry capturing the current workflow rules and review standards.

* **Chores**
  * Updated review and assistant configuration so project guidance is applied more consistently across documentation, tests, and source areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->