### PR TITLE
fix: deploy.py defaults target UNO R4 WiFi (#140)

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -11,8 +11,8 @@ import sys
 sys.stdout.reconfigure(encoding='utf-8', errors='replace')
 
 # Defaults — override via command line or edit here when switching boards
-DEFAULT_FQBN = 'arduino:renesas_uno:nanor4'
-DEFAULT_PORT = 'COM8'
+DEFAULT_FQBN = 'arduino:renesas_uno:unor4wifi'
+DEFAULT_PORT = 'COM7'
 DEFAULT_SKETCH = 'sketches/rc_test'
 
 parser = argparse.ArgumentParser(description='Deploy sketch to Arduino board')


### PR DESCRIPTION
Closes #140

## Summary

Two-line tooling fix: `scripts/deploy.py` still carried Nano R4-era defaults. `DEFAULT_FQBN` `nanor4` → `unor4wifi`, `DEFAULT_PORT` `COM8` → `COM7`, matching CLAUDE.md "Build & Upload" and CI.

**Why it mattered:** both boards are RA4M1-based, so a nanor4-built binary flashes *successfully* onto the UNO R4 WiFi — but with the Nano variant pin map, S.BUS (SCI0: A4/A5 there vs D11/D12 here) is silently dead. Found by Copilot review on PR #139.

**Role tag:** `[C-Builder]`

## Test plan

- Tooling-only diff — zero firmware bytes, zero behavior change on the machine
- CI must stay fully green (the script isn't exercised by CI; the compile matrix already uses unor4wifi)
- Real verification is hardware-gated: first `python scripts/deploy.py` run when the machine returns (upload to COM7 succeeds, RC input works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default Arduino deployment settings to better match the expected board and serial port.
  * The command-line tool now uses a new default board target and port when no custom values are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->