### PR TITLE
V7.35: extract VoltagePlausibility to src/domain/battery/ (#151, Phase D step 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,7 @@ PROJECT-PLAN.md                          — Full technical specification
 OPERATOR-GUIDE.md                        — User guide for Jason (RC) and Malaki (joystick)
 sketches/rc_test/rc_test.ino             — Main Arduino sketch (version: FIRMWARE_VERSION in [CONFIG]; GL10 FOC + telemetry + Wi-Fi + alarms + safety)
 sketches/rc_test/types.h                 — Shared structs (JoystickState, EscTelem, ...)
+sketches/rc_test/src/domain/battery/     — First extracted domain (#117): BatteryTypes.h + VoltagePlausibility.h/.cpp (pure logic, host-testable)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit
 sketches/telem_check/telem_check.ino     — Read-only X.BUS telemetry bench tool (0x50 framing)
@@ -315,7 +316,7 @@ docs/TESTING.md                          — Host characterization + invariants 
 docs/SAFETY.md                           — Safety-invariant registry: propulsion-path invariants + test links (#131)
 docs/AGENT-EXAMPLES.md                   — Good/bad task-execution pairs for AI agents (#53, real precedents)
 docs/wiki/                               — AI-maintained knowledge graph (Obsidian-visualizable, links-only — no constants; #141)
-tests/                                   — Host test harness: stub Arduino env + doctest suites (characterization/ + invariants/)
+tests/                                   — Host test harness: stub Arduino env + doctest suites (characterization/ + invariants/ + per-domain, e.g. battery/)
 .githooks/pre-commit                     — Commit-time test gate (activate: git config core.hooksPath .githooks)
 live_plot.py                             — Real-time matplotlib monitor
 monitor.py                               — Simple serial monitor

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,26 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-09 — Phase D step 1: VoltagePlausibility extracted to src/domain/battery/ (#151)
+
+- First #117 extraction: `worstPackVoltage`'s logic moved VERBATIM to
+  `src/domain/battery/VoltagePlausibility.h/.cpp` (+ `BatteryTypes.h` with
+  `BatteryReading{voltage, valid}`). Plausibility bounds are parameters —
+  the domain function has no config/global dependency. The sketch keeps
+  `worstPackVoltage()` as a one-line delegate, so both ladder call sites and
+  all existing test references are unchanged.
+- The [ALERT] inline plausibility check stays put: its `&&`-form REJECTS NaN
+  while the extracted `||`-form PASSES it (locked #131 FINDING) — the target
+  architecture's "ONE implementation" consolidation is a behavior change
+  requiring the NaN-gap issue first.
+- Harness: test binaries now also compile `sketches/rc_test/src/**/*.cpp`;
+  new pure-domain suite dir `tests/battery/` (no stubs, no firmware);
+  duplicate-basename guard generalized across all suite dirs.
+- Verified: full host suite green before/after with zero expectation changes;
+  compile clean — flash 116296 bytes (+48 vs 116248: extracted function is a
+  cross-TU call now), RAM unchanged 9812. No bench check applicable (pure
+  move). architecture-fitness runs its first real src/ tree: OK.
+
 ## 2026-07-09 — Composition-root .ino rule deferred to a step-11 marker (#150)
 
 - `check_ino` (`.ino` → `application/` only) fired the moment `src/` exists,

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -9,8 +9,12 @@ them green, proving behavior parity while no hardware is available.
 
 ## How it works — zero firmware changes
 
-The production sketch is not modified, extracted, or shimmed. Each test binary
-compiles `sketches/rc_test/rc_test.ino` directly:
+The production sketch is not modified for testing. Each test binary compiles
+`sketches/rc_test/rc_test.ino` directly, plus the extracted
+`sketches/rc_test/src/**/*.cpp` domain sources the sketch delegates to as the
+Phase D migration (#117) proceeds. Pure-domain suites (one dir per extracted
+domain, e.g. `battery/`) test the extracted code directly — no firmware, no
+stubs:
 
 ```text
 tests/
@@ -27,9 +31,11 @@ tests/
 ├── characterization/
 │   ├── FirmwareUnderTest.h     includes the REAL rc_test.ino + firmware state reset
 │   └── test_*.cpp              one focused suite per behavior area
-└── invariants/
-    ├── InvariantChecks.h       reusable safety-invariant checkers + loop driver (#131)
-    └── test_invariant_*.cpp    one property suite per safety invariant
+├── invariants/
+│   ├── InvariantChecks.h       reusable safety-invariant checkers + loop driver (#131)
+│   └── test_invariant_*.cpp    one property suite per safety invariant
+└── battery/                    pure-domain suite for src/domain/battery/ (#117 step 1)
+    └── test_voltage_plausibility.cpp
 ```
 
 The stub headers shadow the real Arduino/library headers via include order

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -12,7 +12,12 @@ drive exactly as before.
 - **Founding ADR** —
   [0001-domain-oriented-firmware-architecture](../architecture/adr/0001-domain-oriented-firmware-architecture.md)
 - **Phases** — A Define → B Protect ([testing](testing.md) suites, done) →
-  C Govern (CI fitness functions) → D Refactor (extract domains) → E Polish
+  C Govern (CI fitness functions, done) → D Refactor (extract domains,
+  **active**) → E Polish
+- **First extracted domain** — the [battery ladder](battery-ladder.md)'s
+  voltage-plausibility gate lives in `src/domain/battery/` (pure logic, no
+  Arduino includes, host-tested directly); the sketch keeps a thin delegate
+  until the composition root lands
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/docs/wiki/battery-ladder.md
+++ b/docs/wiki/battery-ladder.md
@@ -15,7 +15,10 @@ chirping through the cut, so a cutoff is never silent.
 - Voltage arrives via [X.BUS telemetry](xbus-telemetry.md); implausible
   readings are rejected by plausibility gates, and telemetry dropout
   deliberately freezes the ladder ([SAFETY](../SAFETY.md) "Known gaps"
-  documents the edge cases)
+  documents the edge cases). The worst-of-two plausibility gate is the first
+  extracted domain of the
+  [architecture remediation](architecture-remediation.md)
+  (`src/domain/battery/`)
 - Operator-facing behavior and what the beeps mean:
   [OPERATOR-GUIDE](../../OPERATOR-GUIDE.md)
 

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -61,6 +61,11 @@
 #include "types.h"
 #include "web_page.h"   // const char INDEX_HTML[] — the dashboard, served at "/"
 
+// Phase D extraction (#117): pure domain logic lives under src/domain/ and is
+// included here directly until the FirmwareApp composition root lands
+// (migration window, #150).
+#include "src/domain/battery/VoltagePlausibility.h"
+
 
 // Second hardware UART on D11=TX(pin 11) / D12=RX(pin 12) via SCI0.
 // S.BUS only needs RX; TX is unused. Named `sbusUart` (not Serial2)
@@ -1001,13 +1006,13 @@ uint32_t ecoLockStartMs = 0;
 
 // Worst-of-two pack voltage if BOTH packs read a plausible value; else false
 // (a not-yet-powered pack reads ~0 V and must not trip anything).
+// Logic extracted to src/domain/battery/VoltagePlausibility.* (#117 step 1);
+// this delegate keeps both ladder call sites and the test surface unchanged.
 bool worstPackVoltage(float* worst) {
-  float v0 = telem[0].voltage, v1 = telem[1].voltage;
-  if (!(telem[0].valid && telem[1].valid)) return false;
-  if (v0 < LOWV_PLAUS_MIN_V || v0 > LOWV_PLAUS_MAX_V ||
-      v1 < LOWV_PLAUS_MIN_V || v1 > LOWV_PLAUS_MAX_V) return false;
-  *worst = (v0 < v1) ? v0 : v1;
-  return true;
+  return worstPlausiblePackVoltage(
+      BatteryReading{telem[0].voltage, telem[0].valid},
+      BatteryReading{telem[1].voltage, telem[1].valid},
+      LOWV_PLAUS_MIN_V, LOWV_PLAUS_MAX_V, worst);
 }
 
 void batteryEcoLockUpdate() {        // Stage 1 — force Eco

--- a/sketches/rc_test/src/domain/battery/BatteryTypes.h
+++ b/sketches/rc_test/src/domain/battery/BatteryTypes.h
@@ -1,0 +1,11 @@
+// domain/battery — shared value types (#117 step 1).
+// Pure domain: no Arduino includes (host-compilable by design).
+#pragma once
+
+// One ESC's report of its pack voltage, as delivered by X.BUS telemetry.
+// `valid` mirrors EscTelem.valid — the freshness watchdog's verdict, NOT a
+// plausibility judgement (that is VoltagePlausibility's job).
+struct BatteryReading {
+  float voltage;  // volts (EMA-smoothed upstream)
+  bool valid;     // telemetry fresh within the per-ESC watchdog window
+};

--- a/sketches/rc_test/src/domain/battery/VoltagePlausibility.cpp
+++ b/sketches/rc_test/src/domain/battery/VoltagePlausibility.cpp
@@ -1,0 +1,17 @@
+// domain/battery — worst-of-two pack-voltage plausibility gate (#117 step 1).
+// Logic copied VERBATIM from rc_test.ino [SAFETY] worstPackVoltage();
+// behavior is locked by tests/invariants/test_invariant_plausibility.cpp and
+// tests/characterization/test_battery_ladder.cpp.
+#include "VoltagePlausibility.h"
+
+bool worstPlausiblePackVoltage(const BatteryReading& pack0,
+                               const BatteryReading& pack1,
+                               float plausibleMinV, float plausibleMaxV,
+                               float* worstOut) {
+  float v0 = pack0.voltage, v1 = pack1.voltage;
+  if (!(pack0.valid && pack1.valid)) return false;
+  if (v0 < plausibleMinV || v0 > plausibleMaxV ||
+      v1 < plausibleMinV || v1 > plausibleMaxV) return false;
+  *worstOut = (v0 < v1) ? v0 : v1;
+  return true;
+}

--- a/sketches/rc_test/src/domain/battery/VoltagePlausibility.h
+++ b/sketches/rc_test/src/domain/battery/VoltagePlausibility.h
@@ -1,0 +1,20 @@
+// domain/battery — worst-of-two pack-voltage plausibility gate (#117 step 1).
+// Extracted VERBATIM from rc_test.ino [SAFETY] worstPackVoltage() — the
+// battery ladder's single trusted voltage source. Pure domain: no Arduino
+// includes; bounds arrive as parameters (state-ownership rule: dependencies
+// are visible in the signature).
+#pragma once
+
+#include "BatteryTypes.h"
+
+// Worst-of-two pack voltage if BOTH packs read a plausible value; else false
+// (a not-yet-powered pack reads ~0 V and must not trip anything).
+//
+// KNOWN GAP (#131 FINDING, locked as current behavior): a NaN voltage passes
+// the [min,max] band (both comparisons are false) and the ternary min-select
+// is slot-asymmetric under NaN. Do NOT "fix" here — that is a behavior
+// change needing its own issue + operator sign-off.
+bool worstPlausiblePackVoltage(const BatteryReading& pack0,
+                               const BatteryReading& pack1,
+                               float plausibleMinV, float plausibleMaxV,
+                               float* worstOut);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,19 +1,21 @@
 # Host test suites: characterization (#47) + safety invariants (#131) +
 # pure-domain suites (one dir per extracted domain, #117 — e.g. battery/).
 # One binary per test file — characterization/invariants compile the REAL
-# rc_test.ino inside the stub Arduino environment (see stubs/); domain suites
-# compile only the extracted src/ code (no Arduino, no stubs needed — but
-# -Istubs stays first so any transitively-included core header resolves to
-# the fakes).
+# rc_test.ino inside the stub Arduino environment (see stubs/); pure-domain
+# suites compile only the extracted src/ code WITHOUT -Istubs, so an
+# accidental Arduino include in domain code fails the build loudly instead
+# of silently resolving to a fake.
 #   make -C tests run    build + run everything (CI + pre-commit gate)
 #   make -C tests        build only
-# -Istubs must come first so <Arduino.h> etc. resolve to the fakes.
+# -Istubs must come first (firmware-based suites only) so <Arduino.h> etc.
+# resolve to the fakes.
 # Binaries land flat in build/, so file basenames must be unique across suite
 # directories (invariants files carry a test_invariant_ prefix).
 
 CXX      ?= g++
 CXXFLAGS ?= -std=gnu++17 -g -O0 -Wall
 INCLUDES := -Istubs -Ivendor/doctest
+DOMAIN_INCLUDES := -Ivendor/doctest
 
 # Phase D (#117): extracted sketch sources are linked into every test binary —
 # the firmware delegates to them, and domain suites test them directly.
@@ -55,7 +57,7 @@ build/%: invariants/%.cpp $(HARNESS) $(FIRMWARE)
 
 build/%: battery/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
-	$(CXX) $(CXXFLAGS) $(INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 
 run: all
 	@status=0; \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,10 @@
-# Host test suites: characterization (#47) + safety invariants (#131). One
-# binary per test file — each compiles the REAL rc_test.ino inside the stub
-# Arduino environment (see stubs/).
+# Host test suites: characterization (#47) + safety invariants (#131) +
+# pure-domain suites (one dir per extracted domain, #117 — e.g. battery/).
+# One binary per test file — characterization/invariants compile the REAL
+# rc_test.ino inside the stub Arduino environment (see stubs/); domain suites
+# compile only the extracted src/ code (no Arduino, no stubs needed — but
+# -Istubs stays first so any transitively-included core header resolves to
+# the fakes).
 #   make -C tests run    build + run everything (CI + pre-commit gate)
 #   make -C tests        build only
 # -Istubs must come first so <Arduino.h> etc. resolve to the fakes.
@@ -11,21 +15,31 @@ CXX      ?= g++
 CXXFLAGS ?= -std=gnu++17 -g -O0 -Wall
 INCLUDES := -Istubs -Ivendor/doctest
 
+# Phase D (#117): extracted sketch sources are linked into every test binary —
+# the firmware delegates to them, and domain suites test them directly.
+SKETCH_SRC_CPPS    := $(shell find ../sketches/rc_test/src -name '*.cpp' 2>/dev/null)
+SKETCH_SRC_HEADERS := $(shell find ../sketches/rc_test/src -name '*.h' 2>/dev/null)
+
 FIRMWARE := ../sketches/rc_test/rc_test.ino \
             ../sketches/rc_test/types.h \
-            ../sketches/rc_test/web_page.h
+            ../sketches/rc_test/web_page.h \
+            $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 HARNESS  := $(wildcard stubs/*.h) characterization/FirmwareUnderTest.h \
             $(wildcard invariants/*.h)
 
-TESTS := $(wildcard characterization/test_*.cpp) $(wildcard invariants/test_*.cpp)
+TESTS := $(wildcard characterization/test_*.cpp) \
+         $(wildcard invariants/test_*.cpp) \
+         $(wildcard battery/test_*.cpp)
 BINS  := $(addprefix build/,$(notdir $(TESTS:.cpp=)))
 
 # A duplicate basename across suite directories would silently shadow one
 # binary (flat build/ + same-target pattern rules) while CI stayed green —
-# fail the build loudly instead.
-DUPLICATE_BASENAMES := $(filter $(notdir $(wildcard characterization/test_*.cpp)),\
-                                $(notdir $(wildcard invariants/test_*.cpp)))
-ifneq ($(DUPLICATE_BASENAMES),)
+# fail the build loudly instead. Checked across ALL suite dirs pairwise:
+# $(sort) dedupes, so a count mismatch means at least one duplicate.
+TEST_BASENAMES := $(notdir $(TESTS))
+ifneq ($(words $(TEST_BASENAMES)),$(words $(sort $(TEST_BASENAMES))))
+DUPLICATE_BASENAMES := $(strip $(foreach basename,$(sort $(TEST_BASENAMES)),\
+  $(if $(filter-out 1,$(words $(filter $(basename),$(TEST_BASENAMES)))),$(basename))))
 $(error duplicate test file basenames across suite directories: $(DUPLICATE_BASENAMES))
 endif
 
@@ -33,11 +47,15 @@ all: $(BINS)
 
 build/%: characterization/%.cpp $(HARNESS) $(FIRMWARE)
 	@mkdir -p build
-	$(CXX) $(CXXFLAGS) $(INCLUDES) $< -o $@
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 
 build/%: invariants/%.cpp $(HARNESS) $(FIRMWARE)
 	@mkdir -p build
-	$(CXX) $(CXXFLAGS) $(INCLUDES) $< -o $@
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+
+build/%: battery/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
+	@mkdir -p build
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 
 run: all
 	@status=0; \

--- a/tests/battery/test_voltage_plausibility.cpp
+++ b/tests/battery/test_voltage_plausibility.cpp
@@ -1,0 +1,69 @@
+// Pure-domain suite (#117 step 1): src/domain/battery/VoltagePlausibility
+// tested directly on the host — no firmware, no stubs, bounds passed
+// explicitly. End-to-end behavior through the firmware's worstPackVoltage()
+// delegate stays covered by tests/invariants/test_invariant_plausibility.cpp
+// and tests/characterization/test_battery_ladder.cpp; this suite proves the
+// extracted function is host-compilable and locks its contract at the unit
+// level, including the #131 FINDING (NaN passes the band).
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include <cmath>
+
+#include "../../sketches/rc_test/src/domain/battery/VoltagePlausibility.h"
+
+// Bounds mirror LOWV_PLAUS_MIN_V / LOWV_PLAUS_MAX_V — but they are
+// parameters here: the domain function has no config dependency.
+const float PLAUSIBLE_MIN_V = 6.0f;
+const float PLAUSIBLE_MAX_V = 13.0f;
+
+inline bool worstOf(float voltage0, bool valid0, float voltage1, bool valid1,
+                    float* worstOut) {
+  return worstPlausiblePackVoltage(BatteryReading{voltage0, valid0},
+                                   BatteryReading{voltage1, valid1},
+                                   PLAUSIBLE_MIN_V, PLAUSIBLE_MAX_V, worstOut);
+}
+
+TEST_CASE("both packs must be valid — one stale reading rejects the pair") {
+  float worst = -1.0f;
+  CHECK(worstOf(12.6f, true, 12.6f, false, &worst) == false);
+  CHECK(worstOf(12.6f, false, 12.6f, true, &worst) == false);
+  CHECK(worstOf(12.6f, false, 12.6f, false, &worst) == false);
+  CHECK(worst == -1.0f);  // rejected calls never write the out-param
+}
+
+TEST_CASE("plausibility band rejects out-of-band packs on either slot") {
+  float worst = -1.0f;
+  // Unpowered pack (~0 V) below the band.
+  CHECK(worstOf(0.4f, true, 12.6f, true, &worst) == false);
+  CHECK(worstOf(12.6f, true, 0.4f, true, &worst) == false);
+  // Impossibly high read above the band.
+  CHECK(worstOf(14.2f, true, 12.6f, true, &worst) == false);
+  CHECK(worstOf(12.6f, true, 14.2f, true, &worst) == false);
+  CHECK(worst == -1.0f);
+}
+
+TEST_CASE("band boundaries are inclusive; worst = min of the two packs") {
+  float worst = -1.0f;
+  CHECK(worstOf(PLAUSIBLE_MIN_V, true, PLAUSIBLE_MAX_V, true, &worst) == true);
+  CHECK(worst == doctest::Approx(PLAUSIBLE_MIN_V));
+  CHECK(worstOf(12.6f, true, 9.9f, true, &worst) == true);
+  CHECK(worst == doctest::Approx(9.9f));
+  CHECK(worstOf(9.9f, true, 12.6f, true, &worst) == true);
+  CHECK(worst == doctest::Approx(9.9f));
+}
+
+// FINDING (#131, locked current behavior — do NOT "fix" without its own
+// issue + operator sign-off): NaN passes the [min,max] band because both
+// comparisons are false, and the ternary min-select `(v0 < v1) ? v0 : v1`
+// is slot-asymmetric under NaN — NaN in slot 0 selects slot 1's voltage;
+// NaN in slot 1 selects itself (NaN propagates to the out-param).
+TEST_CASE("FINDING #131: NaN voltage is NOT rejected by the plausibility gate") {
+  const float nan = std::nanf("");
+  float worst = -1.0f;
+  CHECK(worstOf(nan, true, 12.6f, true, &worst) == true);
+  CHECK(worst == doctest::Approx(12.6f));  // slot-0 NaN: slot 1 selected
+  worst = -1.0f;
+  CHECK(worstOf(12.6f, true, nan, true, &worst) == true);
+  CHECK(std::isnan(worst));                // slot-1 NaN: NaN propagates
+}


### PR DESCRIPTION
Closes #151

## Summary — first #117 extraction (Phase D begins)

`worstPackVoltage`'s logic moves **verbatim** into the layered structure:

- `src/domain/battery/BatteryTypes.h` — `BatteryReading { voltage, valid }`
- `src/domain/battery/VoltagePlausibility.h/.cpp` — `worstPlausiblePackVoltage()`; plausibility bounds are parameters, so the domain function has **no config/global dependency** and no Arduino includes (host-compilable)
- `rc_test.ino`: `worstPackVoltage()` is now a one-line delegate — both [SAFETY] ladder call sites and all 15 existing test references unchanged
- `tests/Makefile`: test binaries now compile `sketches/rc_test/src/**/*.cpp` (needed by every later extraction step); new `tests/battery/` pure-domain suite dir; duplicate-basename guard generalized across all suite dirs
- `tests/battery/test_voltage_plausibility.cpp`: unit-locks the extracted contract — validity gate, inclusive band, min-select, and the **NaN pass-through #131 FINDING** (assertions mirror `test_invariant_plausibility.cpp` exactly)

**Deliberately out of scope:** the target tree's 'ONE implementation' consolidation. The [ALERT] inline check (`&&`-form) REJECTS NaN while this (`||`-form) PASSES it — merging them changes one path's NaN behavior → needs the NaN-gap issue first (covenant).

## Covenant / behavior preservation

- Logic copied verbatim; delegate adds a call boundary only
- Host suite green before AND after — **zero expectation changes**
- architecture-fitness runs its first real `src/` tree: OK (migration-window NOTE from #150, as designed)
- No bench check applicable (pure move — nothing physical to verify)

## Role tag

`[C-Builder]`

## Test plan

- [x] `wsl -e make -C tests run` — all suites green incl. new `tests/battery/` (4 cases / 19 assertions)
- [x] `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` — clean; flash 116296 bytes (+48 vs V7.35 baseline: extracted function is a cross-TU call now), RAM unchanged 9812
- [x] `python scripts/check_architecture.py` + selftest — OK
- [x] Pre-commit gate (host suite) passed at commit time

🤖 Generated with [Claude Code](https://claude.com/claude-code)