### PR TITLE
Wiki lint: CI health check for docs/wiki (Karpathy lint operation, #145)

### DIFF
--- a/.github/workflows/wiki-lint.yml
+++ b/.github/workflows/wiki-lint.yml
@@ -1,0 +1,27 @@
+name: Wiki Lint
+
+# Health check for the docs/wiki/ knowledge graph (#145) — the "lint"
+# operation of the Karpathy LLM-wiki pattern (#141): link integrity,
+# orphan notes, reachability from home.md, and the anti-drift rule
+# (no tunable values outside canonical docs).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  wiki-lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Self-test (every failure mode must fire)
+        run: python scripts/check_wiki_selftest.py
+      - name: Lint the wiki
+        run: python scripts/check_wiki.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ sits above all four: during epic #116, organization changes NOTHING observable
      `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test`
    - CI green: `arduino-ci.yml`, `lint.yml`, `static-analysis.yml`,
      `code-quality.yml`, `structure-check.yml`, `unit-tests.yml`,
-     `architecture-fitness.yml` (#129 — layer/size/naming rules on `src/` trees)
+     `architecture-fitness.yml` (#129 — layer/size/naming rules on `src/`
+     trees), `wiki-lint.yml` (#145 — docs/wiki graph health)
    - no blocking calls in `loop()` (`delay()`, `pulseIn()`, unbounded `while`)
    - zero behavior change unless the task's own issue explicitly authorizes it
 

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,18 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-07 — Wiki lint in CI (#145) — the Karpathy "lint" operation
+
+- **What:** `scripts/check_wiki.py` + self-test, run by the `wiki-lint`
+  workflow: link integrity, orphan notes, reachability from `home.md`, and a
+  tunable-drift heuristic (numbers with units fail — the #141 anti-drift rule
+  is now machine-enforced). Completes the Karpathy LLM-wiki operation triad:
+  ingest (same-PR note updates), query (reading/Obsidian), lint (this).
+- Pattern source verified: Karpathy's `llm-wiki.md` idea-file gist (Apr
+  2026) — three layers (raw/wiki/schema) + three operations. Our mapping:
+  canonical docs = raw, docs/wiki = wiki, README rules = schema, git
+  history + this log = his log.md.
+
 ## 2026-07-07 — Architecture fitness functions in CI (#129, Phase C)
 
 - **What:** `scripts/check_architecture.py` + `architecture_rules.py`

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -27,4 +27,7 @@ interconnected notes; humans read and visualize them** (issue #141).
 - **Agents own this folder.** A PR that adds, removes, or renames a doc — or
   changes what a subsystem IS — updates the affected wiki notes in the same
   PR. Link fixes are cheap; that is the point of keeping content out.
+- **CI enforces this** (`wiki-lint` workflow, `scripts/check_wiki.py`, #145):
+  broken links, orphan notes, notes unreachable from [home](home.md), and
+  tunable-looking values all fail the build.
 - Start at [home](home.md).

--- a/scripts/check_wiki.py
+++ b/scripts/check_wiki.py
@@ -1,0 +1,111 @@
+"""Wiki lint (#145) — health checks for the docs/wiki/ knowledge graph.
+
+The third operation of the Karpathy LLM-wiki pattern (#141): ingest and
+query exist; this is lint. Stdlib-only, identical locally and in CI.
+
+Checks:
+  1. Link integrity — every relative Markdown link in a wiki note resolves.
+  2. Orphans — every note (except README.md/home.md) has an inbound link
+     from another wiki note.
+  3. Reachability — every note is reachable from home.md via wiki links.
+  4. Tunable drift — wiki notes must not carry tunable-looking values
+     (numbers with units); those live only in canonical docs
+     (docs/wiki/README.md anti-drift rule).
+
+Exit code 1 on any failure.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from collections import deque
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+LINK_PATTERN = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+EXTERNAL_SCHEMES = ("http://", "https://", "mailto:")
+HUB_NOTES = {"README.md", "home.md"}  # allowed to have no inbound links
+TUNABLE_PATTERN = re.compile(
+    r"\b\d+(?:\.\d+)?\s?(?:V|A|Hz|kHz|MHz|s|ms|us|µs|°C|%)\b")
+
+
+def wiki_links(note: Path) -> list[str]:
+    return [target.split("#")[0]
+            for target in LINK_PATTERN.findall(note.read_text(encoding="utf-8"))
+            if target and not target.startswith(EXTERNAL_SCHEMES)
+            and not target.startswith("#")]
+
+
+def check_wiki(wiki_root: Path) -> tuple[list[str], dict[str, set[str]]]:
+    """Return (failures, wiki-internal link graph by note name)."""
+    failures: list[str] = []
+    graph: dict[str, set[str]] = {}
+    notes = sorted(wiki_root.glob("*.md"))
+    if not notes:
+        return [f"{wiki_root}: no wiki notes found"], graph
+
+    for note in notes:
+        graph.setdefault(note.name, set())
+        for target in wiki_links(note):
+            resolved = (note.parent / target).resolve()
+            if not resolved.exists():
+                failures.append(f"{note.name}: broken link -> {target}")
+            elif resolved.parent == wiki_root.resolve():
+                graph[note.name].add(resolved.name)
+        for line_number, line in enumerate(
+                note.read_text(encoding="utf-8").splitlines(), 1):
+            for match in TUNABLE_PATTERN.findall(line):
+                failures.append(
+                    f"{note.name}:{line_number}: tunable-looking value "
+                    f"({match!r}) — constants live in canonical docs only "
+                    f"(docs/wiki/README.md anti-drift rule)")
+    return failures, graph
+
+
+def check_graph_shape(graph: dict[str, set[str]]) -> list[str]:
+    """Orphan and reachability checks over the wiki-internal link graph."""
+    failures: list[str] = []
+    inbound: dict[str, int] = {name: 0 for name in graph}
+    for source, targets in graph.items():
+        for target in targets:
+            if target != source and target in inbound:
+                inbound[target] += 1
+    for name, count in sorted(inbound.items()):
+        if count == 0 and name not in HUB_NOTES:
+            failures.append(f"{name}: orphan — no other wiki note links to it")
+
+    reachable: set[str] = set()
+    queue = deque(name for name in HUB_NOTES if name in graph)
+    reachable.update(queue)
+    while queue:
+        for target in graph.get(queue.popleft(), ()):
+            if target not in reachable:
+                reachable.add(target)
+                queue.append(target)
+    for name in sorted(graph):
+        if name not in reachable:
+            failures.append(f"{name}: not reachable from home.md")
+    return failures
+
+
+def run(repo_root: Path) -> list[str]:
+    wiki_root = repo_root / "docs" / "wiki"
+    failures, graph = check_wiki(wiki_root)
+    failures += check_graph_shape(graph)
+    return failures
+
+
+def main() -> int:
+    failures = run(Path(__file__).resolve().parent.parent)
+    for failure in failures:
+        print(f"FAIL: {failure}")
+    if failures:
+        print(f"\nwiki-lint: {len(failures)} violation(s)")
+        return 1
+    print("wiki-lint: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_wiki.py
+++ b/scripts/check_wiki.py
@@ -27,7 +27,7 @@ LINK_PATTERN = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
 EXTERNAL_SCHEMES = ("http://", "https://", "mailto:")
 HUB_NOTES = {"README.md", "home.md"}  # allowed to have no inbound links
 TUNABLE_PATTERN = re.compile(
-    r"\b\d+(?:\.\d+)?\s?(?:V|A|Hz|kHz|MHz|s|ms|us|µs|°C|%)\b")
+    r"\b\d+(?:\.\d+)?\s?(?:V|A|Hz|kHz|MHz|s|ms|us|µs|°C|%)(?!\w)")
 
 
 def wiki_links(note: Path) -> list[str]:
@@ -37,7 +37,8 @@ def wiki_links(note: Path) -> list[str]:
             and not target.startswith("#")]
 
 
-def check_wiki(wiki_root: Path) -> tuple[list[str], dict[str, set[str]]]:
+def check_wiki(wiki_root: Path,
+               repo_root: Path) -> tuple[list[str], dict[str, set[str]]]:
     """Return (failures, wiki-internal link graph by note name)."""
     failures: list[str] = []
     graph: dict[str, set[str]] = {}
@@ -49,7 +50,12 @@ def check_wiki(wiki_root: Path) -> tuple[list[str], dict[str, set[str]]]:
         graph.setdefault(note.name, set())
         for target in wiki_links(note):
             resolved = (note.parent / target).resolve()
-            if not resolved.exists():
+            try:
+                resolved.relative_to(repo_root.resolve())
+                inside_repo = True
+            except ValueError:
+                inside_repo = False  # escapes the repo — never a valid target
+            if not inside_repo or not resolved.is_file():
                 failures.append(f"{note.name}: broken link -> {target}")
             elif resolved.parent == wiki_root.resolve():
                 graph[note.name].add(resolved.name)
@@ -76,7 +82,7 @@ def check_graph_shape(graph: dict[str, set[str]]) -> list[str]:
             failures.append(f"{name}: orphan — no other wiki note links to it")
 
     reachable: set[str] = set()
-    queue = deque(name for name in HUB_NOTES if name in graph)
+    queue = deque(["home.md"]) if "home.md" in graph else deque()
     reachable.update(queue)
     while queue:
         for target in graph.get(queue.popleft(), ()):
@@ -84,14 +90,14 @@ def check_graph_shape(graph: dict[str, set[str]]) -> list[str]:
                 reachable.add(target)
                 queue.append(target)
     for name in sorted(graph):
-        if name not in reachable:
+        if name not in reachable and name not in HUB_NOTES:
             failures.append(f"{name}: not reachable from home.md")
     return failures
 
 
 def run(repo_root: Path) -> list[str]:
     wiki_root = repo_root / "docs" / "wiki"
-    failures, graph = check_wiki(wiki_root)
+    failures, graph = check_wiki(wiki_root, repo_root)
     failures += check_graph_shape(graph)
     return failures
 

--- a/scripts/check_wiki_selftest.py
+++ b/scripts/check_wiki_selftest.py
@@ -1,8 +1,8 @@
 """Self-test for the wiki lint (#145).
 
-Builds a throwaway docs/wiki fixture with one deliberate violation per
-check, asserts each fires, then asserts a clean fixture passes. CI runs
-this before the real lint so a silently-broken linter cannot go green.
+Builds a throwaway repo skeleton with one deliberate violation per check,
+asserts each fires, then asserts a clean skeleton passes. CI runs this
+before the real lint so a silently-broken linter cannot go green.
 """
 from __future__ import annotations
 
@@ -14,10 +14,14 @@ sys.path.insert(0, str(Path(__file__).parent))
 from check_wiki import run  # noqa: E402
 
 EXPECTED_VIOLATIONS = {
-    "broken link": "note links to a file that does not exist",
-    "tunable-looking value": "note restates '10.5 V'",
+    "broken link -> missing-note.md": "note links to a file that does not exist",
+    "broken link -> ../../../outside.md": "link escaping the repo root",
+    "broken link -> ../": "link resolving to a directory, not a file",
+    "'10.5 V'": "note restates a voltage",
+    "'60%'": "note restates a percentage (regression: trailing \\b never matched %)",
     "orphan": "note with no inbound wiki links",
-    "not reachable from home.md": "linked pair disconnected from home",
+    "island-one.md: not reachable": "linked pair disconnected from home",
+    "readme-only.md: not reachable": "note linked only from README, not from home.md",
 }
 
 
@@ -26,31 +30,40 @@ def write(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
-def build_violating_wiki(root: Path) -> None:
-    wiki = root / "docs" / "wiki"
-    write(wiki / "README.md", "[home](home.md)\n")
-    write(wiki / "home.md", "[gone](missing-note.md)\n[safety](safety.md)\n")
-    write(wiki / "safety.md", "Cutoff at 10.5 V is documented here.\n")
+def build_violating_repo(root: Path) -> Path:
+    repo = root / "repo"
+    wiki = repo / "docs" / "wiki"
+    write(root / "outside.md", "exists on disk, but outside the repo root\n")
+    write(wiki / "README.md", "[home](home.md)\n[readme only](readme-only.md)\n")
+    write(wiki / "home.md",
+          "[gone](missing-note.md)\n"
+          "[escape](../../../outside.md)\n"
+          "[directory](../)\n"
+          "[safety](safety.md)\n")
+    write(wiki / "safety.md", "Cutoff at 10.5 V and caps at 60% live here.\n")
+    write(wiki / "readme-only.md", "[home](home.md)\n")
     write(wiki / "orphan-note.md", "[home](home.md)\n")
     write(wiki / "island-one.md", "[two](island-two.md)\n")
     write(wiki / "island-two.md", "[one](island-one.md)\n")
+    return repo
 
 
-def build_clean_wiki(root: Path) -> None:
-    wiki = root / "docs" / "wiki"
-    write(root / "docs" / "CANONICAL.md", "The real constants live here.\n")
+def build_clean_repo(root: Path) -> Path:
+    repo = root / "repo"
+    wiki = repo / "docs" / "wiki"
+    write(repo / "docs" / "CANONICAL.md", "The real constants live here.\n")
     write(wiki / "README.md", "[home](home.md)\n")
     write(wiki / "home.md", "[safety](safety.md)\n[drive](drive.md)\n")
     write(wiki / "safety.md",
           "Thresholds: see [canonical](../CANONICAL.md). [drive](drive.md)\n")
     write(wiki / "drive.md", "Loops back to [safety](safety.md).\n")
+    return repo
 
 
 def main() -> int:
     with tempfile.TemporaryDirectory() as raw:
-        root = Path(raw)
-        build_violating_wiki(root)
-        report = "\n".join(run(root))
+        repo = build_violating_repo(Path(raw))
+        report = "\n".join(run(repo))
         missing = [f"self-test: expected a '{marker}' failure ({why})"
                    for marker, why in EXPECTED_VIOLATIONS.items()
                    if marker not in report]
@@ -62,9 +75,8 @@ def main() -> int:
             return 1
 
     with tempfile.TemporaryDirectory() as raw:
-        root = Path(raw)
-        build_clean_wiki(root)
-        failures = run(root)
+        repo = build_clean_repo(Path(raw))
+        failures = run(repo)
         if failures:
             print("FAIL: self-test: clean fixture should pass, got:")
             print("\n".join(failures))

--- a/scripts/check_wiki_selftest.py
+++ b/scripts/check_wiki_selftest.py
@@ -1,0 +1,79 @@
+"""Self-test for the wiki lint (#145).
+
+Builds a throwaway docs/wiki fixture with one deliberate violation per
+check, asserts each fires, then asserts a clean fixture passes. CI runs
+this before the real lint so a silently-broken linter cannot go green.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from check_wiki import run  # noqa: E402
+
+EXPECTED_VIOLATIONS = {
+    "broken link": "note links to a file that does not exist",
+    "tunable-looking value": "note restates '10.5 V'",
+    "orphan": "note with no inbound wiki links",
+    "not reachable from home.md": "linked pair disconnected from home",
+}
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def build_violating_wiki(root: Path) -> None:
+    wiki = root / "docs" / "wiki"
+    write(wiki / "README.md", "[home](home.md)\n")
+    write(wiki / "home.md", "[gone](missing-note.md)\n[safety](safety.md)\n")
+    write(wiki / "safety.md", "Cutoff at 10.5 V is documented here.\n")
+    write(wiki / "orphan-note.md", "[home](home.md)\n")
+    write(wiki / "island-one.md", "[two](island-two.md)\n")
+    write(wiki / "island-two.md", "[one](island-one.md)\n")
+
+
+def build_clean_wiki(root: Path) -> None:
+    wiki = root / "docs" / "wiki"
+    write(root / "docs" / "CANONICAL.md", "The real constants live here.\n")
+    write(wiki / "README.md", "[home](home.md)\n")
+    write(wiki / "home.md", "[safety](safety.md)\n[drive](drive.md)\n")
+    write(wiki / "safety.md",
+          "Thresholds: see [canonical](../CANONICAL.md). [drive](drive.md)\n")
+    write(wiki / "drive.md", "Loops back to [safety](safety.md).\n")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        build_violating_wiki(root)
+        report = "\n".join(run(root))
+        missing = [f"self-test: expected a '{marker}' failure ({why})"
+                   for marker, why in EXPECTED_VIOLATIONS.items()
+                   if marker not in report]
+        for problem in missing:
+            print(f"FAIL: {problem}")
+        if missing:
+            print("\n--- violating-fixture output for debugging ---")
+            print(report)
+            return 1
+
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        build_clean_wiki(root)
+        failures = run(root)
+        if failures:
+            print("FAIL: self-test: clean fixture should pass, got:")
+            print("\n".join(failures))
+            return 1
+
+    print(f"wiki-lint self-test: OK "
+          f"({len(EXPECTED_VIOLATIONS)} failure modes demonstrated)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #145

## Summary

Completes the Karpathy LLM-wiki pattern (#141) with its third operation: **lint**. The `docs/wiki/` knowledge graph can no longer silently rot — CI now fails on exactly the failure modes Karpathy's idea file names.

**Role tag:** `[C-Builder]`

| Check | Catches |
| --- | --- |
| Link integrity | any relative link in a wiki note that doesn't resolve |
| Orphan notes | a note no other wiki note links to (README/home exempt) |
| Reachability | notes disconnected from `home.md` (island clusters included) |
| Tunable drift | numbers with units (`10.5 V`, `250 ms`, `95 °C`, `60%`…) inside wiki notes — the #141 anti-drift rule ("constants live only in canonical docs") is now machine-enforced, not just written down |

Same discipline as #129: `scripts/check_wiki_selftest.py` builds violating + clean fixtures and **all 4 failure modes must fire** before the real lint counts; the `wiki-lint` workflow runs self-test → lint. Stdlib-only Python, identical locally and in CI.

Operation triad now complete: **ingest** (doc-changing PRs update affected notes, README rule) · **query** (reading/Obsidian graph) · **lint** (this PR).

Docs synced in-PR: wiki README (CI-enforcement note), CLAUDE.md gate list, DECISION-LOG entry recording the gist-verified pattern mapping.

## Test plan

- `python scripts/check_wiki_selftest.py` → OK, 4 failure modes demonstrated
- `python scripts/check_wiki.py` → OK against the real wiki (zero false positives from the tunable heuristic on all 19 notes)
- Docs + tooling only — zero firmware bytes; all existing CI must stay green; the new `wiki-lint` check appears on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated wiki lint checks to catch broken links, unreachable notes, orphan pages, and unexpected tunable-looking values.
  * Added a self-test that verifies the lint checks report expected issues and pass on clean content.
* **Bug Fixes**
  * Improved documentation quality controls so wiki issues are surfaced during CI.
* **Documentation**
  * Updated wiki guidance and project notes to reflect the new CI checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->