### PR TITLE
ci: defer composition-root .ino rule to the step-11 marker (#150)

### DIFF
--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,17 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-09 — Composition-root .ino rule deferred to a step-11 marker (#150)
+
+- `check_ino` (`.ino` → `application/` only) fired the moment `src/` exists,
+  which would have turned architecture-fitness red for the entire Phase D
+  migration (steps 1–10: the `.ino` is the interim application shell and must
+  include extracted `domain/` headers plus its existing external headers).
+- Fix: the rule activates only when `src/application/FirmwareApp.h` exists —
+  the exact artifact of migration step 11 ("there IS a composition root").
+  Until then the checker emits a NOTE; extracted `src/` files are fully
+  checked from step 1 regardless. Selftest covers both directions.
+
 ## 2026-07-09 — Wi-Fi credentials out of source: arduino_secrets.h pattern (#125)
 
 - `WIFI_SSID`/`WIFI_PASS` now initialize from `SECRET_WIFI_SSID`/

--- a/docs/architecture/ARCHITECTURE-TARGET.md
+++ b/docs/architecture/ARCHITECTURE-TARGET.md
@@ -269,6 +269,12 @@ The check is **advisory** (not in branch protection) until the Phase D
 extraction lands, then flipped to required. Section 3's table is canonical —
 a rule change here must change the script in the same PR.
 
+**Migration window (#150):** the composition-root rule (`.ino` →
+`application/` only) activates once `src/application/FirmwareApp.h` exists —
+the step-11 marker. During steps 1–10 the production `.ino` is the interim
+application shell and may include extracted layers directly (the checker
+emits a NOTE instead); extracted `src/` files are fully checked from step 1.
+
 ## 11. Testing strategy (summary — details in #47/#131)
 
 | Level | What | Where |

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -74,8 +74,18 @@ def check_repo(repo_root: Path) -> tuple[list[str], list[str], list[str]]:
         if not src_root.is_dir():
             continue  # bench sketch / pre-Phase-D production sketch: exempt
 
-        for ino in sketch_dir.glob("*.ino"):
-            failures += rules.check_ino(ino, src_root)
+        # The composition-root rule (.ino -> application/ only) is a property
+        # of the END state: it activates once FirmwareApp.h exists (#117 step
+        # 11). During migration steps 1-10 the .ino is the interim application
+        # shell and may include extracted layers directly (#150); the src/
+        # files themselves are fully checked from step 1 either way.
+        if (src_root / "application" / "FirmwareApp.h").is_file():
+            for ino in sketch_dir.glob("*.ino"):
+                failures += rules.check_ino(ino, src_root)
+        else:
+            notes.append(f"{sketch_dir.name}: no src/application/FirmwareApp.h"
+                         " yet — composition-root .ino rule activates at Phase"
+                         " D step 11 (#150)")
         for file in sorted(src_root.rglob("*")):
             if not (file.is_file() and file.suffix in rules.SOURCE_SUFFIXES):
                 continue

--- a/scripts/check_architecture_selftest.py
+++ b/scripts/check_architecture_selftest.py
@@ -22,7 +22,8 @@ EXPECTED_VIOLATIONS = {
     "exceeds hard limit": "251-line file, not allowlisted",
     "mutable namespace-scope state": "int currentGear = 0; in domain/",
     "more than one file": "FIRMWARE_VERSION defined twice (#define + const char forms)",
-    ".ino may only include application/": "sketch.ino includes domain/ directly",
+    ".ino may only include application/": "sketch.ino includes domain/ "
+                                          "directly (FirmwareApp.h exists)",
     "entry needs 'path | reason'": "allowlist entry missing reason",
     "duplicate entry": "same allowlist path twice (one with backslashes)",
     "GearPolicy.cpp:5:": "line number correct after a multi-line block comment",
@@ -56,6 +57,8 @@ def build_violating_repo(root: Path) -> None:
           '#include "../application/ControlCycle.h"\n')
     write(src / "application" / "ControlCycle.h", "// fine\n")
     write(src / "application" / "SystemSnapshot.h", "// fine\n")
+    # Composition root exists -> the .ino include rule is active (#150).
+    write(src / "application" / "FirmwareApp.h", "// composition root\n")
     write(src / "domain" / "Oversize.h", "// line\n" * 251)
     write(root / ".architecture-allowlist",
           "missing/reason.h\n"
@@ -88,6 +91,20 @@ def build_clean_repo(root: Path) -> None:
           "sketches/fixture/src/domain/Allowlisted.h | self-test fixture\n")
 
 
+def build_migration_repo(root: Path) -> None:
+    """Phase D steps 1-10 (#150): src/ populated, no FirmwareApp.h yet. The
+    .ino is the interim application shell — its direct domain/ and external
+    includes must NOT fail; src/ files stay fully checked."""
+    src = root / "sketches" / "fixture" / "src"
+    write(root / "sketches" / "fixture" / "fixture.ino",
+          "#include <Servo.h>\n"
+          '#include "types.h"\n'
+          '#include "src/domain/CurvatureDrive.h"\n')
+    write(root / "sketches" / "fixture" / "types.h", "// sketch-local\n")
+    write(src / "domain" / "CurvatureDrive.h",
+          "constexpr float kPivotCap = 0.6f;\n")
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory() as raw:
         root = Path(raw)
@@ -113,8 +130,23 @@ def main() -> int:
             print("\n".join(failures))
             return 1
 
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        build_migration_repo(root)
+        failures, _, notes = check_repo(root)
+        if failures:
+            print("FAIL: self-test: migration-window fixture (no "
+                  "FirmwareApp.h) should pass, got:")
+            print("\n".join(failures))
+            return 1
+        if not any("FirmwareApp.h" in note for note in notes):
+            print("FAIL: self-test: migration-window fixture should NOTE the "
+                  "deferred composition-root rule")
+            return 1
+
     print(f"architecture-fitness self-test: OK "
-          f"({len(EXPECTED_VIOLATIONS)} failure modes demonstrated)")
+          f"({len(EXPECTED_VIOLATIONS)} failure modes demonstrated, "
+          f"migration window exempt)")
     return 0
 
 


### PR DESCRIPTION
Closes #150

## Summary

`check_ino` enforces the end-state contract (`.ino` may include `application/` only) but activated as soon as `sketches/<name>/src/` exists — which would turn `architecture-fitness` red on the very first #117 extraction PR and keep it red for the whole migration (the `.ino` is the interim application shell during steps 1–10, and every one of its existing external includes — `Servo.h`, `types.h`, `web_page.h`, … — also gets flagged as unresolvable inside `src/`).

- The rule now activates only when `src/application/FirmwareApp.h` exists — the exact artifact of migration step 11 ('there IS a composition root'). Until then the checker emits a NOTE instead of failures.
- Extracted `src/` files remain fully checked from step 1 — only the `.ino` rule is deferred.
- Selftest: violating fixture gains `FirmwareApp.h` (proves the failure mode still fires when active); new migration-window fixture (no `FirmwareApp.h`, `.ino` → `domain/` + external includes) must produce zero failures and the deferred-rule NOTE.
- `ARCHITECTURE-TARGET.md` §10 documents the activation rule (script + doc change in the same PR, per §10).

No firmware files touched. Unblocks #151 (Phase D step 1).

## Role tag

`[C-Builder]`

## Test plan

- [x] `python scripts/check_architecture_selftest.py` → OK, 13 failure modes demonstrated + migration window exempt
- [x] `python scripts/check_architecture.py` → OK on the real repo (still dormant — no `src/` tree yet)
- [x] No sketch/tests change → host suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated architecture validation so composition-root checks activate at the appropriate migration milestone.
  - Preserved validation of extracted source files throughout the migration period.
  - Added clear guidance when the composition-root check is deferred.

- **Documentation**
  - Documented the migration window, activation criteria, and interim application structure.

- **Tests**
  - Expanded self-tests to cover both deferred and active validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->