### PR TITLE
Phase C: architecture fitness functions in CI (#129)

### DIFF
--- a/.architecture-allowlist
+++ b/.architecture-allowlist
@@ -1,0 +1,6 @@
+# File-size allowlist for the architecture fitness functions (#129).
+# Format: one entry per line — "path/relative/to/repo.h | reason".
+# A file listed here is exempt from the 150-soft / 250-hard line policy
+# (scripts/check_architecture.py); the reason is REQUIRED and should say why
+# the file cannot be split by responsibility. Keep this list short — it is a
+# ledger of debts, not a loophole.

--- a/.github/workflows/architecture-fitness.yml
+++ b/.github/workflows/architecture-fitness.yml
@@ -1,0 +1,28 @@
+name: Architecture Fitness
+
+# Fitness functions for the epic #116 target architecture (#129):
+# forbidden includes, layer direction, file-size policy, banned names,
+# no mutable domain globals, generated-file guard, version SSOT.
+# Advisory until the Phase D extraction lands (not in branch protection);
+# flip to required afterwards — see ARCHITECTURE-TARGET.md section 10.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  architecture-fitness:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Self-test (every failure mode must fire)
+        run: python scripts/check_architecture_selftest.py
+      - name: Check architecture
+        run: python scripts/check_architecture.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,8 @@ sits above all four: during epic #116, organization changes NOTHING observable
    - compiles clean locally:
      `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test`
    - CI green: `arduino-ci.yml`, `lint.yml`, `static-analysis.yml`,
-     `code-quality.yml`, `structure-check.yml`, `unit-tests.yml`
+     `code-quality.yml`, `structure-check.yml`, `unit-tests.yml`,
+     `architecture-fitness.yml` (#129 — layer/size/naming rules on `src/` trees)
    - no blocking calls in `loop()` (`delay()`, `pulseIn()`, unbounded `while`)
    - zero behavior change unless the task's own issue explicitly authorizes it
 

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,24 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-07 — Architecture fitness functions in CI (#129, Phase C)
+
+- **What:** `scripts/check_architecture.py` + `architecture_rules.py`
+  (stdlib-only, identical locally and in CI) enforcing ARCHITECTURE-TARGET §3
+  on every `sketches/<name>/src/` tree: forbidden includes + layer direction
+  (incl. the observer-ring SystemSnapshot exception), file-size 150/250 with
+  `.architecture-allowlist` (reason required), banned names, no mutable
+  namespace-scope state in `domain/` (heuristic, namespace-transparent brace
+  tracking), generated-file guard (dormant until #120), FIRMWARE_VERSION SSOT
+  (dormant until #124). New `architecture-fitness` workflow runs
+  `check_architecture_selftest.py` first — 10 deliberate violations must fire
+  before the real check counts.
+- **Dormant by design:** checks target `src/` trees only; bench sketches and
+  the pre-Phase-D `rc_test` are exempt, so CI is green today and the rules
+  activate file-by-file as Phase D extracts code.
+- **Advisory → required:** not in branch protection until the Phase D
+  extraction lands (per #129), then flipped.
+
 ## 2026-07-07 — AI-maintained knowledge graph at docs/wiki/ (#141, Karpathy LLM-wiki)
 
 - **What:** `docs/wiki/` — 19 link-dense Markdown notes (root hub, 7 domain

--- a/docs/architecture/ARCHITECTURE-TARGET.md
+++ b/docs/architecture/ARCHITECTURE-TARGET.md
@@ -258,9 +258,16 @@ path moves:
 ## 10. Enforcement
 
 Rules in this document are enforced by the CI architecture fitness functions
-(#129): forbidden includes, layer direction, file-size policy, banned names,
-no mutable domain globals, generated-file drift, version SSOT. Until #129
-lands they are review-enforced.
+(#129, shipped): forbidden includes, layer direction, file-size policy
+(allowlist: `.architecture-allowlist`, reason required per entry), banned
+names, no mutable domain globals, generated-file drift (activates with #120),
+version SSOT (activates with #124). Implementation:
+`scripts/check_architecture.py` + `scripts/architecture_rules.py`, run by the
+`architecture-fitness` workflow after a self-test
+(`scripts/check_architecture_selftest.py`) proves every failure mode fires.
+The check is **advisory** (not in branch protection) until the Phase D
+extraction lands, then flipped to required. Section 3's table is canonical —
+a rule change here must change the script in the same PR.
 
 ## 11. Testing strategy (summary — details in #47/#131)
 

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -12,7 +12,10 @@ commit gate: [TESTING](../TESTING.md).
 - **Commit gate** — `.githooks/pre-commit` blocks red suites and firmware
   changes without test changes
 - **CI** — the same suites run in the `unit-tests` workflow alongside
-  compile, lint, static-analysis, and structure checks
+  compile, lint, static-analysis, and structure checks; the
+  `architecture-fitness` workflow additionally enforces the
+  [target architecture's](architecture-remediation.md) dependency, file-size,
+  and naming rules with a self-testing checker
 
 **Test expectations are behavior law**: changing an expected value is a
 behavior change requiring its own issue and operator sign-off — the core of

--- a/scripts/architecture_rules.py
+++ b/scripts/architecture_rules.py
@@ -1,0 +1,168 @@
+"""Architecture fitness rules (#129) — pure check logic, Python stdlib only.
+
+Encodes docs/architecture/ARCHITECTURE-TARGET.md section 3 (the dependency
+table is canonical; if this file and the table disagree, the table wins).
+Checks target sketches/<name>/src/ trees only — bench sketches without a
+src/ tree are exempt by design, so the suite is green until Phase D
+populates the structure.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SOFT_LINE_LIMIT = 150
+HARD_LINE_LIMIT = 250
+
+SOURCE_SUFFIXES = {".h", ".hpp", ".cpp", ".ino"}
+
+# Hardware/system headers allowed ONLY in infrastructure/ (table row 4).
+HARDWARE_HEADERS = {
+    "Arduino.h", "WiFiS3.h", "WiFi.h", "WiFiServer.h", "WiFiClient.h",
+    "Servo.h", "sbus.h", "SBUS.h", "Wire.h", "SPI.h", "EEPROM.h",
+    "SoftwareSerial.h", "WDT.h", "analogWave.h", "IRQManager.h",
+}
+
+# Banned file-name stems (.claude/rules/architecture.md). A stem equal to or
+# ending with one of these fails (PwmManager, EscData, Utils, ...).
+BANNED_STEMS = ("utils", "helpers", "helper", "manager", "common", "misc",
+                "stuff", "data")
+
+# Layer -> layers it may include (ARCHITECTURE-TARGET.md section 3).
+# telemetry/ and alerts/ are the application observer ring: domain types and
+# config only, plus the single application/SystemSnapshot.h exception.
+ALLOWED_INCLUDE_LAYERS = {
+    "domain":         {"domain", "config"},
+    "ports":          {"ports", "domain"},
+    "application":    {"application", "domain", "ports", "config",
+                       "telemetry", "alerts"},
+    "telemetry":      {"telemetry", "domain", "config"},
+    "alerts":         {"alerts", "domain", "config"},
+    "infrastructure": {"infrastructure", "ports", "config"},
+    "config":         {"config"},
+}
+OBSERVER_LAYERS = {"telemetry", "alerts"}
+OBSERVER_APPLICATION_EXCEPTION = "application/SystemSnapshot.h"
+
+INCLUDE_PATTERN = re.compile(r'^\s*#\s*include\s*[<"]([^>"]+)[>"]', re.M)
+
+
+def strip_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def layer_of(path: Path, src_root: Path) -> str:
+    return path.relative_to(src_root).parts[0]
+
+
+def resolve_include(file: Path, include: str, src_root: Path) -> str | None:
+    """Return 'layer/…' path inside src/, or None if external to src/."""
+    for base in (file.parent, src_root):
+        candidate = (base / include).resolve()
+        try:
+            return candidate.relative_to(src_root.resolve()).as_posix()
+        except ValueError:
+            continue
+    return None
+
+
+def check_includes(file: Path, src_root: Path) -> list[str]:
+    """Forbidden includes + layer direction, one file at a time."""
+    violations = []
+    layer = layer_of(file, src_root)
+    allowed = ALLOWED_INCLUDE_LAYERS.get(layer)
+    if allowed is None:  # generated/ and unknown folders: not include-checked
+        return violations
+    for include in INCLUDE_PATTERN.findall(strip_comments(file.read_text(encoding="utf-8", errors="replace"))):
+        base = include.split("/")[-1]
+        if base in HARDWARE_HEADERS:
+            if layer != "infrastructure":
+                violations.append(
+                    f"{file}: {layer}/ must not include hardware header <{include}>")
+            continue
+        internal = resolve_include(file, include, src_root)
+        if internal is None:
+            continue  # external/library/std header — fine outside the hardware list
+        target_layer = internal.split("/")[0]
+        if (layer in OBSERVER_LAYERS and target_layer == "application"
+                and internal == OBSERVER_APPLICATION_EXCEPTION):
+            continue
+        if target_layer not in allowed:
+            violations.append(
+                f"{file}: {layer}/ may not include {target_layer}/ ({include})")
+    return violations
+
+
+def check_ino(ino: Path, src_root: Path) -> list[str]:
+    """.ino may include application/ only (Arduino.h is implicit and allowed)."""
+    violations = []
+    for include in INCLUDE_PATTERN.findall(strip_comments(ino.read_text(encoding="utf-8", errors="replace"))):
+        if include.split("/")[-1] == "Arduino.h":
+            continue
+        internal = resolve_include(ino, include, src_root)
+        if internal is None:
+            violations.append(f"{ino}: .ino may only include application/ ({include})")
+        elif internal.split("/")[0] != "application":
+            violations.append(f"{ino}: .ino may only include application/ ({include})")
+    return violations
+
+
+def check_file_size(file: Path, allowlist: dict[str, str],
+                    repo_root: Path) -> tuple[list[str], list[str]]:
+    """Return (failures, warnings) for the 150-soft / 250-hard policy."""
+    lines = len(file.read_text(encoding="utf-8", errors="replace").splitlines())
+    relative = file.relative_to(repo_root).as_posix()
+    if relative in allowlist:
+        return [], []
+    if lines > HARD_LINE_LIMIT:
+        return [f"{relative}: {lines} lines exceeds hard limit {HARD_LINE_LIMIT} "
+                f"(split by responsibility, or allowlist with a reason)"], []
+    if lines > SOFT_LINE_LIMIT:
+        return [], [f"{relative}: {lines} lines exceeds soft limit {SOFT_LINE_LIMIT}"]
+    return [], []
+
+
+def check_banned_name(file: Path) -> list[str]:
+    stem = file.stem.lower()
+    for banned in BANNED_STEMS:
+        if stem == banned or stem.endswith(banned):
+            return [f"{file}: banned file name (…{banned!r}) — name one precise "
+                    f"responsibility (.claude/rules/architecture.md)"]
+    return []
+
+
+DEFINITION_PATTERN = re.compile(
+    r"^[A-Za-z_][\w:<>,\s\*&]*?\s[A-Za-z_]\w*\s*(=[^;]*)?;\s*$")
+SKIP_KEYWORDS = ("const ", "constexpr", "using ", "typedef ", "extern ",
+                 "static_assert", "friend ", "template", "return ",
+                 "struct ", "class ", "enum ", "namespace ")
+
+
+def check_domain_globals(file: Path) -> list[str]:
+    """Heuristic: no mutable namespace-scope variable definitions in domain/.
+
+    Tracks brace depth; namespace blocks are scope-transparent (their contents
+    are still namespace scope). Contents of any other braced scope (function,
+    class, initializer) are skipped. const/constexpr definitions pass.
+    """
+    violations = []
+    scopes: list[str] = []  # stack of "ns" | "other"
+    for number, raw in enumerate(
+            strip_comments(file.read_text(encoding="utf-8", errors="replace")).splitlines(), 1):
+        line = raw.strip()
+        at_namespace_scope = all(scope == "ns" for scope in scopes)
+        if (at_namespace_scope and line and not line.startswith("#")
+                and "(" not in line and "{" not in line and "}" not in line
+                and not any(line.startswith(k) or f" {k}" in f" {line}" for k in SKIP_KEYWORDS[:2])
+                and not any(line.startswith(k) for k in SKIP_KEYWORDS)
+                and DEFINITION_PATTERN.match(line)):
+            violations.append(
+                f"{file}:{number}: mutable namespace-scope state in domain/ "
+                f"({line[:60]}) — modules own state behind functions")
+        for char in raw:
+            if char == "{":
+                scopes.append("ns" if re.match(r"^\s*namespace\b", raw) else "other")
+            elif char == "}" and scopes:
+                scopes.pop()
+    return violations

--- a/scripts/architecture_rules.py
+++ b/scripts/architecture_rules.py
@@ -48,7 +48,10 @@ INCLUDE_PATTERN = re.compile(r'^\s*#\s*include\s*[<"]([^>"]+)[>"]', re.M)
 
 
 def strip_comments(text: str) -> str:
-    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    """Remove comments, preserving newlines so line numbers stay accurate."""
+    text = re.sub(r"/\*.*?\*/",
+                  lambda match: "\n" * match.group(0).count("\n"),
+                  text, flags=re.S)
     return re.sub(r"//[^\n]*", "", text)
 
 
@@ -145,9 +148,12 @@ def check_domain_globals(file: Path) -> list[str]:
     Tracks brace depth; namespace blocks are scope-transparent (their contents
     are still namespace scope). Contents of any other braced scope (function,
     class, initializer) are skipped. const/constexpr definitions pass.
+    Each '{' is classified by the text since the previous delimiter, so
+    'namespace foo' with the brace on the NEXT line still counts as namespace.
     """
     violations = []
     scopes: list[str] = []  # stack of "ns" | "other"
+    context = ""  # accumulated text since the last '{' / '}' / ';'
     for number, raw in enumerate(
             strip_comments(file.read_text(encoding="utf-8", errors="replace")).splitlines(), 1):
         line = raw.strip()
@@ -162,7 +168,16 @@ def check_domain_globals(file: Path) -> list[str]:
                 f"({line[:60]}) — modules own state behind functions")
         for char in raw:
             if char == "{":
-                scopes.append("ns" if re.match(r"^\s*namespace\b", raw) else "other")
-            elif char == "}" and scopes:
-                scopes.pop()
+                scopes.append(
+                    "ns" if context.strip().startswith("namespace") else "other")
+                context = ""
+            elif char == "}":
+                if scopes:
+                    scopes.pop()
+                context = ""
+            elif char == ";":
+                context = ""
+            else:
+                context += char
+        context += " "  # newline: keep 'namespace foo' linked to next-line '{'
     return violations

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -40,7 +40,12 @@ def load_allowlist(repo_root: Path) -> tuple[dict[str, str], list[str]]:
             failures.append(f".architecture-allowlist:{number}: entry needs "
                             f"'path | reason' — a reason is required")
             continue
-        allowlist[path.strip()] = reason.strip()
+        normalized = path.strip().replace("\\", "/")
+        if normalized in allowlist:
+            failures.append(f".architecture-allowlist:{number}: duplicate "
+                            f"entry for {normalized}")
+            continue
+        allowlist[normalized] = reason.strip()
     return allowlist, failures
 
 

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -1,0 +1,116 @@
+"""Architecture fitness functions (#129) — CLI and reporting.
+
+Usage:
+  python scripts/check_architecture.py            # check the repo
+  python scripts/check_architecture_selftest.py   # prove each check fires
+
+Enforces docs/architecture/ARCHITECTURE-TARGET.md section 3 on every
+sketches/<name>/src/ tree: forbidden includes, layer direction, file-size
+policy (150 soft / 250 hard, allowlist in .architecture-allowlist), banned
+file names, no mutable namespace-scope state in domain/, generated-file
+guard, firmware-version single source of truth. Bench sketches without a
+src/ tree are exempt; the suite is green until Phase D populates src/.
+Exit code 1 on any failure; warnings never fail the build.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+sys.path.insert(0, str(Path(__file__).parent))
+import architecture_rules as rules  # noqa: E402
+
+VERSION_DEFINITION = "#define FIRMWARE_VERSION"
+
+
+def load_allowlist(repo_root: Path) -> tuple[dict[str, str], list[str]]:
+    """Parse .architecture-allowlist ('path | reason' per line)."""
+    allowlist: dict[str, str] = {}
+    failures: list[str] = []
+    listing = repo_root / ".architecture-allowlist"
+    if not listing.exists():
+        return allowlist, failures
+    for number, raw in enumerate(listing.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        path, separator, reason = line.partition("|")
+        if not separator or not reason.strip():
+            failures.append(f".architecture-allowlist:{number}: entry needs "
+                            f"'path | reason' — a reason is required")
+            continue
+        allowlist[path.strip()] = reason.strip()
+    return allowlist, failures
+
+
+def check_repo(repo_root: Path) -> tuple[list[str], list[str], list[str]]:
+    """Run every check. Returns (failures, warnings, notes)."""
+    failures: list[str] = []
+    warnings: list[str] = []
+    notes: list[str] = []
+    allowlist, allowlist_failures = load_allowlist(repo_root)
+    failures += allowlist_failures
+
+    version_definitions: list[str] = []
+    for sketch_dir in sorted((repo_root / "sketches").glob("*/")):
+        for source in sketch_dir.rglob("*"):
+            if source.suffix in rules.SOURCE_SUFFIXES and source.is_file():
+                text = source.read_text(encoding="utf-8", errors="replace")
+                if VERSION_DEFINITION in text:
+                    version_definitions.append(
+                        source.relative_to(repo_root).as_posix())
+
+        src_root = sketch_dir / "src"
+        if not src_root.is_dir():
+            continue  # bench sketch / pre-Phase-D production sketch: exempt
+
+        for ino in sketch_dir.glob("*.ino"):
+            failures += rules.check_ino(ino, src_root)
+        for file in sorted(src_root.rglob("*")):
+            if not (file.is_file() and file.suffix in rules.SOURCE_SUFFIXES):
+                continue
+            layer = rules.layer_of(file, src_root)
+            if layer == "generated":
+                continue  # machine-written: size/name/include rules don't apply
+            failures += rules.check_includes(file, src_root)
+            failures += rules.check_banned_name(file)
+            size_failures, size_warnings = rules.check_file_size(
+                file, allowlist, repo_root)
+            failures += size_failures
+            warnings += size_warnings
+            if layer == "domain":
+                failures += rules.check_domain_globals(file)
+
+        generated = src_root / "generated"
+        if generated.is_dir() and not (repo_root / "scripts" / "generate_web_page.py").exists():
+            notes.append(f"{generated}: exists but no generator yet — drift "
+                         f"check activates with #120")
+
+    if len(version_definitions) > 1:
+        failures.append("FIRMWARE_VERSION defined in more than one file "
+                        f"(single source of truth, #124): {version_definitions}")
+    elif not version_definitions:
+        notes.append("no FIRMWARE_VERSION definition yet — SSOT check "
+                     "activates with #124")
+    return failures, warnings, notes
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    failures, warnings, notes = check_repo(repo_root)
+    for note in notes:
+        print(f"NOTE: {note}")
+    for warning in warnings:
+        print(f"WARN: {warning}")
+    for failure in failures:
+        print(f"FAIL: {failure}")
+    if failures:
+        print(f"\narchitecture-fitness: {len(failures)} violation(s)")
+        return 1
+    print(f"architecture-fitness: OK ({len(warnings)} warning(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_architecture_selftest.py
+++ b/scripts/check_architecture_selftest.py
@@ -1,0 +1,114 @@
+"""Self-test for the architecture fitness functions (#129).
+
+Builds a throwaway repo skeleton with one deliberate violation per check,
+asserts each check fires, then asserts a clean skeleton passes. Run by CI
+before the real check so a silently-broken checker cannot go green.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from check_architecture import check_repo  # noqa: E402
+
+EXPECTED_VIOLATIONS = {
+    "hardware header": "src/domain/Speed.h includes <Arduino.h>",
+    "may not include infrastructure/": "domain/ -> infrastructure/",
+    "may not include domain/": "infrastructure/ -> domain/ directly",
+    "may not include application/": "telemetry/ -> application/ (non-snapshot)",
+    "banned file name": "src/domain/TrackUtils.h",
+    "exceeds hard limit": "251-line file, not allowlisted",
+    "mutable namespace-scope state": "int currentGear = 0; in domain/",
+    "more than one file": "FIRMWARE_VERSION defined twice",
+    ".ino may only include application/": "sketch.ino includes domain/ directly",
+    "entry needs 'path | reason'": "allowlist entry missing reason",
+}
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def build_violating_repo(root: Path) -> None:
+    src = root / "sketches" / "fixture" / "src"
+    write(root / "sketches" / "fixture" / "fixture.ino",
+          '#include "src/domain/Speed.h"\n')
+    write(src / "domain" / "Speed.h",
+          "#include <Arduino.h>\n"
+          '#include "../infrastructure/EscPwm.h"\n'
+          "#define FIRMWARE_VERSION \"1\"\n")
+    write(src / "domain" / "TrackUtils.h", "// banned name\n")
+    write(src / "domain" / "GearPolicy.cpp",
+          "namespace gear {\nint currentGear = 0;\n"
+          "constexpr float kMax = 1.0f;\n}\n"
+          "#define FIRMWARE_VERSION \"2\"\n")
+    write(src / "infrastructure" / "EscPwm.h",
+          '#include "../domain/Speed.h"\n')
+    write(src / "telemetry" / "JsonEncoder.h",
+          '#include "../application/ControlCycle.h"\n')
+    write(src / "application" / "ControlCycle.h", "// fine\n")
+    write(src / "application" / "SystemSnapshot.h", "// fine\n")
+    write(src / "domain" / "Oversize.h", "// line\n" * 251)
+    write(root / ".architecture-allowlist", "missing/reason.h\n")
+
+
+def build_clean_repo(root: Path) -> None:
+    src = root / "sketches" / "fixture" / "src"
+    write(root / "sketches" / "fixture" / "fixture.ino",
+          "#include <Arduino.h>\n"
+          '#include "src/application/ControlCycle.h"\n')
+    write(src / "application" / "ControlCycle.h",
+          '#include "../domain/CurvatureDrive.h"\n'
+          '#include "../ports/EscOutputPort.h"\n')
+    write(src / "application" / "SystemSnapshot.h", "// snapshot\n")
+    write(src / "domain" / "CurvatureDrive.h",
+          "constexpr float kPivotCap = 0.6f;\n"
+          "namespace drive {\nconst int kGears = 3;\n}\n")
+    write(src / "ports" / "EscOutputPort.h",
+          '#include "../domain/CurvatureDrive.h"\n')
+    write(src / "infrastructure" / "EscPwm.h",
+          "#include <Servo.h>\n"
+          '#include "../ports/EscOutputPort.h"\n')
+    write(src / "telemetry" / "JsonEncoder.h",
+          '#include "../application/SystemSnapshot.h"\n')
+    write(src / "domain" / "Allowlisted.h", "// line\n" * 251)
+    write(root / ".architecture-allowlist",
+          "# path | reason\n"
+          "sketches/fixture/src/domain/Allowlisted.h | self-test fixture\n")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        build_violating_repo(root)
+        failures, _, _ = check_repo(root)
+        report = "\n".join(failures)
+        missing = [f"self-test: expected a '{marker}' failure ({why})"
+                   for marker, why in EXPECTED_VIOLATIONS.items()
+                   if marker not in report]
+        for problem in missing:
+            print(f"FAIL: {problem}")
+        if missing:
+            print("\n--- violating-fixture output for debugging ---")
+            print(report)
+            return 1
+
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        build_clean_repo(root)
+        failures, warnings, _ = check_repo(root)
+        if failures:
+            print("FAIL: self-test: clean fixture should pass, got:")
+            print("\n".join(failures))
+            return 1
+
+    print(f"architecture-fitness self-test: OK "
+          f"({len(EXPECTED_VIOLATIONS)} failure modes demonstrated)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_architecture_selftest.py
+++ b/scripts/check_architecture_selftest.py
@@ -24,6 +24,9 @@ EXPECTED_VIOLATIONS = {
     "more than one file": "FIRMWARE_VERSION defined twice",
     ".ino may only include application/": "sketch.ino includes domain/ directly",
     "entry needs 'path | reason'": "allowlist entry missing reason",
+    "duplicate entry": "same allowlist path twice (one with backslashes)",
+    "GearPolicy.cpp:5:": "line number correct after a multi-line block comment",
+    "slippedThrough": "namespace with brace on the NEXT line still checked",
 }
 
 
@@ -42,8 +45,10 @@ def build_violating_repo(root: Path) -> None:
           "#define FIRMWARE_VERSION \"1\"\n")
     write(src / "domain" / "TrackUtils.h", "// banned name\n")
     write(src / "domain" / "GearPolicy.cpp",
+          "/* block\n   comment\n   lines */\n"
           "namespace gear {\nint currentGear = 0;\n"
           "constexpr float kMax = 1.0f;\n}\n"
+          "namespace gear_brace_next_line\n{\nint slippedThrough = 1;\n}\n"
           "#define FIRMWARE_VERSION \"2\"\n")
     write(src / "infrastructure" / "EscPwm.h",
           '#include "../domain/Speed.h"\n')
@@ -52,7 +57,10 @@ def build_violating_repo(root: Path) -> None:
     write(src / "application" / "ControlCycle.h", "// fine\n")
     write(src / "application" / "SystemSnapshot.h", "// fine\n")
     write(src / "domain" / "Oversize.h", "// line\n" * 251)
-    write(root / ".architecture-allowlist", "missing/reason.h\n")
+    write(root / ".architecture-allowlist",
+          "missing/reason.h\n"
+          "twice/listed.h | first reason\n"
+          "twice\\listed.h | second reason\n")
 
 
 def build_clean_repo(root: Path) -> None:


### PR DESCRIPTION
Closes #129

## Summary

Phase C opens: **CI now defends the Phase A architecture** — the fitness functions from ARCHITECTURE-TARGET §10, implemented exactly as the issue specified (stdlib-only Python, identical behavior locally and in CI).

**Role tag:** `[C-Builder]`

| Piece | What it does |
| --- | --- |
| `scripts/architecture_rules.py` | Pure check logic encoding the §3 dependency table: forbidden includes + layer direction (incl. the telemetry/alerts observer-ring rule — `application/SystemSnapshot.h` is the only allowed application include), hardware headers confined to `infrastructure/`, `.ino` → `application/` only, 150-soft/250-hard file-size policy, banned names (`Utils`/`Manager`/… per `.claude/rules/architecture.md`), mutable namespace-scope state in `domain/` (heuristic with namespace-transparent brace tracking) |
| `scripts/check_architecture.py` | CLI + reporting: scans every `sketches/<name>/src/` tree, parses `.architecture-allowlist` (**reason required per entry** — a bare path fails), FIRMWARE_VERSION single-source-of-truth check, generated-file guard |
| `scripts/check_architecture_selftest.py` | Builds throwaway violating + clean repo fixtures; **all 10 failure modes must fire** and the clean fixture must pass — CI runs this before the real check, so a silently-broken checker can't go green (the issue's "deliberately-broken test case" acceptance item) |
| `.github/workflows/architecture-fitness.yml` | Self-test → check, on PR + main push |
| `.architecture-allowlist` | Empty ledger with format/policy header |

**Dormant by design:** checks target `src/` trees only — bench sketches and the pre-Phase-D `rc_test` are exempt, so CI is green today and the rules activate file-by-file as Phase D extracts code. Two sub-checks note their dependency and activate later: generated-file drift (#120), version SSOT (#124).

**Advisory → required:** per the issue, the check stays out of branch protection until the Phase D extraction lands; flipping it to required is the operator's one-click follow-up recorded in ARCHITECTURE-TARGET §10.

Docs synced in-PR: ARCHITECTURE-TARGET §10 (enforcement is now real), CLAUDE.md Working Agreement gate list, DECISION-LOG entry, wiki testing hub.

**#53 smoke test:** this is the first code-touching task executed under the Karpathy Working Agreement — goal + verifiable gate (self-test proves every failure mode; CI green; zero firmware bytes touched), surgical diff, issue-first, one open PR.

## Test plan

- `python scripts/check_architecture_selftest.py` → OK, 10 failure modes demonstrated (run locally, runs in CI)
- `python scripts/check_architecture.py` → OK on today's tree (dormant, 2 activation notes)
- Zero firmware changes — host suite untouched and green by construction; all existing CI must stay green
- New `architecture-fitness` check appears on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)
