### PR TITLE
hooks: documentation-sync prompt on production-code edits (#156)

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -18,6 +18,11 @@
 - **Decisions get logged** in `docs/DECISION-LOG.md` as they are made (terse:
   date, what, why). Physical checks we cannot run (no hardware) go to
   `docs/architecture/BENCH-VERIFICATION-DEFERRED.md`.
+- **Docs travel with code, same PR.** When production code changes, verify
+  docs/wiki notes, architecture docs, the CLAUDE.md file map, TESTING.md and
+  SAFETY.md still match — the documentation-sync hook
+  (`scripts/documentation_sync_hook.py`, #156) prompts this once per session;
+  the prompt is a floor, not the ceiling.
 - **Every firmware flash** (when hardware returns) gets a row in
   `docs/FIRMWARE-UPLOAD-LOG.md` immediately — an unlogged flash is treated as
   not done.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -19,10 +19,10 @@
   date, what, why). Physical checks we cannot run (no hardware) go to
   `docs/architecture/BENCH-VERIFICATION-DEFERRED.md`.
 - **Docs travel with code, same PR.** When production code changes, verify
-  docs/wiki notes, architecture docs, the CLAUDE.md file map, TESTING.md and
-  SAFETY.md still match — the documentation-sync hook
-  (`scripts/documentation_sync_hook.py`, #156) prompts this once per session;
-  the prompt is a floor, not the ceiling.
+  docs/wiki notes, architecture docs, the CLAUDE.md file map,
+  docs/TESTING.md, docs/SAFETY.md and OPERATOR-GUIDE.md still match — the
+  documentation-sync hook (`scripts/documentation_sync_hook.py`, #156)
+  prompts this once per session; the prompt is a floor, not the ceiling.
 - **Every firmware flash** (when hardware returns) gets a row in
   `docs/FIRMWARE-UPLOAD-LOG.md` immediately — an unlogged flash is treated as
   not done.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,6 +47,11 @@
             "type": "command",
             "command": "cat <<'HOOK_EOF'\n[GENERATED-FILE GUARD]\nThis fires after EVERY Write/Edit — act ONLY if the target file's path ends with web_page.h (any location, e.g. sketches/rc_test/web_page.h) or contains a src/generated/ directory segment (otherwise do nothing and say nothing).\n- web_page.h (until issue #120's generator lands): a hand-edit is allowed ONLY if the same PR applies the identical change to dashboard/index.html — verify the mirror is in sync before finishing the task, and say so explicitly.\n- src/generated/** (after #120): hand-edits are FORBIDDEN. Revert the edit, change the source (dashboard/index.html) instead, and regenerate.\nHOOK_EOF",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python \"$CLAUDE_PROJECT_DIR/scripts/documentation_sync_hook.py\"",
+            "timeout": 10000
           }
         ]
       }

