### PR TITLE
V7.35: extract thermal ladder to src/domain/thermal/ (#158, Phase D step 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,8 @@ PROJECT-PLAN.md                          — Full technical specification
 OPERATOR-GUIDE.md                        — User guide for Jason (RC) and Malaki (joystick)
 sketches/rc_test/rc_test.ino             — Main Arduino sketch (version: FIRMWARE_VERSION in [CONFIG]; GL10 FOC + telemetry + Wi-Fi + alarms + safety)
 sketches/rc_test/types.h                 — Shared structs (JoystickState, EscTelem, ...)
-sketches/rc_test/src/domain/battery/     — First extracted domain (#117): BatteryTypes.h + VoltagePlausibility.h/.cpp + BatteryLadder.h/.cpp (pure logic, host-testable)
+sketches/rc_test/src/domain/battery/     — Extracted domain (#117): BatteryTypes.h + VoltagePlausibility.h/.cpp + BatteryLadder.h/.cpp (pure logic, host-testable)
+sketches/rc_test/src/domain/thermal/     — Extracted domain (#117): ThermalTypes.h + ThermalHysteresis.h/.cpp + ThermalDerating.h/.cpp (pure logic, host-testable)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit
 sketches/telem_check/telem_check.ino     — Read-only X.BUS telemetry bench tool (0x50 framing)

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,36 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-12 — Phase D step 3: thermal ladder extracted to src/domain/thermal/ (#158)
+
+- `tempStageUpdate()` / `hottestMotorTemp()` / `thermalUpdate()` staging
+  logic moved VERBATIM to `src/domain/thermal/` as `thermalStageStep()`
+  (ThermalHysteresis), `hottestPlausibleTemperature()` +
+  `thermalDeratingStep()` (ThermalDerating) over ThermalTypes structs.
+  Thresholds/bounds stay in `[CONFIG]`, passed as parameters. The sketch
+  keeps all three functions as delegate shims — all 28 test references
+  unchanged. The firmware's three independent stage bools kept verbatim;
+  the target glossary's ThermalStage enum is a later consolidation.
+- Boundary work stays in the shims: clock read (time is a parameter),
+  telem[]→ThermalReading flattening (per-ESC validity mirrored to both its
+  sensors — comparison-identical to the original per-ESC loop), stage-global
+  mirroring, and BEEP_THERM_RESTORED queued on the domain's cut-released
+  return ([BEEPER] stays application-side, as with lowVoltLatched in #154).
+- Same accepted non-observable delta as #154 (logged precedent): the shim
+  reads `millis()` and builds the reading array unconditionally where the
+  original early-returned on telemetry dropout. `hot` initialized to 0.0f
+  (the #155-round lesson: never pass a possibly-unwritten out-param).
+- New pure-domain suite `tests/thermal/test_thermal_domain.cpp` (8 cases)
+  locks: trip at exactly since+debounce, timer reset on drop-back, the
+  hysteresis HOLD inside the on/off gap incl. exactly-OFF (behavior law),
+  immediate release below OFF, plausible-hottest selection with inclusive
+  band edges and unwritten out-param on reject, dropout-holds-every-stage
+  (timers too), cut-released edge fires exactly once, stage independence at
+  86 C. Makefile: thermal/ glob + no-stubs rule mirroring battery/.
+- Verified: full host suite green before/after, zero expectation changes;
+  compile clean — flash 116688 (+200 vs 116488), RAM unchanged 9812. No
+  bench check applicable (pure move).
+
 ## 2026-07-12 — Documentation-sync hook + autonomous merge protocol (#156)
 
 - **Documentation-sync hook** (operator directive): `PostToolUse` hook in

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -8,9 +8,12 @@ Updated by session hooks — only technical content, no personal info.
 ## 2026-07-12 — Phase D step 3: thermal ladder extracted to src/domain/thermal/ (#158)
 
 - `tempStageUpdate()` / `hottestMotorTemp()` / `thermalUpdate()` staging
-  logic moved VERBATIM to `src/domain/thermal/` as `thermalStageStep()`
+  logic moved to `src/domain/thermal/` as `thermalStageStep()`
   (ThermalHysteresis), `hottestPlausibleTemperature()` +
-  `thermalDeratingStep()` (ThermalDerating) over ThermalTypes structs.
+  `thermalDeratingStep()` (ThermalDerating) over ThermalTypes structs —
+  observable staging behavior preserved exactly; the shim-boundary deltas
+  and one provably output-identical initialization change are itemized
+  below for the audit trail.
   Thresholds/bounds stay in `[CONFIG]`, passed as parameters. The sketch
   keeps all three functions as delegate shims — all 28 test references
   unchanged. The firmware's three independent stage bools kept verbatim;

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -34,6 +34,12 @@ Updated by session hooks — only technical content, no personal info.
 - Verified: full host suite green before/after, zero expectation changes;
   compile clean — flash 116688 (+200 vs 116488), RAM unchanged 9812. No
   bench check applicable (pure move).
+- Review fix (Copilot): the hottest-selection running max now starts at
+  `plausibleMinC` instead of the original `-1000.0f` sentinel — provably
+  output-identical for every input (accepted readings are all >= minC), but
+  correct for any parameter range now that the bounds are parameters (the
+  sentinel was only safe with the fixed -20 °C constant). Unit-locked with a
+  below-sentinel-band test case.
 
 ## 2026-07-12 — Documentation-sync hook + autonomous merge protocol (#156)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,9 +34,11 @@ tests/
 ├── invariants/
 │   ├── InvariantChecks.h       reusable safety-invariant checkers + loop driver (#131)
 │   └── test_invariant_*.cpp    one property suite per safety invariant
-└── battery/                    pure-domain suites for src/domain/battery/ (#117)
-    ├── test_voltage_plausibility.cpp
-    └── test_battery_ladder_domain.cpp
+├── battery/                    pure-domain suites for src/domain/battery/ (#117)
+│   ├── test_voltage_plausibility.cpp
+│   └── test_battery_ladder_domain.cpp
+└── thermal/                    pure-domain suite for src/domain/thermal/ (#117)
+    └── test_thermal_domain.cpp
 ```
 
 The stub headers shadow the real Arduino/library headers via include order

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -14,11 +14,13 @@ drive exactly as before.
 - **Phases** — A Define → B Protect ([testing](testing.md) suites, done) →
   C Govern (CI fitness functions, done) → D Refactor (extract domains,
   **active**) → E Polish
-- **First extracted domain** — the [battery ladder](battery-ladder.md)'s
+- **Extracted domains so far** — the [battery ladder](battery-ladder.md)'s
   voltage-plausibility gate and its two staged state machines (Eco lock,
-  cutoff + boot gate) live in `src/domain/battery/` (pure logic, no Arduino
-  includes, time passed as a parameter, host-tested directly); the sketch
-  keeps thin delegates until the composition root lands
+  cutoff + boot gate) live in `src/domain/battery/`; the
+  [thermal derating](thermal-derating.md) hysteresis stage, hottest-sensor
+  selection, and warn/eco/cut staging live in `src/domain/thermal/`. All
+  pure logic — no Arduino includes, time passed as a parameter, host-tested
+  directly; the sketch keeps thin delegates until the composition root lands
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/docs/wiki/thermal-derating.md
+++ b/docs/wiki/thermal-derating.md
@@ -15,9 +15,9 @@ hysteresis band is correct behavior, not a stuck state.
 - Temperatures arrive via [X.BUS telemetry](xbus-telemetry.md); implausible
   spikes are rejected, and dropout freezes the active stage rather than
   releasing it. The hysteresis stage, hottest-sensor selection, and staging
-  logic are extracted domain code of the
-  [architecture remediation](architecture-remediation.md)
-  (`src/domain/thermal/`); the sketch keeps thin delegates
+  logic were extracted into domain code (`src/domain/thermal/`) as part of
+  the [architecture remediation](architecture-remediation.md); the sketch
+  keeps thin delegates
 
 Deliberate asymmetry with the [battery ladder](battery-ladder.md): thermal
 cut **auto-recovers** when temperature falls; battery cutoff latches until

--- a/docs/wiki/thermal-derating.md
+++ b/docs/wiki/thermal-derating.md
@@ -14,7 +14,10 @@ hysteresis band is correct behavior, not a stuck state.
   [testing](testing.md)
 - Temperatures arrive via [X.BUS telemetry](xbus-telemetry.md); implausible
   spikes are rejected, and dropout freezes the active stage rather than
-  releasing it
+  releasing it. The hysteresis stage, hottest-sensor selection, and staging
+  logic are extracted domain code of the
+  [architecture remediation](architecture-remediation.md)
+  (`src/domain/thermal/`); the sketch keeps thin delegates
 
 Deliberate asymmetry with the [battery ladder](battery-ladder.md): thermal
 cut **auto-recovers** when temperature falls; battery cutoff latches until

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -1093,7 +1093,7 @@ void tempStageUpdate(bool* state, uint32_t* since, float temp,
 }
 
 void thermalUpdate() {
-  float hot = 0.0f;  // stays unwritten when no fresh reading; the step holds then
+  float hot = 0.0f;  // defensive init: the out-param is left unchanged on reject
   bool haveReading = hottestMotorTemp(&hot);
   ThermalDeratingState derating{{tempWarnActive, tempWarnSinceMs},
                                 {tempEcoActive,  tempEcoSinceMs},

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -66,6 +66,8 @@
 // (migration window, #150).
 #include "src/domain/battery/VoltagePlausibility.h"
 #include "src/domain/battery/BatteryLadder.h"
+#include "src/domain/thermal/ThermalHysteresis.h"
+#include "src/domain/thermal/ThermalDerating.h"
 
 
 // Second hardware UART on D11=TX(pin 11) / D12=RX(pin 12) via SCI0.
@@ -1061,58 +1063,54 @@ uint32_t tempWarnSinceMs = 0;   // trip-debounce timers (0 = not currently above
 uint32_t tempEcoSinceMs  = 0;
 uint32_t tempCutSinceMs  = 0;
 
+// The thermal ladder is extracted to src/domain/thermal/ (#117 step 3, #158);
+// these delegate shims keep every call site and test reference unchanged.
+// The shims own the boundary work the domain must not do: read the clock
+// (time is a parameter), flatten telem[] into ThermalReadings, mirror the
+// stage globals in/out, and — on the domain's cut-released signal — queue
+// [BEEPER]'s one-shot "restored" flourish (4 quick beeps; the repeating cut
+// alarm has already stopped because tempCutActive just went false). Domain
+// code never calls another module.
+
 // Hottest plausible temp across both ESCs (ESC + motor sensor each). Returns
 // false if neither ESC has a fresh valid plausible reading → caller HOLDS state.
 bool hottestMotorTemp(float* hot) {
-  float h = -1000.0f;
-  bool any = false;
+  ThermalReading readings[NUM_ESCS * 2];
   for (uint8_t i = 0; i < NUM_ESCS; i++) {
-    if (!telem[i].valid) continue;
-    float te = telem[i].escTempC;
-    float tm = telem[i].motorTempC;
-    if (te >= TEMP_PLAUS_MIN_C && te <= TEMP_PLAUS_MAX_C) {
-      if (te > h) h = te;
-      any = true;
-    }
-    if (tm >= TEMP_PLAUS_MIN_C && tm <= TEMP_PLAUS_MAX_C) {
-      if (tm > h) h = tm;
-      any = true;
-    }
+    readings[i * 2]     = ThermalReading{telem[i].escTempC, telem[i].valid};
+    readings[i * 2 + 1] = ThermalReading{telem[i].motorTempC, telem[i].valid};
   }
-  if (any) *hot = h;
-  return any;
+  return hottestPlausibleTemperature(readings, NUM_ESCS * 2,
+                                     TEMP_PLAUS_MIN_C, TEMP_PLAUS_MAX_C, hot);
 }
 
-// One hysteresis stage with trip debounce: flips ON when temp stays >= onC for
-// TEMP_DEBOUNCE_MS; flips OFF immediately when temp < offC (the on/off gap makes
-// release chatter impossible, so release needs no debounce).
 void tempStageUpdate(bool* state, uint32_t* since, float temp,
                      float onC, float offC, uint32_t nowMs) {
-  if (*state) {
-    if (temp < offC) {
-      *state = false;
-      *since = 0;
-    }
-  } else if (temp >= onC) {
-    if (*since == 0) *since = nowMs;
-    if (nowMs - *since >= TEMP_DEBOUNCE_MS) *state = true;
-  } else {
-    *since = 0;                      // dropped back before debounce elapsed
-  }
+  ThermalStageState stage{*state, *since};
+  thermalStageStep(stage, temp, nowMs, onC, offC, TEMP_DEBOUNCE_MS);
+  *state = stage.active;
+  *since = stage.sinceMs;
 }
 
 void thermalUpdate() {
-  float hot;
-  if (!hottestMotorTemp(&hot)) return;   // no fresh reading → hold every stage
-  uint32_t nowMs = millis();
-  bool wasCut = tempCutActive;
-  tempStageUpdate(&tempWarnActive, &tempWarnSinceMs, hot, TEMP_WARN_ON_C, TEMP_WARN_OFF_C, nowMs);
-  tempStageUpdate(&tempEcoActive,  &tempEcoSinceMs,  hot, TEMP_ECO_ON_C,  TEMP_ECO_OFF_C,  nowMs);
-  tempStageUpdate(&tempCutActive,  &tempCutSinceMs,  hot, TEMP_CUT_ON_C,  TEMP_CUT_OFF_C,  nowMs);
-  // Cooled back below the cut-release threshold → queue the one-shot "restored"
-  // flourish (4 quick beeps). The repeating cut alarm has already stopped because
-  // tempCutActive just went false.
-  if (wasCut && !tempCutActive) beepStart(BEEP_THERM_RESTORED, BEEP_THERM_RESTORED_LEN);
+  float hot = 0.0f;  // stays unwritten when no fresh reading; the step holds then
+  bool haveReading = hottestMotorTemp(&hot);
+  ThermalDeratingState derating{{tempWarnActive, tempWarnSinceMs},
+                                {tempEcoActive,  tempEcoSinceMs},
+                                {tempCutActive,  tempCutSinceMs}};
+  bool cutReleased = thermalDeratingStep(
+      derating, haveReading, hot, millis(),
+      ThermalDeratingThresholds{TEMP_WARN_ON_C, TEMP_WARN_OFF_C,
+                                TEMP_ECO_ON_C,  TEMP_ECO_OFF_C,
+                                TEMP_CUT_ON_C,  TEMP_CUT_OFF_C,
+                                TEMP_DEBOUNCE_MS});
+  tempWarnActive = derating.warn.active;
+  tempWarnSinceMs = derating.warn.sinceMs;
+  tempEcoActive = derating.eco.active;
+  tempEcoSinceMs = derating.eco.sinceMs;
+  tempCutActive = derating.cut.active;
+  tempCutSinceMs = derating.cut.sinceMs;
+  if (cutReleased) beepStart(BEEP_THERM_RESTORED, BEEP_THERM_RESTORED_LEN);
 }
 
 

--- a/sketches/rc_test/src/domain/thermal/ThermalDerating.cpp
+++ b/sketches/rc_test/src/domain/thermal/ThermalDerating.cpp
@@ -1,0 +1,43 @@
+// domain/thermal — warn/eco/cut staging (#117 step 3, #158).
+// Logic copied VERBATIM from rc_test.ino [SAFETY]; behavior is locked by
+// tests/characterization/test_thermal_stages.cpp,
+// tests/invariants/test_invariant_thermal_monotone.cpp and
+// tests/thermal/test_thermal_domain.cpp.
+#include "ThermalDerating.h"
+
+#include "ThermalHysteresis.h"
+
+bool hottestPlausibleTemperature(const ThermalReading* readings,
+                                 uint8_t count,
+                                 float plausibleMinC, float plausibleMaxC,
+                                 float* hottestOut) {
+  float h = -1000.0f;
+  bool any = false;
+  for (uint8_t i = 0; i < count; i++) {
+    if (!readings[i].valid) continue;
+    float t = readings[i].temperatureC;
+    if (t >= plausibleMinC && t <= plausibleMaxC) {
+      if (t > h) h = t;
+      any = true;
+    }
+  }
+  if (any) *hottestOut = h;
+  return any;
+}
+
+bool thermalDeratingStep(ThermalDeratingState& derating, bool haveReading,
+                         float hottestC, uint32_t nowMs,
+                         const ThermalDeratingThresholds& thresholds) {
+  if (!haveReading) return false;  // no fresh reading → hold every stage
+  bool wasCut = derating.cut.active;
+  thermalStageStep(derating.warn, hottestC, nowMs,
+                   thresholds.warnOnC, thresholds.warnOffC,
+                   thresholds.debounceMs);
+  thermalStageStep(derating.eco, hottestC, nowMs,
+                   thresholds.ecoOnC, thresholds.ecoOffC,
+                   thresholds.debounceMs);
+  thermalStageStep(derating.cut, hottestC, nowMs,
+                   thresholds.cutOnC, thresholds.cutOffC,
+                   thresholds.debounceMs);
+  return wasCut && !derating.cut.active;  // cut released on THIS call
+}

--- a/sketches/rc_test/src/domain/thermal/ThermalDerating.cpp
+++ b/sketches/rc_test/src/domain/thermal/ThermalDerating.cpp
@@ -11,7 +11,11 @@ bool hottestPlausibleTemperature(const ThermalReading* readings,
                                  uint8_t count,
                                  float plausibleMinC, float plausibleMaxC,
                                  float* hottestOut) {
-  float h = -1000.0f;
+  // Running max starts at the lower plausibility bound: every accepted
+  // reading is >= plausibleMinC, so the result is identical to the
+  // firmware's original fixed -1000.0f sentinel — but stays correct for
+  // any parameter range now that the bounds are parameters.
+  float h = plausibleMinC;
   bool any = false;
   for (uint8_t i = 0; i < count; i++) {
     if (!readings[i].valid) continue;

--- a/sketches/rc_test/src/domain/thermal/ThermalDerating.h
+++ b/sketches/rc_test/src/domain/thermal/ThermalDerating.h
@@ -1,0 +1,28 @@
+// domain/thermal — warn/eco/cut staging off the hottest sensor (#117 step 3,
+// #158). Logic extracted VERBATIM from rc_test.ino [SAFETY]
+// hottestMotorTemp() / thermalUpdate(). Pure domain: readings, time and
+// thresholds arrive as parameters.
+#pragma once
+
+#include <stdint.h>
+
+#include "ThermalTypes.h"
+
+// Hottest plausible temperature across the given readings. Returns false
+// when no reading is both fresh (valid) and inside [plausibleMinC,
+// plausibleMaxC] — the out-param is left unwritten and the caller HOLDS
+// state (a telemetry dropout never cuts and never releases).
+bool hottestPlausibleTemperature(const ThermalReading* readings,
+                                 uint8_t count,
+                                 float plausibleMinC, float plausibleMaxC,
+                                 float* hottestOut);
+
+// One derating pass over all three stages. With haveReading false every
+// stage HOLDS — the deliberate dropout asymmetry vs the battery ladder's
+// timer reset (docs/SAFETY.md). Returns true exactly when the cut stage
+// releases on THIS call, so the application layer can queue the "restored"
+// flourish — [BEEPER] owns its own patterns; domain code never calls
+// another module.
+bool thermalDeratingStep(ThermalDeratingState& derating, bool haveReading,
+                         float hottestC, uint32_t nowMs,
+                         const ThermalDeratingThresholds& thresholds);

--- a/sketches/rc_test/src/domain/thermal/ThermalHysteresis.cpp
+++ b/sketches/rc_test/src/domain/thermal/ThermalHysteresis.cpp
@@ -1,0 +1,22 @@
+// domain/thermal — one hysteresis stage (#117 step 3, #158).
+// Logic copied VERBATIM from rc_test.ino [SAFETY] tempStageUpdate();
+// behavior is locked by tests/characterization/test_thermal_stages.cpp,
+// tests/invariants/test_invariant_thermal_monotone.cpp and
+// tests/thermal/test_thermal_domain.cpp.
+#include "ThermalHysteresis.h"
+
+void thermalStageStep(ThermalStageState& stage, float temperatureC,
+                      uint32_t nowMs, float onC, float offC,
+                      uint32_t debounceMs) {
+  if (stage.active) {
+    if (temperatureC < offC) {
+      stage.active = false;
+      stage.sinceMs = 0;
+    }
+  } else if (temperatureC >= onC) {
+    if (stage.sinceMs == 0) stage.sinceMs = nowMs;
+    if (nowMs - stage.sinceMs >= debounceMs) stage.active = true;
+  } else {
+    stage.sinceMs = 0;  // dropped back before debounce elapsed
+  }
+}

--- a/sketches/rc_test/src/domain/thermal/ThermalHysteresis.h
+++ b/sketches/rc_test/src/domain/thermal/ThermalHysteresis.h
@@ -1,0 +1,19 @@
+// domain/thermal — one hysteresis stage with trip debounce (#117 step 3,
+// #158). Logic extracted VERBATIM from rc_test.ino [SAFETY]
+// tempStageUpdate(). Pure domain: time and thresholds arrive as parameters
+// (state-ownership rules: time is a parameter, dependencies are visible in
+// the signature).
+#pragma once
+
+#include <stdint.h>
+
+#include "ThermalTypes.h"
+
+// Flips ON when temperatureC stays >= onC for debounceMs; flips OFF
+// immediately when temperatureC < offC (the on/off gap makes release
+// chatter impossible, so release needs no debounce). Inside the gap
+// (offC <= temperatureC < onC) an active stage HOLDS — that hold is
+// test-locked behavior law.
+void thermalStageStep(ThermalStageState& stage, float temperatureC,
+                      uint32_t nowMs, float onC, float offC,
+                      uint32_t debounceMs);

--- a/sketches/rc_test/src/domain/thermal/ThermalTypes.h
+++ b/sketches/rc_test/src/domain/thermal/ThermalTypes.h
@@ -13,7 +13,9 @@ struct ThermalReading {
 };
 
 // One hysteresis stage: flips ON after the trip debounce, OFF immediately
-// below the release threshold. sinceMs of 0 = not currently above ON.
+// below the release threshold. sinceMs is the trip-debounce start timestamp,
+// meaningful only while inactive (0 = debounce not running); it is not
+// consulted while the stage is active.
 struct ThermalStageState {
   bool active;
   uint32_t sinceMs;

--- a/sketches/rc_test/src/domain/thermal/ThermalTypes.h
+++ b/sketches/rc_test/src/domain/thermal/ThermalTypes.h
@@ -1,0 +1,39 @@
+// domain/thermal — shared value types (#117 step 3, #158).
+// Pure domain: no Arduino includes (host-compilable by design).
+#pragma once
+
+#include <stdint.h>
+
+// One temperature sensor's report, as delivered by X.BUS telemetry.
+// `valid` mirrors EscTelem.valid — the freshness watchdog's verdict for the
+// ESC carrying the sensor; plausibility is ThermalDerating's job.
+struct ThermalReading {
+  float temperatureC;
+  bool valid;
+};
+
+// One hysteresis stage: flips ON after the trip debounce, OFF immediately
+// below the release threshold. sinceMs of 0 = not currently above ON.
+struct ThermalStageState {
+  bool active;
+  uint32_t sinceMs;
+};
+
+// The three derating stages (#111). NON-LATCHING with hysteresis by design:
+// heat is not a drained LiPo — once cool, drive resumes (deliberate
+// asymmetry vs the battery ladder's latched cutoff; both test-locked).
+struct ThermalDeratingState {
+  ThermalStageState warn;
+  ThermalStageState eco;
+  ThermalStageState cut;
+};
+
+// On/off temperature pairs + trip debounce, mirrored from [CONFIG]
+// (TEMP_*_ON_C / TEMP_*_OFF_C / TEMP_DEBOUNCE_MS) — parameters here: the
+// domain has no config dependency.
+struct ThermalDeratingThresholds {
+  float warnOnC, warnOffC;
+  float ecoOnC, ecoOffC;
+  float cutOnC, cutOffC;
+  uint32_t debounceMs;
+};

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -31,7 +31,8 @@ HARNESS  := $(wildcard stubs/*.h) characterization/FirmwareUnderTest.h \
 
 TESTS := $(wildcard characterization/test_*.cpp) \
          $(wildcard invariants/test_*.cpp) \
-         $(wildcard battery/test_*.cpp)
+         $(wildcard battery/test_*.cpp) \
+         $(wildcard thermal/test_*.cpp)
 BINS  := $(addprefix build/,$(notdir $(TESTS:.cpp=)))
 
 # A duplicate basename across suite directories would silently shadow one
@@ -56,6 +57,10 @@ build/%: invariants/%.cpp $(HARNESS) $(FIRMWARE)
 	$(CXX) $(CXXFLAGS) $(INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 
 build/%: battery/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
+	@mkdir -p build
+	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+
+build/%: thermal/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 

--- a/tests/thermal/test_thermal_domain.cpp
+++ b/tests/thermal/test_thermal_domain.cpp
@@ -97,6 +97,16 @@ TEST_CASE("hottest selection: band edges inclusive; none usable leaves out-param
   CHECK(hottest == -1.0f);                   // rejected calls never write it
 }
 
+TEST_CASE("hottest selection stays correct for bounds below the old sentinel") {
+  // The bounds are parameters: with a band reaching below -1000 the result
+  // must still be the actual hottest reading, not a sentinel artifact.
+  const ThermalReading deepCold[1] = {{-1500.0f, true}};
+  float hottest = 0.0f;
+  CHECK(hottestPlausibleTemperature(deepCold, 1, -2000.0f, 200.0f,
+                                    &hottest) == true);
+  CHECK(hottest == doctest::Approx(-1500.0f));
+}
+
 TEST_CASE("telemetry dropout HOLDS every stage — never cuts, never releases") {
   ThermalDeratingState derating{{true, 0}, {true, 0}, {true, 0}};
   CHECK(thermalDeratingStep(derating, false, 0.0f, 7000, THRESHOLDS) == false);

--- a/tests/thermal/test_thermal_domain.cpp
+++ b/tests/thermal/test_thermal_domain.cpp
@@ -1,0 +1,138 @@
+// Pure-domain suite (#117 step 3, #158): src/domain/thermal tested directly
+// on the host — no firmware, no stubs, time and thresholds passed
+// explicitly. End-to-end behavior through the firmware's tempStageUpdate()/
+// hottestMotorTemp()/thermalUpdate() shims stays covered by
+// tests/characterization/test_thermal_stages.cpp and
+// tests/invariants/test_invariant_thermal_monotone.cpp; this suite locks the
+// extracted logic at the unit level: trip-debounce boundaries, the
+// hysteresis HOLD inside the on/off gap (behavior law), immediate release,
+// plausible-hottest selection, dropout-holds-state, and the cut-released
+// signal firing exactly once per release edge.
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include "../../sketches/rc_test/src/domain/thermal/ThermalDerating.h"
+#include "../../sketches/rc_test/src/domain/thermal/ThermalHysteresis.h"
+
+// Values mirror TEMP_*_ON_C / TEMP_*_OFF_C / TEMP_DEBOUNCE_MS /
+// TEMP_PLAUS_MIN_C / TEMP_PLAUS_MAX_C — but they are parameters here: the
+// domain functions have no config dependency.
+const float    WARN_ON_C  = 80.0f;
+const float    WARN_OFF_C = 78.0f;
+const float    ECO_ON_C   = 90.0f;
+const float    ECO_OFF_C  = 80.0f;
+const float    CUT_ON_C   = 95.0f;
+const float    CUT_OFF_C  = 75.0f;
+const uint32_t DEBOUNCE_MS = 1000UL;
+const float    PLAUSIBLE_MIN_C = -20.0f;
+const float    PLAUSIBLE_MAX_C = 200.0f;
+
+const ThermalDeratingThresholds THRESHOLDS{
+    WARN_ON_C, WARN_OFF_C, ECO_ON_C, ECO_OFF_C, CUT_ON_C, CUT_OFF_C,
+    DEBOUNCE_MS};
+
+TEST_CASE("stage trips only after the full debounce at/above ON") {
+  ThermalStageState stage{false, 0};
+  thermalStageStep(stage, ECO_ON_C, 1000, ECO_ON_C, ECO_OFF_C, DEBOUNCE_MS);
+  CHECK(stage.active == false);              // timer starts, no trip yet
+  CHECK(stage.sinceMs == 1000);
+  thermalStageStep(stage, 95.0f, 1000 + DEBOUNCE_MS - 1,
+                   ECO_ON_C, ECO_OFF_C, DEBOUNCE_MS);
+  CHECK(stage.active == false);              // one ms short
+  thermalStageStep(stage, 95.0f, 1000 + DEBOUNCE_MS,
+                   ECO_ON_C, ECO_OFF_C, DEBOUNCE_MS);
+  CHECK(stage.active == true);               // exact boundary trips
+}
+
+TEST_CASE("dropping below ON before the debounce elapses resets the timer") {
+  ThermalStageState stage{false, 0};
+  thermalStageStep(stage, 92.0f, 1000, ECO_ON_C, ECO_OFF_C, DEBOUNCE_MS);
+  thermalStageStep(stage, 85.0f, 1500, ECO_ON_C, ECO_OFF_C, DEBOUNCE_MS);
+  CHECK(stage.sinceMs == 0);                 // dropped back → reset
+  thermalStageStep(stage, 92.0f, 2000, ECO_ON_C, ECO_OFF_C, DEBOUNCE_MS);
+  thermalStageStep(stage, 92.0f, 2000 + DEBOUNCE_MS - 1,
+                   ECO_ON_C, ECO_OFF_C, DEBOUNCE_MS);
+  CHECK(stage.active == false);              // fresh full window required
+}
+
+TEST_CASE("behavior law: an active stage HOLDS inside the on/off gap") {
+  ThermalStageState stage{true, 0};
+  // Eco band is 90 ON / 80 OFF: 85 C sits inside the gap and must HOLD.
+  thermalStageStep(stage, 85.0f, 5000, ECO_ON_C, ECO_OFF_C, DEBOUNCE_MS);
+  CHECK(stage.active == true);
+  // Exactly the OFF threshold is NOT below it — still holds.
+  thermalStageStep(stage, ECO_OFF_C, 6000, ECO_ON_C, ECO_OFF_C, DEBOUNCE_MS);
+  CHECK(stage.active == true);
+  // Below OFF releases immediately, no debounce.
+  thermalStageStep(stage, ECO_OFF_C - 0.5f, 6001,
+                   ECO_ON_C, ECO_OFF_C, DEBOUNCE_MS);
+  CHECK(stage.active == false);
+  CHECK(stage.sinceMs == 0);
+}
+
+TEST_CASE("hottest selection skips stale and implausible readings") {
+  const ThermalReading readings[4] = {
+      {150.0f, false},   // hottest but stale → skipped
+      {250.0f, true},    // above plausibility band → skipped
+      {-40.0f, true},    // below plausibility band (unplugged) → skipped
+      {72.0f, true},     // the only usable reading
+  };
+  float hottest = -1.0f;
+  CHECK(hottestPlausibleTemperature(readings, 4, PLAUSIBLE_MIN_C,
+                                    PLAUSIBLE_MAX_C, &hottest) == true);
+  CHECK(hottest == doctest::Approx(72.0f));
+}
+
+TEST_CASE("hottest selection: band edges inclusive; none usable leaves out-param") {
+  const ThermalReading edges[2] = {{PLAUSIBLE_MIN_C, true},
+                                   {PLAUSIBLE_MAX_C, true}};
+  float hottest = -1.0f;
+  CHECK(hottestPlausibleTemperature(edges, 2, PLAUSIBLE_MIN_C,
+                                    PLAUSIBLE_MAX_C, &hottest) == true);
+  CHECK(hottest == doctest::Approx(PLAUSIBLE_MAX_C));
+  const ThermalReading unusable[2] = {{90.0f, false}, {999.0f, true}};
+  hottest = -1.0f;
+  CHECK(hottestPlausibleTemperature(unusable, 2, PLAUSIBLE_MIN_C,
+                                    PLAUSIBLE_MAX_C, &hottest) == false);
+  CHECK(hottest == -1.0f);                   // rejected calls never write it
+}
+
+TEST_CASE("telemetry dropout HOLDS every stage — never cuts, never releases") {
+  ThermalDeratingState derating{{true, 0}, {true, 0}, {true, 0}};
+  CHECK(thermalDeratingStep(derating, false, 0.0f, 7000, THRESHOLDS) == false);
+  CHECK(derating.warn.active == true);       // all stages held
+  CHECK(derating.eco.active == true);
+  CHECK(derating.cut.active == true);
+  ThermalDeratingState cold{{false, 500}, {false, 500}, {false, 500}};
+  CHECK(thermalDeratingStep(cold, false, 150.0f, 7000, THRESHOLDS) == false);
+  CHECK(cold.warn.sinceMs == 500);           // timers held too, not reset
+}
+
+TEST_CASE("cut-released fires exactly once per release edge; stages stay independent") {
+  ThermalDeratingState derating{{false, 0}, {false, 0}, {false, 0}};
+  // Sustained 96 C trips all three stages after the shared debounce.
+  CHECK(thermalDeratingStep(derating, true, 96.0f, 1000, THRESHOLDS) == false);
+  CHECK(thermalDeratingStep(derating, true, 96.0f, 1000 + DEBOUNCE_MS,
+                            THRESHOLDS) == false);  // trip is not a release
+  CHECK(derating.warn.active == true);
+  CHECK(derating.eco.active == true);
+  CHECK(derating.cut.active == true);
+  // 85 C sits inside every stage's on/off gap → everything holds, no edge.
+  CHECK(thermalDeratingStep(derating, true, 85.0f, 3000, THRESHOLDS) == false);
+  CHECK(derating.cut.active == true);        // 85 C inside the 95/75 gap holds
+  CHECK(derating.warn.active == true);       // 85 C >= 78 holds warn too
+  // 74 C is below every OFF threshold → all release; the cut edge fires ONCE.
+  CHECK(thermalDeratingStep(derating, true, 74.0f, 4000, THRESHOLDS) == true);
+  CHECK(derating.cut.active == false);
+  CHECK(thermalDeratingStep(derating, true, 74.0f, 5000, THRESHOLDS) == false);
+}
+
+TEST_CASE("86 C sustained trips warn only — eco and cut never engage") {
+  ThermalDeratingState derating{{false, 0}, {false, 0}, {false, 0}};
+  thermalDeratingStep(derating, true, 86.0f, 1000, THRESHOLDS);
+  thermalDeratingStep(derating, true, 86.0f, 1000 + DEBOUNCE_MS, THRESHOLDS);
+  CHECK(derating.warn.active == true);
+  CHECK(derating.eco.active == false);
+  CHECK(derating.cut.active == false);
+  CHECK(derating.eco.sinceMs == 0);          // never started debouncing
+}


### PR DESCRIPTION
Closes #158

## Summary

Phase D step 3 (#117, epic #116): the motor/ESC over-temperature protection (#111) moves VERBATIM from `rc_test.ino` `[SAFETY]` into `src/domain/thermal/`, the same strangler-fig pattern as #151 (VoltagePlausibility) and #154 (BatteryLadder).

- **`ThermalHysteresis`** — `thermalStageStep()`: one stage, trips after the debounce at/above ON, releases immediately below OFF; the hold inside the on/off gap is preserved verbatim (behavior law).
- **`ThermalDerating`** — `hottestPlausibleTemperature()` (plausible-max over N readings; out-param untouched on reject) and `thermalDeratingStep()` (warn/eco/cut pass; **holds every stage on telemetry dropout** — the deliberate asymmetry vs the battery ladder's timer reset, now unit-locked; returns "cut released this pass").
- The `.ino` keeps `tempStageUpdate` / `hottestMotorTemp` / `thermalUpdate` as delegate shims — **all 28 existing test references untouched**. Shims own the boundary work: clock read (time is a parameter), `telem[]` → `ThermalReading` flattening (per-ESC validity mirrored to both sensors — comparison-identical to the original per-ESC loop), stage-global mirroring, and `BEEP_THERM_RESTORED` queued on the domain's cut-released return (`[BEEPER]` stays application-side, same treatment as `lowVoltLatched` in #154).
- Thresholds/bounds stay in `[CONFIG]`, passed as parameters. The three independent stage bools are kept verbatim; the target glossary's `ThermalStage` enum is a later consolidation, not this step.
- Applied the #155 review lesson up front: `hot` is initialized before the unconditional pass into the domain step (no indeterminate read on the dropout path).
- Accepted non-observable delta (same as #154, logged in DECISION-LOG): the shim reads `millis()` and builds the reading array unconditionally where the original early-returned on dropout.
- New pure-domain suite `tests/thermal/test_thermal_domain.cpp` (8 cases, compiled WITHOUT `-Istubs`): exact debounce boundary, drop-back timer reset, hysteresis hold incl. exactly-OFF, immediate release, plausible-hottest selection with inclusive band edges, dropout-holds-everything (timers included), cut-released firing exactly once per edge, stage independence at 86 °C.

**Behavior preservation:** zero expectation changes; full host suite green before and after; flash 116688 (+200: cross-TU calls + state mirror), RAM 9812 unchanged.

Docs synced same-PR: DECISION-LOG entry, TESTING.md tree, wiki notes (thermal-derating, architecture-remediation), CLAUDE.md file map.

**Role tag:** `[C-Builder]`

## Test plan

- [x] `wsl -e make -C tests run` green — characterization + invariants + battery + new thermal suite, zero expectation changes
- [x] `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` clean — flash 116688 (+200), RAM 9812 unchanged
- [x] `python scripts/check_architecture.py` OK (expected migration-window NOTE)
- [x] Pre-commit gate passed (suite + sketch-change-with-test-change)
- [ ] CI: all workflows green
- [ ] Bench: none applicable (pure move, no hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thermal protection logic for warning, eco, and cutback stages.
  * Thermal protection now evaluates valid sensor readings, applies hysteresis and debounce timing, and preserves stage state during data dropouts.
  * Added a one-time notification when thermal cutback is released.

* **Bug Fixes**
  * Improved handling of missing, invalid, and out-of-range temperature readings.
  * Prevented uninitialized temperature output values.

* **Tests**
  * Added comprehensive coverage for thermal thresholds, debounce timing, sensor filtering, dropout behavior, and stage transitions.

* **Documentation**
  * Updated architecture, testing, and thermal derating documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->