### PR TITLE
V7.34: generate web_page.h from dashboard source + CI drift check (#120)

### DIFF
--- a/.claude/rules/dashboard.md
+++ b/.claude/rules/dashboard.md
@@ -7,10 +7,11 @@ paths:
 
 # Dashboard Rules
 
-- **`dashboard/index.html` is the source; `web_page.h` is the mirror.** Any
-  change to one must land in the other in the same PR. (Until the generator
-  from issue #120 exists, the mirror is maintained by hand — after #120,
-  `web_page.h` moves to `src/generated/` and is never hand-edited.)
+- **`dashboard/index.html` is the single source of truth; `web_page.h` is
+  GENERATED** (#120) — never hand-edit it. After editing the source, run
+  `python scripts/generate_web_page.py` and commit both files; CI
+  (`dashboard-drift` job in structure-check) fails on any mismatch. The
+  generated file moves to `src/generated/` when the Phase D tree exists.
 - **Test UI changes locally before any flash**: run the Playwright harness
   (`tools/ui-test*.mjs`) with mock data and check the screenshots. Never make
   the operator tether to the machine to verify a UI change.

--- a/.github/workflows/structure-check.yml
+++ b/.github/workflows/structure-check.yml
@@ -88,3 +88,15 @@ jobs:
           else
             echo "OK: All structure checks passed"
           fi
+
+  dashboard-drift:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: web_page.h must match dashboard/index.html (#120)
+        run: python scripts/generate_web_page.py --check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,8 @@ Loop rate: ~20,000 Hz (non-blocking), micros()-based timing.
   embedded in flash (`web_page.h`, served at `/`) and streams telemetry over
   Server-Sent Events (`/events`) at ~5 Hz (`SSE_INTERVAL_MS = 200`); `/data` one-shot JSON kept for debug.
 - **Monitoring only — no control input over Wi-Fi, ever** (safety; permanent
-  decision). The dashboard mirror lives in `dashboard/index.html`.
+  decision). The dashboard source is `dashboard/index.html`; `web_page.h` is
+  generated from it (`python scripts/generate_web_page.py`, CI-enforced, #120).
 
 ## Audible Alerts — Implemented (V7.11–V7.12, active piezo on D8)
 
@@ -293,10 +294,10 @@ PROJECT-PLAN.md                          — Full technical specification
 OPERATOR-GUIDE.md                        — User guide for Jason (RC) and Malaki (joystick)
 sketches/rc_test/rc_test.ino             — Main Arduino sketch (V7.34 — GL10 FOC + telemetry + Wi-Fi + alarms + safety)
 sketches/rc_test/types.h                 — Shared structs (JoystickState, EscTelem, ...)
-sketches/rc_test/web_page.h              — Embedded Wi-Fi dashboard (PROGMEM), served at "/"
+sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit
 sketches/telem_check/telem_check.ino     — Read-only X.BUS telemetry bench tool (0x50 framing)
 sketches/sbus_d12_test/sbus_d12_test.ino — S.BUS-on-D12 bring-up test
-dashboard/index.html                     — Wi-Fi dashboard source (mirror of web_page.h)
+dashboard/index.html                     — Wi-Fi dashboard SOURCE (single source of truth; web_page.h generated from it, #120)
 docs/WIRING-GUIDE-V8.md                  — Canonical hardware wiring reference (UNO R4 WiFi)
 docs/INTERFACE-BOARD-PERFBOARD.md        — Soldered interface board build
 docs/GL10-Manual.pdf                     — XC-ESC official user manual (image-based, 3 pages)

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,25 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-08 — web_page.h generated from dashboard/index.html (#120)
+
+- **What:** `scripts/generate_web_page.py` wraps `dashboard/index.html`
+  verbatim (LF-normalized) into the PROGMEM raw-string in
+  `sketches/rc_test/web_page.h`, with a GENERATED header, a 100 KB page
+  budget gate (epic #81), and a raw-delimiter collision guard. `--check`
+  mode byte-compares; new `dashboard-drift` CI job (structure-check
+  workflow) fails any PR where the two files diverge.
+- **Drift found and resolved:** the hand-maintained mirror lacked three
+  JS comment blocks that had been added to the source (SoC curve, battery
+  colour bands, safety banner) in the same commits — proven comment-only by
+  byte-comparing comment-stripped payloads (identical). Regenerated
+  web_page.h picks them up: served bytes +~620 (42.1 KB total, well under
+  budget), ETag auto-updates, rendered dashboard and machine behavior
+  unchanged. Compile clean (44% flash), host suite green.
+- **Rule change:** web_page.h is never hand-edited again
+  (`.claude/rules/dashboard.md`); the manual "keep in sync" discipline is
+  retired in favor of the generator + CI check.
+
 ## 2026-07-07 — Wiki lint in CI (#145) — the Karpathy "lint" operation
 
 - **What:** `scripts/check_wiki.py` + self-test, run by the `wiki-lint`

--- a/scripts/generate_web_page.py
+++ b/scripts/generate_web_page.py
@@ -1,0 +1,68 @@
+"""Generate the embedded dashboard header from its source (#120).
+
+dashboard/index.html is the single source of truth; this script wraps it
+verbatim into sketches/rc_test/web_page.h as the PROGMEM raw-string literal
+the firmware serves at "/". Never edit web_page.h by hand.
+
+Usage:
+  python scripts/generate_web_page.py          # regenerate web_page.h
+  python scripts/generate_web_page.py --check  # exit 1 if web_page.h differs
+                                               # from what the source produces
+
+Newlines are normalized to LF so output is byte-identical on every platform
+(the CI drift check depends on that). The served page must stay within the
+100 KB budget (epic #81) — generation fails if the source exceeds it.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+PAGE_BUDGET_BYTES = 100 * 1024  # epic #81: served dashboard <= 100 KB
+RAW_DELIMITER = "DIGGER"
+
+HEADER = f"""\
+// GENERATED FILE — do not edit. Source: dashboard/index.html
+// Regenerate: python scripts/generate_web_page.py   (CI enforces sync, #120)
+const char INDEX_HTML[] PROGMEM = R"{RAW_DELIMITER}(
+"""
+TRAILER = f"){RAW_DELIMITER}\";\n"
+
+
+def generate(repo_root: Path) -> bytes:
+    source_path = repo_root / "dashboard" / "index.html"
+    page = source_path.read_bytes().replace(b"\r\n", b"\n")
+    if len(page) > PAGE_BUDGET_BYTES:
+        raise SystemExit(f"FAIL: {source_path} is {len(page)} bytes — over the "
+                         f"{PAGE_BUDGET_BYTES} byte page budget (epic #81)")
+    closer = f"){RAW_DELIMITER}".encode()
+    if closer in page:
+        raise SystemExit(f"FAIL: {source_path} contains {closer!r}, which "
+                         f"terminates the raw-string literal early")
+    if not page.endswith(b"\n"):
+        page += b"\n"
+    return HEADER.encode() + page + TRAILER.encode()
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    target = repo_root / "sketches" / "rc_test" / "web_page.h"
+    generated = generate(repo_root)
+    if "--check" in sys.argv:
+        current = target.read_bytes().replace(b"\r\n", b"\n")
+        if current != generated:
+            print(f"FAIL: {target} is out of sync with dashboard/index.html "
+                  f"— run: python scripts/generate_web_page.py")
+            return 1
+        print("web_page.h: in sync with dashboard/index.html")
+        return 0
+    target.write_bytes(generated)
+    print(f"wrote {target} ({len(generated)} bytes, "
+          f"page {len(generated) - len(HEADER) - len(TRAILER)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sketches/rc_test/web_page.h
+++ b/sketches/rc_test/web_page.h
@@ -1,3 +1,5 @@
+// GENERATED FILE — do not edit. Source: dashboard/index.html
+// Regenerate: python scripts/generate_web_page.py   (CI enforces sync, #120)
 const char INDEX_HTML[] PROGMEM = R"DIGGER(
 <!DOCTYPE html>
 <html lang="en">
@@ -452,6 +454,10 @@ let dOutL=1500, dOutR=1500;
 const SMOOTH=0.18;                       // ease factor per frame (higher = snappier)
 function ez(c,t){ return c + (t - c) * SMOOTH; }
 
+// 3S LiPo state-of-charge from pack voltage. The discharge curve is NON-linear
+// (flat mid-range, steep at the ends), so a straight line over-reads the middle.
+// Lookup table + linear interpolation; 0% anchored at the 10.0 V motor cutoff,
+// 100% at 12.6 V. (Resting curve; under load the pack reads a touch low.)
 function bp(v){
   const C=[[10.0,0],[10.3,10],[10.6,22],[10.8,30],[11.1,40],[11.4,50],[11.7,65],[12.0,80],[12.3,90],[12.6,100]];
   if(v<=C[0][0])return 0;
@@ -461,6 +467,8 @@ function bp(v){
   }
   return 100;
 }
+// Battery colour bands aligned to the firmware staging: green >30% (full power),
+// orange 20-30% (Eco-lock zone), red <=20% (beep/cutoff zone).
 function bc(p){return p>30?'linear-gradient(90deg,#0c6,#4f8)':p>20?'linear-gradient(90deg,#fa0,#fc0)':'linear-gradient(90deg,#f44,#f66)'}
 function ndl(id,val,max){const e=document.getElementById(id);
   if(e) e.setAttribute('transform',`rotate(${-135+Math.max(0,Math.min(val/max,1))*270},50,50)`);}
@@ -496,6 +504,9 @@ function showBanner(msg, kind){
   b.style.display = 'block';
 }
 function hideBanner(){const b=document.getElementById('errBanner'); if(b) b.style.display='none';}
+
+// Persistent low-battery safety banner (eco lock / hard cutoff), separate from
+// the connection errBanner so the two never overwrite each other.
 let _tcutPrev=false,_restoreUntil=0;
 function setSafetyBanner(d){
   let b=document.getElementById('safetyBanner');
@@ -729,5 +740,4 @@ fitStage(); setTimeout(fitStage, 200); setTimeout(fitStage, 600);
 </script>
 </body>
 </html>
-
 )DIGGER";


### PR DESCRIPTION
Closes #120

## Summary

The dashboard now has a **single source of truth**: `dashboard/index.html`. `sketches/rc_test/web_page.h` is generated from it and CI fails on any divergence — the manual "keep in sync" discipline is retired.

**Role tag:** `[C-Builder]`

| Piece | What it does |
| --- | --- |
| `scripts/generate_web_page.py` | Wraps the source verbatim (LF-normalized for platform-stable bytes) into the PROGMEM raw-string with a "GENERATED — do not edit" header. Enforces the epic #81 **100 KB page budget** and guards against a `)DIGGER` raw-delimiter collision. `--check` mode byte-compares for CI. |
| `dashboard-drift` CI job (structure-check workflow) | Runs `--check` on every PR — hand-edits to `web_page.h` or a forgotten regeneration fail the build. |
| Regenerated `web_page.h` | Resolves **existing drift found during this work**: three JS comment blocks (SoC curve, battery colour bands, safety-banner note) were in the source but had been hand-stripped from the mirror. |
| Docs | `.claude/rules/dashboard.md` (never hand-edit + the one-liner), CLAUDE.md (file map + Wi-Fi section), DECISION-LOG entry. |

## Behavior-preservation evidence (covenant)

This PR touches a firmware file, so the proof standard is explicit:

- **Comment-only payload change, proven mechanically**: comment-stripped old and new payloads are **byte-identical** (HTML/CSS/JS comments and blank lines removed → zero difference). No markup, styles, or logic changed.
- Rendered dashboard and machine behavior unchanged; served bytes +~620 (page 42.1 KB, well under the 100 KB budget); the FNV-1a **ETag auto-updates** — explicitly expected and accepted by #120's own acceptance criteria.
- `arduino-cli` compile clean (44% flash), host suite green **92/92**, commit made with `DIGGER_NO_TEST_CHANGE=1` (test-neutral firmware edit, per the gate's design).

## Test plan

- `python scripts/generate_web_page.py --check` → in sync (runs in CI as `dashboard-drift`)
- Deliberate hand-edit of `web_page.h` → `--check` fails (verified locally, reverted)
- All CI green including the new job
- Bench (hardware-gated, queued in BENCH-VERIFICATION-DEFERRED if needed): dashboard loads and renders identically after next flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated check to keep the dashboard page and generated web page output in sync.
  * Introduced a generation workflow for updating the dashboard’s embedded web content.

* **Documentation**
  * Clarified that the dashboard source page is the authoritative version and that the generated web page should not be edited manually.
  * Added notes about the new regeneration process and sync requirements.

* **Bug Fixes**
  * Regenerated the web page content to resolve drift and align the served UI with the latest dashboard content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->