### PR TITLE
V7.35: FIRMWARE_VERSION single source of truth + docs-drift audit (#124)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,8 +189,9 @@ lastGoodMs, valid }`. The `[TELEMETRY]` module polls it on Serial1 (D0/D1):
 ## Architecture Summary
 
 Sketch: `sketches/rc_test/rc_test.ino` (GL10 FOC + telemetry + Wi-Fi + alarms + battery/thermal safety) + `types.h` + `web_page.h`. The version
-string is defined ONCE — `FIRMWARE_VERSION` at the top of `[CONFIG]` (#124);
-no doc carries a copy.
+string is defined ONCE — `FIRMWARE_VERSION` at the top of `[CONFIG]` (#124).
+No doc carries a live copy; dated records (DECISION-LOG,
+FIRMWARE-UPLOAD-LOG) cite versions historically.
 
 Signal pipeline:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,8 +188,9 @@ lastGoodMs, valid }`. The `[TELEMETRY]` module polls it on Serial1 (D0/D1):
 
 ## Architecture Summary
 
-Sketch: `sketches/rc_test/rc_test.ino` (V7.35 — GL10 FOC + telemetry + Wi-Fi + alarms + battery/thermal safety) + `types.h` + `web_page.h`. The
-version string is defined ONCE: `FIRMWARE_VERSION` at the top of `[CONFIG]` (#124).
+Sketch: `sketches/rc_test/rc_test.ino` (GL10 FOC + telemetry + Wi-Fi + alarms + battery/thermal safety) + `types.h` + `web_page.h`. The version
+string is defined ONCE — `FIRMWARE_VERSION` at the top of `[CONFIG]` (#124);
+no doc carries a copy.
 
 Signal pipeline:
 
@@ -293,7 +294,7 @@ and the Arduino-side filter was double-smoothing the stream (operator felt
 ```text
 PROJECT-PLAN.md                          — Full technical specification
 OPERATOR-GUIDE.md                        — User guide for Jason (RC) and Malaki (joystick)
-sketches/rc_test/rc_test.ino             — Main Arduino sketch (V7.35 — GL10 FOC + telemetry + Wi-Fi + alarms + safety)
+sketches/rc_test/rc_test.ino             — Main Arduino sketch (version: FIRMWARE_VERSION in [CONFIG]; GL10 FOC + telemetry + Wi-Fi + alarms + safety)
 sketches/rc_test/types.h                 — Shared structs (JoystickState, EscTelem, ...)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit
 sketches/telem_check/telem_check.ino     — Read-only X.BUS telemetry bench tool (0x50 framing)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,8 @@ lastGoodMs, valid }`. The `[TELEMETRY]` module polls it on Serial1 (D0/D1):
 
 ## Architecture Summary
 
-Sketch: `sketches/rc_test/rc_test.ino` (V7.34 — GL10 FOC + telemetry + Wi-Fi + alarms + battery/thermal safety) + `types.h` + `web_page.h`
+Sketch: `sketches/rc_test/rc_test.ino` (V7.35 — GL10 FOC + telemetry + Wi-Fi + alarms + battery/thermal safety) + `types.h` + `web_page.h`. The
+version string is defined ONCE: `FIRMWARE_VERSION` at the top of `[CONFIG]` (#124).
 
 Signal pipeline:
 
@@ -292,7 +293,7 @@ and the Arduino-side filter was double-smoothing the stream (operator felt
 ```text
 PROJECT-PLAN.md                          — Full technical specification
 OPERATOR-GUIDE.md                        — User guide for Jason (RC) and Malaki (joystick)
-sketches/rc_test/rc_test.ino             — Main Arduino sketch (V7.34 — GL10 FOC + telemetry + Wi-Fi + alarms + safety)
+sketches/rc_test/rc_test.ino             — Main Arduino sketch (V7.35 — GL10 FOC + telemetry + Wi-Fi + alarms + safety)
 sketches/rc_test/types.h                 — Shared structs (JoystickState, EscTelem, ...)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit
 sketches/telem_check/telem_check.ino     — Read-only X.BUS telemetry bench tool (0x50 framing)
@@ -367,6 +368,10 @@ monitor.py                               — Simple serial monitor
 - Use `constrain()` at all servo output boundaries
 - Comment each `[MODULE]` section header with a brief description
 - Commit messages: `V{major}.{minor}: {imperative verb} {what changed}`
+- **README describes behavior, never tunable numbers** (#124): current values
+  live in `[CONFIG]`. PROJECT-PLAN and OPERATOR-GUIDE are technical
+  references — numbers are allowed there but must match `[CONFIG]` (drift is
+  a doc bug)
 
 ### ESC / motor configuration changes
 

--- a/PROJECT-PLAN.md
+++ b/PROJECT-PLAN.md
@@ -153,9 +153,10 @@ python live_plot.py
 
 ## Status
 
-> Current firmware version: `FIRMWARE_VERSION` in `rc_test.ino` `[CONFIG]`
-> (single source of truth, #124). Live feature status: CLAUDE.md
-> "Implementation Status". The list below is a historical snapshot.
+> Current firmware version: `FIRMWARE_VERSION` in
+> `sketches/rc_test/rc_test.ino` `[CONFIG]` (single source of truth, #124).
+> Live feature status: CLAUDE.md "Implementation Status". The list below is
+> a historical snapshot.
 
 ### Done
 

--- a/PROJECT-PLAN.md
+++ b/PROJECT-PLAN.md
@@ -151,7 +151,11 @@ python live_plot.py
 
 ---
 
-## Status (V7.14)
+## Status
+
+> Current firmware version: `FIRMWARE_VERSION` in `rc_test.ino` `[CONFIG]`
+> (single source of truth, #124). Live feature status: CLAUDE.md
+> "Implementation Status". The list below is a historical snapshot.
 
 ### Done
 
@@ -160,7 +164,7 @@ python live_plot.py
 - [x] curvatureDrive tank mixing + per-axis expo + pivot authority
 - [x] Removed Arduino-side inertia / PID (GL10 FOC owns smoothing)
 - [x] Gear caps (Eco 65% / Normal 80% / Boost 100%) capping average speed, outer-track turn headroom
-- [x] Eco reverse/pivot boost; ×1.05 joystick throttle gain
+- [x] Eco reverse/pivot boost; joystick throttle gain (retuned since — current value in `[CONFIG]`)
 - [x] Smooth pivot↔drive blend (wide 5–55% band) — no snap at low throttle (#72)
 - [x] Migrated Nano R4 → UNO R4 WiFi
 - [x] Soldered interface board (X.BUS merge + S.BUS inverter)
@@ -183,7 +187,7 @@ python live_plot.py
 
 ```text
 sketches/rc_test/
-  rc_test.ino       — Main controller sketch (V7.14 — GL10 FOC + telemetry + Wi-Fi + alarms)
+  rc_test.ino       — Main controller sketch (version: FIRMWARE_VERSION in [CONFIG])
   types.h           — Shared structs (JoystickState, EscTelem, ...)
   web_page.h        — Embedded Wi-Fi dashboard (PROGMEM), served at "/"
 sketches/telem_check/ — Read-only X.BUS telemetry bench tool (0x50 framing)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Wi-Fi dashboard you open on your phone.
   left/right track control; counter-rotating **pivot turn** on the spot at a standstill.
 - **Two drivers, one machine** — RC transmitter *and* a rider joystick, with a
   3-position override switch (RC-only / RC-priority / 50-50 blend).
-- **Gear caps** — Eco / Normal / Turbo wheel-speed limits selectable from the remote.
+- **Gear caps** — Eco / Normal / Boost wheel-speed limits selectable from the remote.
 - **Exponential response curves** — separate throttle and steering expo for fine,
   controllable low-speed handling.
 - **Instant failsafe** — loss of the RC signal holds both tracks at neutral.
@@ -53,7 +53,7 @@ PWM throttle (1000–2000 µs) per track on D9/D10. Full wiring lives in
 - **Trigger = throttle, wheel = steering** — the Arduino mixes these into the two
   tracks.
 - **3-position switch (CH5)** selects the override mode (below).
-- **Gear switch (CH4)** selects Eco / Normal / Turbo.
+- **Gear switch (CH4)** selects Eco / Normal / Boost.
 - Moving the controls takes priority over the joystick in RC-priority mode, so the
   supervisor can always step in.
 
@@ -68,11 +68,11 @@ The rider drives with a single dual-axis stick:
 | **Right** | Left track forward + right track back — turn right |
 | **Left** | Right track forward + left track back — turn left |
 | **Diagonal** | Blends forward/back with turning (curvature drive) |
-| **Right/left at a standstill** | **Pivot turn** — tracks counter-rotate on the spot (capped at 60%) |
+| **Right/left at a standstill** | **Pivot turn** — tracks counter-rotate on the spot (speed-capped, with extra authority in Eco) |
 
 A deadband around center keeps the machine still when the stick is released, and
 an expo curve makes small movements gentle for precise maneuvering. The
-joystick throttle also carries a slight boost (×1.05) so it doesn't feel weaker
+joystick throttle also carries a configured gain so it doesn't feel weaker
 than the RC throttle — full deflection still tops out at the active gear cap.
 
 ### Override modes (3-position switch)
@@ -90,14 +90,16 @@ In a turn, Eco and Normal let the *outer* track climb into the headroom up to th
 ESC rail, so the machine **holds its speed through corners** instead of bogging
 down. Boost is already at the rail, so it has no extra turn headroom.
 
-| Gear | Straight-line cap | Use |
+| Gear | Straight-line speed | Use |
 | --- | --- | --- |
-| **Eco** | 65% | Training / tight spaces (~35% turn headroom; reverse & pivot get extra authority) |
-| **Normal** | 80% | Everyday driving (~20% turn headroom) |
-| **Boost** | 100% | Full authority (at the rail — no turn headroom) |
+| **Eco** | Slowest | Training / tight spaces (largest turn headroom; reverse & pivot get extra authority) |
+| **Normal** | Medium | Everyday driving |
+| **Boost** | Fastest | Full authority (at the rail — no turn headroom) |
 
-Reverse is capped to 50% of forward stick travel (62.5% in Eco), and pivoting in
-place is capped at 60% (72.5% in Eco) — all gear-scaled.
+Reverse is additionally capped below forward speed per gear, and pivot rotation
+has its own speed cap. The exact percentages are tunables — see the current
+values in `[CONFIG]` (`sketches/rc_test/rc_test.ino`) and the operator-facing
+table in [OPERATOR-GUIDE.md](OPERATOR-GUIDE.md).
 
 ---
 

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,25 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-08 — V7.35: FIRMWARE_VERSION single source of truth + docs-drift audit (#124)
+
+- **Code:** `const char FIRMWARE_VERSION[] = "V7.35"` at the top of
+  `[CONFIG]` — the only place the version is defined. `debugInit()` banner
+  reduced from a 300-char changelog string to version + short tag
+  (changelog belongs to git + FIRMWARE-UPLOAD-LOG). Authorized by #124.
+  Dashboard version display: deferred (nice-to-have; would touch the SSE
+  frame budget + dashboard UI test cycle — its own change when wanted).
+- **Docs drift fixed (audited against [CONFIG]):** README "Turbo"→Boost
+  (twice); "×1.05" joystick boost claim was wrong (JOY_THROTTLE_GAIN is a
+  different value — README now describes behavior without the number);
+  stale reverse-cap percentages (pre-#113 50%/62.5%) removed; gear table
+  de-numbered. PROJECT-PLAN stale "Status (V7.14)" header + file-map
+  version replaced with pointers to the SSOT.
+- **New rule (CLAUDE.md Style):** user-facing docs (README, PROJECT-PLAN)
+  describe behavior, never tunable numbers — numbers live only in [CONFIG]
+  and OPERATOR-GUIDE (the tuning reference). OPERATOR-GUIDE table audited:
+  already correct (65/80/100, 55/55/65, 72.5/60/60).
+
 ## 2026-07-08 — web_page.h generated from dashboard/index.html (#120)
 
 - **What:** `scripts/generate_web_page.py` wraps `dashboard/index.html`

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -19,10 +19,11 @@ Updated by session hooks — only technical content, no personal info.
   stale reverse-cap percentages (pre-#113 50%/62.5%) removed; gear table
   de-numbered. PROJECT-PLAN stale "Status (V7.14)" header + file-map
   version replaced with pointers to the SSOT.
-- **New rule (CLAUDE.md Style):** user-facing docs (README, PROJECT-PLAN)
-  describe behavior, never tunable numbers — numbers live only in [CONFIG]
-  and OPERATOR-GUIDE (the tuning reference). OPERATOR-GUIDE table audited:
-  already correct (65/80/100, 55/55/65, 72.5/60/60).
+- **New rule (CLAUDE.md Style):** README describes behavior, never tunable
+  numbers — current values live in [CONFIG]. PROJECT-PLAN and OPERATOR-GUIDE
+  are technical references: numbers allowed there but must match [CONFIG]
+  (drift is a doc bug). OPERATOR-GUIDE table audited: already correct
+  (65/80/100, 55/55/65, 72.5/60/60).
 
 ## 2026-07-08 — web_page.h generated from dashboard/index.html (#120)
 

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -14,6 +14,7 @@ Exit code 1 on any failure; warnings never fail the build.
 """
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -21,7 +22,10 @@ sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 sys.path.insert(0, str(Path(__file__).parent))
 import architecture_rules as rules  # noqa: E402
 
-VERSION_DEFINITION = "#define FIRMWARE_VERSION"
+# Both definition forms count: the pre-#124 macro and the current const char.
+VERSION_DEFINITION_PATTERN = re.compile(
+    r"^\s*(?:#\s*define\s+FIRMWARE_VERSION\b|const\s+char\s+FIRMWARE_VERSION\s*\[)",
+    re.M)
 
 
 def load_allowlist(repo_root: Path) -> tuple[dict[str, str], list[str]]:
@@ -62,7 +66,7 @@ def check_repo(repo_root: Path) -> tuple[list[str], list[str], list[str]]:
         for source in sketch_dir.rglob("*"):
             if source.suffix in rules.SOURCE_SUFFIXES and source.is_file():
                 text = source.read_text(encoding="utf-8", errors="replace")
-                if VERSION_DEFINITION in text:
+                if VERSION_DEFINITION_PATTERN.search(text):
                     version_definitions.append(
                         source.relative_to(repo_root).as_posix())
 

--- a/scripts/check_architecture_selftest.py
+++ b/scripts/check_architecture_selftest.py
@@ -21,7 +21,7 @@ EXPECTED_VIOLATIONS = {
     "banned file name": "src/domain/TrackUtils.h",
     "exceeds hard limit": "251-line file, not allowlisted",
     "mutable namespace-scope state": "int currentGear = 0; in domain/",
-    "more than one file": "FIRMWARE_VERSION defined twice",
+    "more than one file": "FIRMWARE_VERSION defined twice (#define + const char forms)",
     ".ino may only include application/": "sketch.ino includes domain/ directly",
     "entry needs 'path | reason'": "allowlist entry missing reason",
     "duplicate entry": "same allowlist path twice (one with backslashes)",
@@ -49,7 +49,7 @@ def build_violating_repo(root: Path) -> None:
           "namespace gear {\nint currentGear = 0;\n"
           "constexpr float kMax = 1.0f;\n}\n"
           "namespace gear_brace_next_line\n{\nint slippedThrough = 1;\n}\n"
-          "#define FIRMWARE_VERSION \"2\"\n")
+          "const char FIRMWARE_VERSION[] = \"2\";\n")
     write(src / "infrastructure" / "EscPwm.h",
           '#include "../domain/Speed.h"\n')
     write(src / "telemetry" / "JsonEncoder.h",

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -77,6 +77,10 @@ UART sbusUart(PIN_SBUS_TX, PIN_SBUS_RX);
 // [CONFIG] — All tunable constants
 // ═══════════════════════════════════════════════════════════════
 
+// Firmware version — SINGLE SOURCE OF TRUTH (#124). The debug banner prints
+// it; docs and FIRMWARE-UPLOAD-LOG reference it. Bump here, nowhere else.
+const char FIRMWARE_VERSION[] = "V7.35";
+
 // Pins
 const uint8_t PIN_JOY_Y  = A0;  // Throttle
 const uint8_t PIN_JOY_X  = A1;  // Steering
@@ -1459,7 +1463,11 @@ void debugInit() {
   Serial.begin(115200);
   delay(50);
   if (Serial) {
-    Serial.println("# === Digger V7.34 — GL10 FOC + S.BUS + Gear + X.BUS telem + Wi-Fi AP + beeper/alarms + battery & motor-thermal protection + per-gear reverse cap (55% Eco/Normal, 65% Boost) + loop watchdog ===");
+    // Version + short tag only (#124) — the changelog lives in git history
+    // and docs/FIRMWARE-UPLOAD-LOG.md, not in a string constant.
+    Serial.print("# === Digger ");
+    Serial.print(FIRMWARE_VERSION);
+    Serial.println(" — dual-input track control, GL10 FOC ===");
     Serial.println("# CSV: RCThr,RCStr,RC4,RC5,JoyY,JoyX,OutL,OutR,Gear,FS,Lost,V0dV,I0dA,RPM0,TE0,TM0,OK0,V1dV,I1dA,RPM1,TE1,TM1,OK1");
   }
 }


### PR DESCRIPTION
Closes #124

## Summary

The firmware version now has a **single source of truth**, and the README/PROJECT-PLAN drift the issue documented is fixed.

**Role tag:** `[C-Builder]`

**Code (V7.35):**
- `const char FIRMWARE_VERSION[] = "V7.35"` at the top of `[CONFIG]` — the only definition. Bump here, nowhere else.
- `debugInit()` banner is now `version + short tag` instead of a 300-char changelog-in-a-string (changelog belongs to git history + FIRMWARE-UPLOAD-LOG). **This observable banner change is explicitly authorized by #124's own proposal** — no other behavior is touched (banner is debug-serial only, not asserted by any test).
- Dashboard version display: **deferred** (issue marks it nice-to-have; it would touch the SSE frame budget and require the dashboard UI-test cycle — a clean standalone change if wanted later).

**Docs audit (against current `[CONFIG]`):**
- README: `Turbo`→`Boost` (×2); the **wrong** "×1.05" joystick-gain claim (actual `JOY_THROTTLE_GAIN` differs) and **stale pre-#113 reverse-cap numbers** (50%/62.5%) replaced with behavior descriptions + pointers to `[CONFIG]`/OPERATOR-GUIDE
- PROJECT-PLAN: stale "Status (V7.14)" header and file-map version replaced with SSOT pointers; stale historical ×1.05 line de-numbered
- OPERATOR-GUIDE: audited — its tuning table already matches code exactly (no changes)
- New CLAUDE.md rule: **README describes behavior, never tunable numbers**; PROJECT-PLAN/OPERATOR-GUIDE are technical references where numbers are allowed but must match `[CONFIG]`

## Test plan

- `arduino-cli` compile clean (44% flash)
- Host suite green **92/92** (no expectations touched; banner unasserted — commit via `DIGGER_NO_TEST_CHANGE=1` per the gate's design for test-neutral edits)
- All CI green
- Bench note: first flash after merge shows the new one-line banner — FIRMWARE-UPLOAD-LOG row will record V7.35

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the startup/debug banner and documentation to reflect the current firmware version consistently.

* **Documentation**
  * Renamed **Turbo** to **Boost** throughout operator guidance.
  * Revised joystick/gear-cap explanations to remove outdated hardcoded percentages and numeric boost claims, replacing them with descriptions that reference current configuration values.
  * Added documentation guidance to prevent future version/tuning drift across files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->