--- a/.github/workflows/hooks-selftest.yml
+++ b/.github/workflows/hooks-selftest.yml
@@ -13,5 +13,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Self-test the documentation-sync hook (#156)
         run: python scripts/documentation_sync_hook_selftest.py

--- a/.github/workflows/hooks-selftest.yml
+++ b/.github/workflows/hooks-selftest.yml
@@ -1,0 +1,17 @@
+name: hooks-selftest
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  hooks-selftest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Self-test the documentation-sync hook (#156)
+        run: python scripts/documentation_sync_hook_selftest.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ sits above all four: during epic #116, organization changes NOTHING observable
    - CI green: `arduino-ci.yml`, `lint.yml`, `static-analysis.yml`,
      `code-quality.yml`, `structure-check.yml`, `unit-tests.yml`,
      `architecture-fitness.yml` (#129 — layer/size/naming rules on `src/`
-     trees), `wiki-lint.yml` (#145 — docs/wiki graph health)
+     trees), `wiki-lint.yml` (#145 — docs/wiki graph health),
+     `hooks-selftest.yml` (#156 — documentation-sync hook health)
    - no blocking calls in `loop()` (`delay()`, `pulseIn()`, unbounded `while`)
    - zero behavior change unless the task's own issue explicitly authorizes it
 

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,28 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-12 — Documentation-sync hook + autonomous merge protocol (#156)
+
+- **Documentation-sync hook** (operator directive): `PostToolUse` hook in
+  `.claude/settings.json` runs `scripts/documentation_sync_hook.py` after
+  every Edit/Write. When the file is production code (sketches/ source,
+  dashboard/index.html, scripts/*.py, workflows, tests/ — excluding
+  web_page.h, arduino_secrets.h, src/generated/, vendor/), it injects a
+  once-per-session prompt telling the agent to verify docs/wiki +
+  architecture docs + CLAUDE.md file map against the change in the same PR.
+  Selftest (10 checks) wired to new `hooks-selftest.yml` CI.
+- **Mechanism finding:** PostToolUse hooks that print plain stdout never
+  reach the model (transcript-only) — the three pre-existing prompt-style
+  PostToolUse hooks in `.claude/settings.json` are silently inert. The new
+  hook uses the working `hookSpecificOutput.additionalContext` JSON form.
+  Converting the old hooks is left to the operator (they would start firing
+  for the first time).
+- **Autonomous merge protocol** (operator, same day): after a PR's review
+  rounds are resolved, 3 consecutive clean Copilot request→no-comments
+  cycles (~5 min apart) + CI green + zero unresolved threads ⇒ the agent
+  merges (squash, admin bypass of the 1-approval rule — bots cannot approve)
+  and continues to the next issue. First use: PR #155 (c595722).
+
 ## 2026-07-10 — Phase D step 2: BatteryLadder extracted to src/domain/battery/ (#154)
 
 - `batteryEcoLockUpdate()` / `batteryCutoffUpdate()` logic moved VERBATIM to

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -9,9 +9,10 @@ Updated by session hooks — only technical content, no personal info.
 
 - **Documentation-sync hook** (operator directive): `PostToolUse` hook in
   `.claude/settings.json` runs `scripts/documentation_sync_hook.py` after
-  every Edit/Write. When the file is production code (sketches/ source,
-  dashboard/index.html, scripts/*.py, workflows, tests/ — excluding
-  web_page.h, arduino_secrets.h, src/generated/, vendor/), it injects a
+  every Edit/Write. When the file matches the watched paths
+  (sketches/**/*.ino|.h|.cpp, dashboard/index.html, scripts/*.py,
+  .github/workflows/*.yml, tests/** — excluding web_page.h,
+  arduino_secrets.h, src/generated/, tests/build/, vendor/), it injects a
   once-per-session prompt telling the agent to verify docs/wiki +
   architecture docs + CLAUDE.md file map against the change in the same PR.
   Selftest (10 checks) wired to new `hooks-selftest.yml` CI.

--- a/docs/wiki/agent-governance.md
+++ b/docs/wiki/agent-governance.md
@@ -23,7 +23,9 @@ the Karpathy method (#53) plus the behavior-preservation covenant
   [copilot-instructions](../../.github/copilot-instructions.md) mirror the
   same rules so bot reviews align with the program
 - **This wiki** is itself governed here: agents maintain it, PRs that change
-  docs update affected notes ([README](README.md))
+  docs update affected notes ([README](README.md)); a session hook
+  (`scripts/documentation_sync_hook.py`, #156) prompts the agent to re-check
+  wiki + architecture docs whenever production code changes
 
 The [testing](testing.md) suites are the enforcement arm: expectations are
 law, and the gate defines "done" for any agent task.

--- a/scripts/documentation_sync_hook.py
+++ b/scripts/documentation_sync_hook.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""PostToolUse hook (#156): documentation-sync prompt on production-code edits.
+
+Claude Code pipes the tool payload to stdin after every Edit/Write. When the
+edited file is production code (not generated, not a secret), this emits the
+JSON `additionalContext` form — the only PostToolUse output that reaches the
+model (plain stdout is transcript-only) — telling the agent to verify the
+architecture docs and docs/wiki against the change in the same PR.
+
+Fires once per session (marker file keyed by the payload's session_id): the
+prompt is a nudge to audit at the end of the task, not per-edit noise.
+"""
+
+import json
+import os
+import re
+import sys
+import tempfile
+
+WATCHED = (
+    re.compile(r"(^|[\\/])sketches[\\/].*\.(ino|h|cpp)$"),
+    re.compile(r"(^|[\\/])dashboard[\\/]index\.html$"),
+    re.compile(r"(^|[\\/])scripts[\\/][^\\/]+\.py$"),
+    re.compile(r"(^|[\\/])\.github[\\/]workflows[\\/][^\\/]+\.ya?ml$"),
+    re.compile(r"(^|[\\/])tests[\\/]"),
+)
+
+EXCLUDED = (
+    re.compile(r"web_page\.h$"),          # generated from dashboard/index.html
+    re.compile(r"arduino_secrets\.h$"),   # gitignored secret, never documented
+    re.compile(r"[\\/]src[\\/]generated[\\/]"),
+    re.compile(r"[\\/]tests[\\/]build[\\/]"),
+    re.compile(r"[\\/]vendor[\\/]"),
+)
+
+PROMPT = (
+    "[DOCUMENTATION-SYNC HOOK #156] Production code changed this session "
+    "(first hit: {path}). Before this task ends, verify the documentation "
+    "still matches the code and update it in the SAME PR wherever it does "
+    "not: docs/wiki/ notes covering the changed area (same-PR rule, "
+    "docs/wiki/README.md), docs/architecture/ARCHITECTURE-TARGET.md, the "
+    "CLAUDE.md file map, docs/TESTING.md, docs/SAFETY.md, and "
+    "OPERATOR-GUIDE.md for operator-facing behavior. Tunable values stay "
+    "canonical in [CONFIG] — docs describe behavior, never live numbers "
+    "(#124). If everything already matches, say so briefly and move on."
+)
+
+
+def should_fire(file_path):
+    if not file_path:
+        return False
+    if any(pattern.search(file_path) for pattern in EXCLUDED):
+        return False
+    return any(pattern.search(file_path) for pattern in WATCHED)
+
+
+def marker_path(session_id):
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", session_id or "unknown")
+    return os.path.join(tempfile.gettempdir(),
+                        "documentation-sync-hook-" + safe)
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0  # malformed payload: a hook must never break the session
+    file_path = (payload.get("tool_input") or {}).get("file_path", "")
+    if not should_fire(file_path):
+        return 0
+    marker = marker_path(payload.get("session_id", ""))
+    if os.path.exists(marker):
+        return 0
+    try:
+        open(marker, "w").close()
+    except OSError:
+        pass  # fail open: reminding twice beats never reminding
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": PROMPT.format(path=file_path),
+        }
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/documentation_sync_hook.py
+++ b/scripts/documentation_sync_hook.py
@@ -28,9 +28,9 @@ WATCHED = (
 EXCLUDED = (
     re.compile(r"web_page\.h$"),          # generated from dashboard/index.html
     re.compile(r"arduino_secrets\.h$"),   # gitignored secret, never documented
-    re.compile(r"[\\/]src[\\/]generated[\\/]"),
-    re.compile(r"[\\/]tests[\\/]build[\\/]"),
-    re.compile(r"[\\/]vendor[\\/]"),
+    re.compile(r"(^|[\\/])src[\\/]generated[\\/]"),
+    re.compile(r"(^|[\\/])tests[\\/]build[\\/]"),
+    re.compile(r"(^|[\\/])vendor[\\/]"),
 )
 
 PROMPT = (

--- a/scripts/documentation_sync_hook_selftest.py
+++ b/scripts/documentation_sync_hook_selftest.py
@@ -61,7 +61,9 @@ def main():
         "sketches/rc_test/web_page.h",            # generated
         "sketches/rc_test/arduino_secrets.h",     # secret
         "sketches/rc_test/src/generated/page.h",  # generated tree
+        "src/generated/page.h",                   # generated tree, relative root
         "tests/vendor/doctest/doctest.h",         # third-party
+        "tests/build/test_alerts",                # build artifact, relative root
         "docs/wiki/battery-ladder.md",            # docs are the TARGET, not a trigger
         "",                                        # missing path
     )

--- a/scripts/documentation_sync_hook_selftest.py
+++ b/scripts/documentation_sync_hook_selftest.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Selftest for documentation_sync_hook.py (#156) — proves the hook fires on
+watched paths, stays silent on excluded/unwatched paths and malformed input,
+and dedupes per session. Run in CI (hooks-selftest.yml) and locally:
+    python scripts/documentation_sync_hook_selftest.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HOOK = os.path.join(os.path.dirname(__file__), "documentation_sync_hook.py")
+
+
+def run_hook(stdin_text, temp_dir):
+    env = dict(os.environ)
+    for var in ("TMPDIR", "TEMP", "TMP"):  # isolate the session marker
+        env[var] = temp_dir
+    result = subprocess.run([sys.executable, HOOK], input=stdin_text,
+                            capture_output=True, text=True, env=env)
+    return result.returncode, result.stdout.strip()
+
+
+def payload(file_path, session_id="session-a"):
+    return json.dumps({"session_id": session_id,
+                       "tool_input": {"file_path": file_path}})
+
+
+def main():
+    failures = []
+    checks = 0
+
+    def check(name, condition):
+        nonlocal checks
+        checks += 1
+        if not condition:
+            failures.append(name)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # 1. Watched firmware file fires with valid additionalContext JSON.
+        code, out = run_hook(payload("sketches/rc_test/rc_test.ino"), temp_dir)
+        fired = json.loads(out) if out else {}
+        context = fired.get("hookSpecificOutput", {})
+        check("fires on watched .ino", code == 0 and
+              context.get("hookEventName") == "PostToolUse" and
+              "DOCUMENTATION-SYNC" in context.get("additionalContext", ""))
+
+        # 2. Same session again: deduped, silent.
+        code, out = run_hook(payload("sketches/rc_test/types.h"), temp_dir)
+        check("dedupes within a session", code == 0 and out == "")
+
+        # 3. A different session fires again.
+        code, out = run_hook(
+            payload("tests/battery/test_battery_ladder_domain.cpp",
+                    session_id="session-b"), temp_dir)
+        check("fires again for a new session", code == 0 and out != "")
+
+    silent_paths = (
+        "sketches/rc_test/web_page.h",            # generated
+        "sketches/rc_test/arduino_secrets.h",     # secret
+        "sketches/rc_test/src/generated/page.h",  # generated tree
+        "tests/vendor/doctest/doctest.h",         # third-party
+        "docs/wiki/battery-ladder.md",            # docs are the TARGET, not a trigger
+        "",                                        # missing path
+    )
+    for path in silent_paths:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            code, out = run_hook(payload(path, session_id="fresh"), temp_dir)
+            check("silent on %r" % path, code == 0 and out == "")
+
+    # Malformed stdin must exit 0 silently — a hook never breaks the session.
+    with tempfile.TemporaryDirectory() as temp_dir:
+        code, out = run_hook("not json at all", temp_dir)
+        check("silent on malformed payload", code == 0 and out == "")
+
+    if failures:
+        print("documentation-sync-hook selftest: %d/%d FAILED: %s"
+              % (len(failures), checks, ", ".join(failures)))
+        return 1
+    print("documentation-sync-hook selftest: %d checks OK" % checks)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #156

## Summary

Operator directive (2026-07-12): documentation must stay synchronized with the code automatically. This adds a `PostToolUse` hook that fires a documentation-sync prompt whenever Edit/Write touches production code.

- `scripts/documentation_sync_hook.py` — reads the hook payload on stdin; when the edited file is production code (`sketches/**/*.{ino,h,cpp}`, `dashboard/index.html`, `scripts/*.py`, workflows, `tests/**` — excluding generated `web_page.h`/`src/generated/`, `arduino_secrets.h`, `vendor/`), it emits `hookSpecificOutput.additionalContext` JSON directing the agent to verify `docs/wiki/`, `ARCHITECTURE-TARGET.md`, the `CLAUDE.md` file map, `TESTING.md`/`SAFETY.md` against the change **in the same PR**. Fires once per session (marker keyed by `session_id`) — a nudge, not per-edit noise. Fails open and never breaks the session (malformed payload → silent exit 0).
- **Mechanism finding (logged in DECISION-LOG):** `PostToolUse` hooks that print plain stdout are transcript-only — they never reach the model. The three pre-existing prompt-style PostToolUse hooks in `.claude/settings.json` are therefore silently inert today. This PR uses the working JSON form for the new hook and leaves the existing hooks untouched — converting them would make them fire for the first time, which is the operator's call.
- `scripts/documentation_sync_hook_selftest.py` (10 checks: fires on watched, silent on excluded/unwatched/malformed, per-session dedupe) wired into new `hooks-selftest.yml` CI, following the architecture-fitness / wiki-lint selftest pattern.
- Docs synced same-PR: DECISION-LOG entry, `.claude/rules/workflow.md` "docs travel with code" rule, `docs/wiki/agent-governance.md` bullet, CLAUDE.md CI gate list.

No firmware changes — zero behavior impact on the machine.

**Role tag:** `[C-Builder]`

## Test plan

- [x] `python scripts/documentation_sync_hook_selftest.py` — 10 checks OK locally
- [x] `python scripts/check_wiki.py` — only the known untracked operator strays fail locally; tracked graph clean
- [x] `.claude/settings.json` validates as JSON
- [ ] CI: hooks-selftest (new), wiki-lint, markdownlint, structure-check, all others green
- [ ] Post-merge observation: hook prompt appears once in a fresh session after the first production-code edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation and architecture references are now checked for synchronization when production changes are made.
  * Governance guidance and CI checklists have been updated to reflect the expanded verification process.

* **Quality Improvements**
  * Added automated safeguards to prevent unsynchronized edits to generated files.
  * Added continuous integration checks to validate documentation-sync workflows and ensure they behave reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->