### PR TITLE
docs/wiki: AI-maintained knowledge graph for Obsidian (#141)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules/
 # Screenshot artifacts
 .shots/
 .claude/settings.local.json
+
+# Obsidian vault settings (local-only; repo root is the vault, docs/wiki/ is the graph layer)
+.obsidian/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,7 @@ docs/DECISION-LOG.md                     — Technical decision log
 docs/TESTING.md                          — Host characterization + invariants suites + commit gate (#47, #131)
 docs/SAFETY.md                           — Safety-invariant registry: propulsion-path invariants + test links (#131)
 docs/AGENT-EXAMPLES.md                   — Good/bad task-execution pairs for AI agents (#53, real precedents)
+docs/wiki/                               — AI-maintained knowledge graph (Obsidian-visualizable, links-only — no constants; #141)
 tests/                                   — Host test harness: stub Arduino env + doctest suites (characterization/ + invariants/)
 .githooks/pre-commit                     — Commit-time test gate (activate: git config core.hooksPath .githooks)
 live_plot.py                             — Real-time matplotlib monitor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,9 +239,11 @@ percentage-based plan was implemented as a simpler **voltage** threshold:
 | Inactivity ("unplug me") | one long beep / 2 s | RC off > 60 s (`INACT_RC_OFF_MS`) |
 | Low battery | three fast chirps / ~1.2 s, **latched** | worse pack EMA < 10.5 V (`LOWV_THRESH_V`), debounced 3 s, suppressed first 60 s |
 
-Alarms are **sound-only** — they do not stop or slow the motors. A low-battery
-motor cutoff is still pending (issue #65). See OPERATOR-GUIDE.md for the
-operator-facing beep table.
+The alarms themselves are **sound-only** — motor-affecting protection lives in
+the separate `[SAFETY]` staged ladder (#65, shipped): Eco lock at 10.8 V and a
+latched hard cutoff at 10.0 V, with the alarm chirping along with the cut so a
+cutoff is never silent. See OPERATOR-GUIDE.md for the operator-facing beep
+table.
 
 ## Key Design Decisions
 
@@ -279,7 +281,7 @@ and the Arduino-side filter was double-smoothing the stream (operator felt
 - [x] Karpathy method + behavior-preservation covenant on every agent surface (#53)
 - [ ] Wi-Fi serving latency mitigation (issue #54 — hardware-gated)
 - [ ] Track-speed asymmetry investigation — per-ESC throttle calibration
-- [ ] Low-battery motor cutoff (issue #65 — alarm is sound-only today)
+- [x] Staged low-battery protection: Eco lock 10.8 V + latched motor cutoff 10.0 V (#65)
 - [ ] Current-sensor wiring/calibration on A2/A3 (issue #5)
 
 ## File Map

--- a/OPERATOR-GUIDE.md
+++ b/OPERATOR-GUIDE.md
@@ -141,7 +141,7 @@ each pattern means one thing, and nothing else.
 | **Two short beeps** (once, right after power-on) | Wi-Fi telemetry is up | Connect your phone to `Digger-Telemetry` to see the dashboard (optional) |
 | **Steady tone** (only while held) | Someone is pressing the horn button on the RC remote | Nothing — that's the horn |
 | **One long beep, every 2 seconds** | The **RC remote has been turned off for over a minute** | **Unplug the LiPo batteries.** Left plugged in, they slowly drain and can be ruined within a week or two |
-| **Three fast chirps, over and over, won't stop** | A **battery is low** (below 10.5 V) | **Stop and charge the batteries.** This is a *warning only* — it does **not** stop the motors. The packs are protected by you stopping and charging them, not by the firmware. The alarm will NOT turn off until you unplug and re-power the digger. (An automatic motor cutoff is planned — issue #65.) |
+| **Three fast chirps, over and over, won't stop** | A **battery is low** (below 10.5 V) | **Stop and charge the batteries.** At this stage it is a warning — the motors keep running. If a battery keeps dropping, the firmware protects the packs in stages: below 10.8 V it locks the digger into Eco (slower), and below 10.0 V it **stops the motors entirely** (the chirping continues so the cutoff is never silent). The alarm and the cutoff will NOT reset until you unplug and re-power the digger. |
 
 **Notes:**
 
@@ -151,8 +151,9 @@ each pattern means one thing, and nothing else.
 - The low-battery alarm checks **both** batteries and sounds for the weaker one.
 - It only triggers when both batteries are reporting — if one isn't plugged in
   yet, it stays quiet (so it won't false-alarm while you're powering up).
-- These alarms are **sound only.** They do not stop or slow the motors. (A
-  separate low-battery motor cutoff is planned — see issue #65.)
+- The alarms themselves are **sound only** — but the firmware's separate staged
+  battery protection (#65) does act on the motors: Eco lock below 10.8 V, full
+  motor cutoff below 10.0 V (latched until power-cycle).
 
 ---
 

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,21 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-07 — AI-maintained knowledge graph at docs/wiki/ (#141, Karpathy LLM-wiki)
+
+- **What:** `docs/wiki/` — 19 link-dense Markdown notes (root hub, 7 domain
+  hubs, 11 concept notes) forming a graph layer over the canonical docs,
+  visualizable in Obsidian (vault = repo root; `.obsidian/` gitignored).
+- **Anti-drift rules (the design):** notes carry stable concepts and links
+  ONLY — constants/thresholds/pins stay exclusively in canonical docs; a wiki
+  note restating a number is a bug. Standard relative Markdown links (no
+  `[[wikilink]]` syntax) so notes read on GitHub and lint clean; Obsidian
+  graphs them natively. Agents own the folder: doc-changing PRs update
+  affected notes in the same PR.
+- **Placement:** `docs/wiki/` not top-level `wiki/` — structure-check CI
+  restricts `.md` locations to root/docs/.github/.claude; no CI change
+  needed.
+
 ## 2026-07-06 — Karpathy method adopted repo-wide; #53 re-prioritized FIRST; behavior-preservation covenant codified
 
 - **Reprioritization (operator):** #53 moves from Phase E to NOW — before any

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,27 @@
+# Project Wiki — AI-maintained knowledge graph
+
+A navigation layer over this repo's documentation, built for graph
+visualization (Obsidian) and fast orientation. It follows the Karpathy
+LLM-wiki pattern adopted in #53: **agents create and maintain these
+interconnected notes; humans read and visualize them** (issue #141).
+
+## How to visualize
+
+1. Open **the repository root** as an Obsidian vault (File → Open folder as
+   vault). The graph then includes both these hub notes and the canonical
+   docs they link to.
+2. `.obsidian/` (your local vault settings) is gitignored — theme and graph
+   tweaks stay on your machine.
+3. Notes use standard relative Markdown links, so everything here also reads
+   normally on GitHub. Obsidian graphs Markdown links natively.
+
+## Rules for this folder (anti-drift)
+
+- **Navigation layer, not a second copy.** Notes describe stable concepts and
+  link to the canonical source. Constants, thresholds, pin numbers, and
+  versions live ONLY in the canonical docs (`CLAUDE.md`, `docs/SAFETY.md`,
+  …) — a wiki note that restates a number is a bug.
+- **Agents own this folder.** A PR that adds, removes, or renames a doc — or
+  changes what a subsystem IS — updates the affected wiki notes in the same
+  PR. Link fixes are cheap; that is the point of keeping content out.
+- Start at [home](home.md).

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -18,9 +18,12 @@ interconnected notes; humans read and visualize them** (issue #141).
 ## Rules for this folder (anti-drift)
 
 - **Navigation layer, not a second copy.** Notes describe stable concepts and
-  link to the canonical source. Constants, thresholds, pin numbers, and
-  versions live ONLY in the canonical docs (`CLAUDE.md`, `docs/SAFETY.md`,
-  …) — a wiki note that restates a number is a bug.
+  link to the canonical source. Tunable values — constants, thresholds, pin
+  numbers, versions — live ONLY in the canonical docs (`CLAUDE.md`,
+  `docs/SAFETY.md`, …); a wiki note that restates one is a bug. Stable
+  identity is fine: component model names and ordinary descriptive
+  quantities ("three-position switch") make notes readable and only change
+  when the thing itself changes.
 - **Agents own this folder.** A PR that adds, removes, or renames a doc — or
   changes what a subsystem IS — updates the affected wiki notes in the same
   PR. Link fixes are cheap; that is the point of keeping content out.

--- a/docs/wiki/agent-governance.md
+++ b/docs/wiki/agent-governance.md
@@ -1,8 +1,8 @@
 # Agent governance
 
 How AI agents (Claude Code, Copilot, CodeRabbit) are steered in this repo —
-the Karpathy method (#53) plus the behavior-preservation covenant (epic
-#116).
+the Karpathy method (#53) plus the behavior-preservation covenant
+(epic #116).
 
 - **Working Agreement** — four principles (think before coding, simplicity
   first, surgical changes, goal-driven execution with a verifiable gate):

--- a/docs/wiki/agent-governance.md
+++ b/docs/wiki/agent-governance.md
@@ -1,0 +1,29 @@
+# Agent governance
+
+How AI agents (Claude Code, Copilot, CodeRabbit) are steered in this repo —
+the Karpathy method (#53) plus the behavior-preservation covenant (epic
+#116).
+
+- **Working Agreement** — four principles (think before coding, simplicity
+  first, surgical changes, goal-driven execution with a verifiable gate):
+  [CLAUDE.md](../../CLAUDE.md)
+- **The covenant** — organization changes NOTHING observable; behavior fixes
+  need their own issue BEFORE the fix, never ride another PR:
+  [.claude/rules/behavior-preservation](../../.claude/rules/behavior-preservation.md)
+- **Worked examples** — real good/bad task-execution pairs:
+  [AGENT-EXAMPLES](../AGENT-EXAMPLES.md)
+- **Path-scoped rules** —
+  [architecture](../../.claude/rules/architecture.md) ·
+  [naming](../../.claude/rules/naming.md) ·
+  [state-ownership](../../.claude/rules/state-ownership.md) ·
+  [firmware-realtime](../../.claude/rules/firmware-realtime.md) ·
+  [dashboard](../../.claude/rules/dashboard.md) ·
+  [workflow](../../.claude/rules/workflow.md)
+- **Review bots** — `.coderabbit.yaml` (epic-scoped covenant steering) and
+  [copilot-instructions](../../.github/copilot-instructions.md) mirror the
+  same rules so bot reviews align with the program
+- **This wiki** is itself governed here: agents maintain it, PRs that change
+  docs update affected notes ([README](README.md))
+
+The [testing](testing.md) suites are the enforcement arm: expectations are
+law, and the gate defines "done" for any agent task.

--- a/docs/wiki/alerts-and-alarms.md
+++ b/docs/wiki/alerts-and-alarms.md
@@ -1,0 +1,18 @@
+# Alerts and alarms
+
+Audible signals from a piezo beeper, driven non-blocking with a strict
+priority: the horn overrides one-shot patterns, which override repeating
+alarms. Today's set: a boot chirp when Wi-Fi is ready, a horn button on the
+RC transmitter, an inactivity reminder ("unplug me"), and a latched
+low-battery alarm fed by the [battery ladder](battery-ladder.md).
+
+- Current pin, patterns, thresholds, and debounce:
+  [CLAUDE.md](../../CLAUDE.md) (canonical); the beep table for operators:
+  [OPERATOR-GUIDE](../../OPERATOR-GUIDE.md)
+- **Sound-only by design**: alarms never slow or stop the motors — motion
+  authority belongs exclusively to the [safety system](safety-system.md)
+  ladders and the [output gate](output-gate.md). A low-battery motor cutoff
+  exists separately in the [battery ladder](battery-ladder.md); the alarm is
+  the operator-warning layer above it.
+- History (a reverse beeper was removed, alerts returned as alarms):
+  [DECISION-LOG](../DECISION-LOG.md)

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -1,0 +1,25 @@
+# Architecture remediation (epic #116)
+
+Active program: reorganize the single-sketch firmware into a domain-oriented
+structure — **without changing one observable behavior**
+([governance](agent-governance.md)). Firmware flashed after any refactor must
+drive exactly as before.
+
+- **Target architecture** —
+  [ARCHITECTURE-TARGET](../architecture/ARCHITECTURE-TARGET.md): layers
+  (`application` / `domain` / `ports` / `infrastructure`), dependency rules,
+  migration order
+- **Founding ADR** —
+  [0001-domain-oriented-firmware-architecture](../architecture/adr/0001-domain-oriented-firmware-architecture.md)
+- **Phases** — A Define → B Protect ([testing](testing.md) suites, done) →
+  C Govern (CI fitness functions) → D Refactor (extract domains) → E Polish
+- **Protection first** — the [characterization and invariant
+  suites](testing.md) were built BEFORE any code moves, so every refactor
+  step is verified against locked behavior
+- **Physical checks we cannot run** (no hardware during the program) are
+  queued in
+  [BENCH-VERIFICATION-DEFERRED](../architecture/BENCH-VERIFICATION-DEFERRED.md)
+- Decisions land in the [DECISION-LOG](../DECISION-LOG.md) as they are made
+
+Work is tracked on the GitHub project board — one issue per PR, one PR open
+at a time ([.claude/rules/workflow](../../.claude/rules/workflow.md)).

--- a/docs/wiki/battery-ladder.md
+++ b/docs/wiki/battery-ladder.md
@@ -1,0 +1,23 @@
+# Battery ladder
+
+Staged response to falling pack voltage, always keyed to the **worse** of the
+two packs: first a forced-Eco lock (machine keeps driving, slower), then an
+audible low-voltage alarm ([alerts and alarms](alerts-and-alarms.md)), and at
+the bottom a **latched cutoff** — the [output gate](output-gate.md) closes
+and stays closed until power-cycle, even if voltage recovers.
+
+- Current thresholds, debounce times, and the boot-gate behavior:
+  [CLAUDE.md](../../CLAUDE.md) and [SAFETY](../SAFETY.md) (canonical)
+- Invariants and fault-injection tests (cutoff dominates every drive request;
+  boot with a low pack never emits one non-neutral pulse):
+  [SAFETY](../SAFETY.md) · [testing](testing.md)
+- Voltage arrives via [X.BUS telemetry](xbus-telemetry.md); implausible
+  readings are rejected by plausibility gates, and telemetry dropout
+  deliberately freezes the ladder ([SAFETY](../SAFETY.md) "Known gaps"
+  documents the edge cases)
+- Operator-facing behavior and what the beeps mean:
+  [OPERATOR-GUIDE](../../OPERATOR-GUIDE.md)
+
+Deliberate asymmetry: battery cutoff **latches** until power-cycle, while
+[thermal cut](thermal-derating.md) auto-recovers — both are intended and
+test-locked.

--- a/docs/wiki/battery-ladder.md
+++ b/docs/wiki/battery-ladder.md
@@ -4,7 +4,8 @@ Staged response to falling pack voltage, always keyed to the **worse** of the
 two packs: first a forced-Eco lock (machine keeps driving, slower), then an
 audible low-voltage alarm ([alerts and alarms](alerts-and-alarms.md)), and at
 the bottom a **latched cutoff** — the [output gate](output-gate.md) closes
-and stays closed until power-cycle, even if voltage recovers.
+and stays closed until power-cycle, even if voltage recovers. The alarm keeps
+chirping through the cut, so a cutoff is never silent.
 
 - Current thresholds, debounce times, and the boot-gate behavior:
   [CLAUDE.md](../../CLAUDE.md) and [SAFETY](../SAFETY.md) (canonical)

--- a/docs/wiki/control-pipeline.md
+++ b/docs/wiki/control-pipeline.md
@@ -1,0 +1,21 @@
+# Control pipeline
+
+Stick to track, end to end — all shaping happens on the Arduino, all motor
+smoothing inside the ESC's FOC. Canonical description with current values:
+[CLAUDE.md](../../CLAUDE.md) "Architecture Summary"; research background:
+[CONTROL-RESEARCH](../CONTROL-RESEARCH.md).
+
+1. Inputs: [S.BUS input](sbus-input.md) (RC) and the joystick ADC
+2. Shaping: deadband + expo curves per axis
+3. Mixing: [curvature drive](curvature-drive.md) (tank mix with pivot blend)
+4. Authority: [override modes](override-modes.md) select RC / joystick / blend
+5. Limits: [gear and reverse caps](gear-and-reverse-caps.md), then the
+   [safety system](safety-system.md) may derate or close the
+   [output gate](output-gate.md)
+6. Output: servo PWM per track to the GL10 ESCs ([hardware](hardware.md))
+
+Two permanent design decisions guard this pipeline: it is **open-loop** (no
+RPM feedback — the FOC ESC owns execution) and **nothing on the Wi-Fi side
+can command a motor** ([telemetry and dashboard](telemetry-and-dashboard.md)
+is monitoring-only). Why smoothness dominates every trade-off:
+[MISSION](../MISSION.md).

--- a/docs/wiki/curvature-drive.md
+++ b/docs/wiki/curvature-drive.md
@@ -1,0 +1,22 @@
+# Curvature drive
+
+The tank-mixing algorithm: throttle plus steering in, one speed per track
+out. At speed it behaves like a car (inner track slows, outer speeds up by
+the same delta — average speed stays what the stick asked); near standstill
+it blends smoothly into **pivot mode**, counter-rotating the tracks in place.
+Feeding throttle mid-pivot arcs the machine out of the pivot instead of
+surging it forward.
+
+- Current constants, blend thresholds, and taper values:
+  [CLAUDE.md](../../CLAUDE.md) "Architecture Summary" (canonical)
+- Why this mix was chosen and the research behind it:
+  [CONTROL-RESEARCH](../CONTROL-RESEARCH.md)
+- Field-tuning history (blend band, pivot throttle taper, reverse-steer
+  consistency): [DECISION-LOG](../DECISION-LOG.md)
+- Its outputs are bounded by [gear and reverse caps](gear-and-reverse-caps.md)
+  and gated by the [safety system](safety-system.md)
+- Position in the chain: [control pipeline](control-pipeline.md)
+
+The average-speed property matters for safety review: caps bound the AVERAGE
+track command, and single-track excursions in turns are design headroom, not
+violations ([SAFETY](../SAFETY.md)).

--- a/docs/wiki/gear-and-reverse-caps.md
+++ b/docs/wiki/gear-and-reverse-caps.md
@@ -1,0 +1,22 @@
+# Gear and reverse caps
+
+The speed-limiting layer between [curvature drive](curvature-drive.md) and
+the [output gate](output-gate.md). A three-position RC switch selects a gear
+(Eco / Normal / Boost); each gear caps the **average** track speed, leaving
+the outer track headroom to hold speed through corners. Reverse gets its own,
+lower cap per gear. In Eco, the pivot cap is boosted so the rider keeps
+usable maneuvering authority.
+
+- Current cap values, the pivot boost, and the joystick gain:
+  [CLAUDE.md](../../CLAUDE.md) (canonical)
+- The invariant and its test — no input combination exceeds the active caps
+  on the average track command: [SAFETY](../SAFETY.md)
+- Why reverse caps are true percentages (ESC recalibration history) and how
+  the gear spread was tuned: [DECISION-LOG](../DECISION-LOG.md)
+- The [battery ladder](battery-ladder.md) and
+  [thermal derating](thermal-derating.md) can force the Eco cap regardless of
+  the switch position
+
+**Average, not per-track**: a single track legitimately exceeds the gear cap
+mid-turn — that headroom is the design, not a bug. Reviewers and agents keep
+tripping on this; it is locked by test.

--- a/docs/wiki/hardware.md
+++ b/docs/wiki/hardware.md
@@ -1,0 +1,22 @@
+# Hardware
+
+Arduino **UNO R4 WiFi** (RA4M1 + ESP32-S3 Wi-Fi coprocessor) drives two
+XC GL10 FOC ESCs paired with GL540L sensored brushless motors, powered by two
+3S LiPo packs. Inputs: Radiolink RC system over [S.BUS](sbus-input.md) and a
+hall-effect dual-axis joystick on the ADC. Canonical component table and pin
+assignments: [CLAUDE.md](../../CLAUDE.md).
+
+- [WIRING-GUIDE-V8](../WIRING-GUIDE-V8.md) — canonical wiring reference
+- [INTERFACE-BOARD-PERFBOARD](../INTERFACE-BOARD-PERFBOARD.md) — soldered
+  interface board (X.BUS merge + S.BUS inverter); design history in
+  [INTERFACE-BOARD](../INTERFACE-BOARD.md) and netlist in
+  [INTERFACE-BOARD-NETLIST](../INTERFACE-BOARD-NETLIST.md)
+- [GL10-PARAMETERS](../GL10-PARAMETERS.md) — every ESC parameter analyzed
+  against what the firmware actually commands (read before ANY ESC change)
+- [GL10-OPERATION](../GL10-OPERATION.md) — calibration, factory reset, LED
+  and beep codes; quick card: [GL10-QUICK-REFERENCE](../GL10-QUICK-REFERENCE.md)
+
+The GL10's internal FOC owns motor smoothing — the Arduino sends open-loop
+servo PWM commands only (see [control pipeline](control-pipeline.md)). The
+hardware history (older sensored ESCs, the board migration) is recorded in
+[CLAUDE.md](../../CLAUDE.md) and the [DECISION-LOG](../DECISION-LOG.md).

--- a/docs/wiki/home.md
+++ b/docs/wiki/home.md
@@ -1,0 +1,23 @@
+# Home — Excavator Track Controller
+
+Tank-style dual-track controller for a ride-on excavator: Arduino UNO R4
+WiFi, two FOC ESCs, dual input (RC transmitter + rider joystick), Wi-Fi
+telemetry dashboard. Project memory: [CLAUDE.md](../../CLAUDE.md) · full
+spec: [PROJECT-PLAN.md](../../PROJECT-PLAN.md) · design philosophy:
+[MISSION](../MISSION.md) (smoothness above all).
+
+## Domains
+
+- [Hardware](hardware.md) — board, ESCs, motors, batteries, wiring
+- [Control pipeline](control-pipeline.md) — stick to track PWM, end to end
+- [Safety system](safety-system.md) — invariants, ladders, gates, failsafes
+- [Telemetry and dashboard](telemetry-and-dashboard.md) — X.BUS in, Wi-Fi out
+- [Testing](testing.md) — host suites that compile the real firmware
+- [Agent governance](agent-governance.md) — Karpathy method, covenant, bots
+- [Architecture remediation](architecture-remediation.md) — epic #116 program
+
+## People and operations
+
+- [OPERATOR-GUIDE](../../OPERATOR-GUIDE.md) — for the RC supervisor and rider
+- [FIRMWARE-UPLOAD-LOG](../FIRMWARE-UPLOAD-LOG.md) — the device's flight log
+- [DECISION-LOG](../DECISION-LOG.md) — every technical decision, dated

--- a/docs/wiki/output-gate.md
+++ b/docs/wiki/output-gate.md
@@ -1,0 +1,22 @@
+# Output gate
+
+The final authority between the mixer and the servo pins. When any
+closing condition fires — [battery cutoff](battery-ladder.md),
+[thermal cut](thermal-derating.md) — commands ease to neutral over a bounded
+ramp, then the servo signal **detaches entirely** (no pulses at all, which an
+ESC treats as signal loss, not as "hold neutral").
+
+- Current ramp timing and gate conditions: [CLAUDE.md](../../CLAUDE.md) and
+  [SAFETY](../SAFETY.md) (canonical)
+- Invariants: gate closed ⇒ neutral within the ramp window, then no pulses;
+  cutoff dominates any drive request in any [override
+  mode](override-modes.md) — tests in [testing](testing.md)
+- Every value written to the pins is double-bounded (float domain and
+  microsecond domain) — the "outputs always in range" invariant in
+  [SAFETY](../SAFETY.md)
+- Position in the chain: [control pipeline](control-pipeline.md)
+
+The boot-side counterpart: on power-up the gate waits for battery
+confirmation but **fails open** after a bounded window, so the machine
+remains drivable with dead telemetry — a deliberate, documented trade-off
+([SAFETY](../SAFETY.md)).

--- a/docs/wiki/output-gate.md
+++ b/docs/wiki/output-gate.md
@@ -1,10 +1,12 @@
 # Output gate
 
 The final authority between the mixer and the servo pins. When any
-closing condition fires — [battery cutoff](battery-ladder.md),
-[thermal cut](thermal-derating.md) — commands ease to neutral over a bounded
-ramp, then the servo signal **detaches entirely** (no pulses at all, which an
-ESC treats as signal loss, not as "hold neutral").
+closing condition fires — RC signal loss ([sbus-input](sbus-input.md)),
+[battery cutoff](battery-ladder.md), [thermal cut](thermal-derating.md), or
+the boot gate still awaiting battery confirmation — commands ease to neutral
+over a bounded ramp, then the servo signal **detaches entirely** (no pulses
+at all, which an ESC treats as signal loss, not as "hold neutral"). RC loss
+and thermal cut reopen the gate when they clear; battery cutoff latches.
 
 - Current ramp timing and gate conditions: [CLAUDE.md](../../CLAUDE.md) and
   [SAFETY](../SAFETY.md) (canonical)

--- a/docs/wiki/override-modes.md
+++ b/docs/wiki/override-modes.md
@@ -1,0 +1,20 @@
+# Override modes
+
+Who is driving. A three-position switch on the RC transmitter selects the
+authority model: RC only, RC-overrides-joystick, or a blended mode where both
+inputs mix. This is how the supervisor (RC) can take over from the rider
+(joystick) at any moment — the core supervision mechanism for a child-ridden
+machine.
+
+- Current mode mapping and blend behavior: [CLAUDE.md](../../CLAUDE.md)
+  (canonical); operator-facing description:
+  [OPERATOR-GUIDE](../../OPERATOR-GUIDE.md)
+- RC loss in any mode neutralizes RC's contribution via per-channel failsafe
+  ([sbus-input](sbus-input.md)); the stale-RC invariant is tested across all
+  modes ([SAFETY](../SAFETY.md) · [testing](testing.md))
+- Mode selection feeds the [control pipeline](control-pipeline.md) after
+  mixing, before [gear caps](gear-and-reverse-caps.md)
+
+Safety-relevant detail: the [battery cutoff](battery-ladder.md) and
+[output gate](output-gate.md) dominate **every** mode — no authority setting
+can drive through a closed gate.

--- a/docs/wiki/safety-system.md
+++ b/docs/wiki/safety-system.md
@@ -1,0 +1,27 @@
+# Safety system
+
+Everything that can slow, stop, or refuse a drive command. The canonical,
+test-linked registry of what must ALWAYS hold is [SAFETY](../SAFETY.md) —
+each invariant there has an executable host test ([testing](testing.md)).
+
+Layers, from input to output:
+
+- Per-channel RC failsafe and stale-input neutralization
+  ([sbus-input](sbus-input.md))
+- [Battery ladder](battery-ladder.md) — staged response to falling pack
+  voltage, from forced-Eco to latched cutoff
+- [Thermal derating](thermal-derating.md) — staged response to ESC/motor
+  temperature, monotone by design
+- Plausibility gates — implausible voltage/temperature readings are never
+  trusted ([SAFETY](../SAFETY.md))
+- [Output gate](output-gate.md) — the final authority between the mixer and
+  the servo pins
+- Loop watchdog — born from a real incident (Wi-Fi stall while PWM held the
+  last throttle); the story is in [SAFETY](../SAFETY.md) and the fix in the
+  [DECISION-LOG](../DECISION-LOG.md)
+- [Alerts and alarms](alerts-and-alarms.md) — sound-only today, by design
+
+Operator-facing behavior (what the machine does when a layer trips):
+[OPERATOR-GUIDE](../../OPERATOR-GUIDE.md). Known, deliberately-unfixed gaps
+are documented in [SAFETY](../SAFETY.md) "Known gaps" — fixing one requires
+its own issue per the [governance rules](agent-governance.md).

--- a/docs/wiki/sbus-input.md
+++ b/docs/wiki/sbus-input.md
@@ -1,0 +1,18 @@
+# S.BUS input
+
+All RC channels arrive on one wire: the receiver's S.BUS output — an
+electrically **inverted** UART protocol — passes through an NPN inverter on
+the [interface board](hardware.md) into a dedicated hardware UART on the
+Arduino. From one frame the firmware reads throttle, steering, the
+[override mode](override-modes.md) switch, the
+[gear](gear-and-reverse-caps.md) switch, and the horn button.
+
+- Current pins, UART instance naming, and frame parameters:
+  [CLAUDE.md](../../CLAUDE.md) "UART Architecture" (canonical); wiring:
+  [WIRING-GUIDE-V8](../WIRING-GUIDE-V8.md)
+- **Per-channel failsafe** — each channel times out independently, and the
+  receiver's failsafe flag is honored; stale or failsafed RC never produces
+  non-neutral propulsion ([SAFETY](../SAFETY.md) · [testing](testing.md))
+- Standing rule: hardware UARTs only, never `SoftwareSerial`
+  ([CLAUDE.md](../../CLAUDE.md) coding rules)
+- Position in the chain: [control pipeline](control-pipeline.md)

--- a/docs/wiki/telemetry-and-dashboard.md
+++ b/docs/wiki/telemetry-and-dashboard.md
@@ -1,0 +1,22 @@
+# Telemetry and dashboard
+
+Read-only observation path: the ESCs report voltage, current, RPM, and
+temperatures over [X.BUS telemetry](xbus-telemetry.md); the firmware smooths
+and streams them to the [Wi-Fi dashboard](wifi-dashboard.md).
+
+**Monitoring only — permanent decision.** There is no path from Wi-Fi (or any
+telemetry) back into motor output; the [safety system](safety-system.md)
+consumes telemetry for derating/cutoff decisions, but nothing network-side
+can ever command a track. Canonical detail and current cadence/keys:
+[CLAUDE.md](../../CLAUDE.md).
+
+- [XBUS-PROTOCOL](../XBUS-PROTOCOL.md) — wire protocol reference
+- Dashboard source lives at `dashboard/index.html`, embedded into firmware as
+  `sketches/rc_test/web_page.h` (generated — edit the source, regenerate)
+- Dashboard rules (frame budget, UI testing before flashing):
+  [.claude/rules/dashboard](../../.claude/rules/dashboard.md)
+- Telemetry feeds the [battery ladder](battery-ladder.md) and
+  [thermal derating](thermal-derating.md); when telemetry drops out, those
+  ladders deliberately freeze ([SAFETY](../SAFETY.md))
+- Open latency work is hardware-gated:
+  [HANDOFF-V8-V9-WIFI-LATENCY-AND-OFFLOAD](../HANDOFF-V8-V9-WIFI-LATENCY-AND-OFFLOAD.md)

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -1,0 +1,23 @@
+# Testing
+
+Host-side suites that compile the **real firmware** (`rc_test.ino`) against
+stub Arduino headers — no hardware needed. Canonical guide, commands, and the
+commit gate: [TESTING](../TESTING.md).
+
+- **Characterization suite** (`tests/characterization/`) — locks current
+  behavior; the parity gate for every firmware-touching PR
+- **Invariant suite** (`tests/invariants/`) — property tests + fault
+  injection for the [safety system](safety-system.md); each maps to a row in
+  [SAFETY](../SAFETY.md)
+- **Commit gate** — `.githooks/pre-commit` blocks red suites and firmware
+  changes without test changes
+- **CI** — the same suites run in the `unit-tests` workflow alongside
+  compile, lint, static-analysis, and structure checks
+
+**Test expectations are behavior law**: changing an expected value is a
+behavior change requiring its own issue and operator sign-off — the core of
+the [governance covenant](agent-governance.md). What cannot be tested on the
+host (physical behavior) is deferred to a bench pass:
+[BENCH-VERIFICATION-DEFERRED](../architecture/BENCH-VERIFICATION-DEFERRED.md).
+Dashboard UI has its own local test path (Playwright screenshots) per
+[.claude/rules/dashboard](../../.claude/rules/dashboard.md).

--- a/docs/wiki/thermal-derating.md
+++ b/docs/wiki/thermal-derating.md
@@ -1,0 +1,21 @@
+# Thermal derating
+
+Staged response to ESC and motor temperature — **monotone by design**: a
+rising thermal stage never increases allowed propulsion. Stages run from a
+warning, through a forced-Eco cap ([gear and reverse
+caps](gear-and-reverse-caps.md)), to a full thermal cut via the
+[output gate](output-gate.md). Each stage trips after a debounce and releases
+with **hysteresis** — the machine holding a reduced stage anywhere inside its
+hysteresis band is correct behavior, not a stuck state.
+
+- Current stage temperatures, debounce, and release bands:
+  [CLAUDE.md](../../CLAUDE.md) and [SAFETY](../SAFETY.md) (canonical)
+- The monotonicity invariant and its tests: [SAFETY](../SAFETY.md) ·
+  [testing](testing.md)
+- Temperatures arrive via [X.BUS telemetry](xbus-telemetry.md); implausible
+  spikes are rejected, and dropout freezes the active stage rather than
+  releasing it
+
+Deliberate asymmetry with the [battery ladder](battery-ladder.md): thermal
+cut **auto-recovers** when temperature falls; battery cutoff latches until
+power-cycle. Both intended, both test-locked.

--- a/docs/wiki/wifi-dashboard.md
+++ b/docs/wiki/wifi-dashboard.md
@@ -1,0 +1,22 @@
+# Wi-Fi dashboard
+
+The UNO R4 WiFi hosts its own access point and serves a single-page
+dashboard streaming live telemetry over Server-Sent Events. **Monitoring
+only, permanently** — there is no control input over Wi-Fi, and no code path
+from the network to motor output
+([telemetry and dashboard](telemetry-and-dashboard.md)).
+
+- Current AP name, addresses, stream cadence, and endpoints:
+  [CLAUDE.md](../../CLAUDE.md) (canonical)
+- Source of truth for the page is `dashboard/index.html`;
+  `sketches/rc_test/web_page.h` is generated from it — never hand-edited
+- Rules (SSE frame budget, wire-format keys, local Playwright screenshot
+  testing BEFORE flashing):
+  [.claude/rules/dashboard](../../.claude/rules/dashboard.md)
+- History: a blocking page send once froze the control loop and became the
+  motivating incident for the loop watchdog
+  ([safety system](safety-system.md), [SAFETY](../SAFETY.md)); serving is
+  incremental and bounded since — details in the
+  [DECISION-LOG](../DECISION-LOG.md)
+- Open latency investigation (hardware-gated):
+  [HANDOFF-V8-V9-WIFI-LATENCY-AND-OFFLOAD](../HANDOFF-V8-V9-WIFI-LATENCY-AND-OFFLOAD.md)

--- a/docs/wiki/xbus-telemetry.md
+++ b/docs/wiki/xbus-telemetry.md
@@ -15,7 +15,9 @@ throttle-over-bus function would fight our PWM and is never used.
   [thermal derating](thermal-derating.md), and the
   [Wi-Fi dashboard](wifi-dashboard.md) — monitoring-only by permanent
   decision ([telemetry and dashboard](telemetry-and-dashboard.md))
-- Plausibility gates reject implausible readings; dropout freezes the safety
-  ladders ([SAFETY](../SAFETY.md), including the known NaN edge case)
+- Plausibility gates reject implausible readings — with one documented
+  exception: NaN pack voltage passes the voltage band ([SAFETY](../SAFETY.md)
+  "Known gaps"; unreachable today via the integer parse path). Dropout
+  freezes the safety ladders rather than releasing them.
 - Bus wiring and the X.BUS merge on the interface board:
   [hardware](hardware.md)

--- a/docs/wiki/xbus-telemetry.md
+++ b/docs/wiki/xbus-telemetry.md
@@ -1,0 +1,21 @@
+# X.BUS telemetry
+
+How the firmware reads voltage, current, RPM, and temperatures from both
+ESCs without ever taking control authority: it polls the GL10's **Read
+Register** function over a shared half-duplex UART bus. The critical protocol
+choice — Read Register is point-to-point service traffic that never puts the
+ESC into bus-control mode, so PWM command authority is fully preserved. The
+throttle-over-bus function would fight our PWM and is never used.
+
+- Wire protocol, framing, and register map:
+  [XBUS-PROTOCOL](../XBUS-PROTOCOL.md) (canonical)
+- Current registers polled, cadence, smoothing, and freshness watchdog:
+  [CLAUDE.md](../../CLAUDE.md) "Telemetry"
+- Consumers: the [battery ladder](battery-ladder.md),
+  [thermal derating](thermal-derating.md), and the
+  [Wi-Fi dashboard](wifi-dashboard.md) — monitoring-only by permanent
+  decision ([telemetry and dashboard](telemetry-and-dashboard.md))
+- Plausibility gates reject implausible readings; dropout freezes the safety
+  ladders ([SAFETY](../SAFETY.md), including the known NaN edge case)
+- Bus wiring and the X.BUS merge on the interface board:
+  [hardware](hardware.md)


### PR DESCRIPTION
Closes #141

## Summary

AI-maintained knowledge graph at `docs/wiki/` — the Karpathy LLM-wiki pattern as a follow-up to #53: agents create and maintain interconnected Markdown; humans read it on GitHub or visualize it as a graph in Obsidian.

**Role tag:** `[C-Builder]`

**What's in the graph (19 notes, 447 lines):**
- `home.md` — root hub, plus `README.md` (ownership + how to open the vault)
- 7 domain hubs: hardware, control-pipeline, safety-system, telemetry-and-dashboard, testing, agent-governance, architecture-remediation
- 11 concept notes for things no single doc owns: curvature-drive, gear-and-reverse-caps, battery-ladder, thermal-derating, output-gate, override-modes, sbus-input, xbus-telemetry, wifi-dashboard, alerts-and-alarms

**Design decisions (anti-drift):**
- **Navigation layer, not a second copy** — notes carry stable concepts + links; constants/thresholds/pins live ONLY in canonical docs. A wiki note restating a number is a bug.
- **Standard relative Markdown links**, no `[[wikilink]]` syntax — GitHub-readable, lint-clean, and Obsidian graphs them natively.
- **`docs/wiki/` not top-level `wiki/`** — structure-check CI restricts `.md` locations to root/docs/.github/.claude; this placement needs zero CI changes.
- **Agents own the folder** — PRs that change docs update affected notes in the same PR (cheap: links, not content). Rule stated in `docs/wiki/README.md`.
- Vault = repo root (so canonical docs appear as graph nodes too); `.obsidian/` gitignored.

Also: CLAUDE.md file-map row + DECISION-LOG entry.

## Test plan

- Docs-only diff — zero firmware, zero tests touched
- All relative links machine-verified against existing files (zero broken)
- CI: markdownlint + structure-check must stay green (structure-check passes by construction — all `.md` under `docs/`)
- Manual: open repo root as Obsidian vault → graph view shows wiki hubs connected to canonical docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an AI-maintained knowledge-graph wiki under `docs/wiki/`, including new pages covering hardware, control pipeline, curvature drive, gear/reverse caps, override modes, safety system, output gate, telemetry/dashboard, testing, and thermal/battery behavior.
  * Expanded decision-log and navigation guidance for clearer documentation workflows.
  * Updated operator guidance for beep meanings to match the low-battery Eco lock and latched motor cutoff behavior.
  * Clarified audible alarms as sound-only versus staged battery protection that affects drive behavior.
* **Chores**
  * Updated local ignore rules to exclude Obsidian workspace settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->