### PR TITLE
V7.35: extract TelemetryScaling to src/telemetry/ (#160, Phase D step 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,7 @@ sketches/rc_test/rc_test.ino             — Main Arduino sketch (version: FIRMW
 sketches/rc_test/types.h                 — Shared structs (JoystickState, EscTelem, ...)
 sketches/rc_test/src/domain/battery/     — Extracted domain (#117): BatteryTypes.h + VoltagePlausibility.h/.cpp + BatteryLadder.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/thermal/     — Extracted domain (#117): ThermalTypes.h + ThermalHysteresis.h/.cpp + ThermalDerating.h/.cpp (pure logic, host-testable)
+sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (X.BUS register decode + ×10 wire encode, header-only)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit
 sketches/telem_check/telem_check.ino     — Read-only X.BUS telemetry bench tool (0x50 framing)

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,23 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-12 — Phase D step 4: TelemetryScaling extracted to src/telemetry/ (#160)
+
+- The X.BUS register decode math from `[TELEMETRY]` `telemApplyReg()`
+  (VBAT ×0.1 V; IBUS ×0.1 A signed; MSPEED signed electrical Hz; TESC/TMOT
+  low byte − 40 °C; the EMA fold) and the compact wire encode from `[WIFI]`
+  `buildTelemJson()` (volts/amps → deci-integers via `lroundf(v*10)`,
+  temperatures → whole °C, electrical Hz ×30 → dashboard RPM) moved to
+  header-only `src/telemetry/TelemetryScaling.h` — first file in the
+  observer `telemetry/` layer; the two `.ino` functions stay as callers
+  delegating each expression. Observable behavior and wire format preserved
+  exactly.
+- Verified: all 20 host binaries green (new `tests/telemetry/` pure suite:
+  register signedness, low-byte temperature mask, EMA seeding, half-away-
+  from-zero deci rounding), zero expectation changes; compile clean — flash
+  116688 BYTE-IDENTICAL to pre-change (inline header functions), RAM 9812
+  unchanged. No bench check applicable (pure move).
+
 ## 2026-07-12 — Phase D step 3: thermal ladder extracted to src/domain/thermal/ (#158)
 
 - `tempStageUpdate()` / `hottestMotorTemp()` / `thermalUpdate()` staging

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -37,8 +37,10 @@ tests/
 ├── battery/                    pure-domain suites for src/domain/battery/ (#117)
 │   ├── test_voltage_plausibility.cpp
 │   └── test_battery_ladder_domain.cpp
-└── thermal/                    pure-domain suite for src/domain/thermal/ (#117)
-    └── test_thermal_domain.cpp
+├── thermal/                    pure-domain suite for src/domain/thermal/ (#117)
+│   └── test_thermal_domain.cpp
+└── telemetry/                  pure suite for src/telemetry/ (#117)
+    └── test_telemetry_scaling.cpp
 ```
 
 The stub headers shadow the real Arduino/library headers via include order

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -18,9 +18,11 @@ drive exactly as before.
   voltage-plausibility gate and its two staged state machines (Eco lock,
   cutoff + boot gate) live in `src/domain/battery/`; the
   [thermal derating](thermal-derating.md) hysteresis stage, hottest-sensor
-  selection, and warn/eco/cut staging live in `src/domain/thermal/`. All
-  pure logic — no Arduino includes, time passed as a parameter, host-tested
-  directly; the sketch keeps thin delegates until the composition root lands
+  selection, and warn/eco/cut staging live in `src/domain/thermal/`; the
+  [X.BUS telemetry](xbus-telemetry.md) register-decode and ×10 wire-encode
+  scaling lives in `src/telemetry/` (observer layer). All pure logic — no
+  Arduino includes, time passed as a parameter, host-tested directly; the
+  sketch keeps thin delegates until the composition root lands
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -61,13 +61,14 @@
 #include "types.h"
 #include "web_page.h"   // const char INDEX_HTML[] — the dashboard, served at "/"
 
-// Phase D extraction (#117): pure domain logic lives under src/domain/ and is
-// included here directly until the FirmwareApp composition root lands
-// (migration window, #150).
+// Phase D extraction (#117): pure extracted logic lives under src/ (domain/
+// and observer layers) and is included here directly until the FirmwareApp
+// composition root lands (migration window, #150).
 #include "src/domain/battery/VoltagePlausibility.h"
 #include "src/domain/battery/BatteryLadder.h"
 #include "src/domain/thermal/ThermalHysteresis.h"
 #include "src/domain/thermal/ThermalDerating.h"
+#include "src/telemetry/TelemetryScaling.h"
 
 
 // Second hardware UART on D11=TX(pin 11) / D12=RX(pin 12) via SCI0.
@@ -758,32 +759,33 @@ void telemSendRequest(uint8_t esc) {
   telRxLen = 0;
 }
 
-// Fold one register value into the telem struct for ESC index e.
+// Fold one register value into the telem struct for ESC index e. Scaling and
+// EMA math extracted to src/telemetry/TelemetryScaling.h (#117 step 4, #160).
 void telemApplyReg(uint8_t e, uint8_t reg, uint16_t raw) {
   EscTelem *t = &telem[e];
   bool first = !t->valid;
   switch (reg) {
     case REG_VBAT: {
-      float v = raw * 0.1f;
-      t->voltage = first ? v : t->voltage + TELEM_A_VOLT * (v - t->voltage);
+      float v = vbatRawToVolts(raw);
+      t->voltage = emaFold(t->voltage, v, TELEM_A_VOLT, first);
       break;
     }
     case REG_IBUS: {
-      float a = (int16_t)raw * 0.1f;
-      t->busCurrentA = first ? a : t->busCurrentA + TELEM_A_CURR * (a - t->busCurrentA);
+      float a = busCurrentRawToAmps(raw);
+      t->busCurrentA = emaFold(t->busCurrentA, a, TELEM_A_CURR, first);
       break;
     }
     case REG_MSPEED:
-      t->rpmHz = (int16_t)raw;                 // instantaneous
+      t->rpmHz = motorSpeedRawToElectricalHz(raw);  // instantaneous
       break;
     case REG_TESC: {
-      float c = (float)(raw & 0xFF) - 40.0f;   // temp is the low byte, raw − 40
-      t->escTempC = first ? c : t->escTempC + TELEM_A_TEMP * (c - t->escTempC);
+      float c = temperatureRawToCelsius(raw);       // temp is the low byte, raw − 40
+      t->escTempC = emaFold(t->escTempC, c, TELEM_A_TEMP, first);
       break;
     }
     case REG_TMOT: {
-      float c = (float)(raw & 0xFF) - 40.0f;
-      t->motorTempC = first ? c : t->motorTempC + TELEM_A_TEMP * (c - t->motorTempC);
+      float c = temperatureRawToCelsius(raw);
+      t->motorTempC = emaFold(t->motorTempC, c, TELEM_A_TEMP, first);
       break;
     }
   }
@@ -1250,12 +1252,14 @@ int buildTelemJson(char *body, size_t cap) {
     ecoLockLatched ? 1 : 0, batteryCutoffLatched ? 1 : 0,
     tempWarnActive ? 1 : 0, tempEcoActive ? 1 : 0, tempCutActive ? 1 : 0,
     outL, outR,
-    telem[0].valid ? 1 : 0, (unsigned long)age0, (long)telem[0].rpmHz * 30,
-    (int)lroundf(telem[0].busCurrentA * 10.0f), (int)lroundf(telem[0].voltage * 10.0f),
-    (int)lroundf(telem[0].escTempC), (int)lroundf(telem[0].motorTempC),
-    telem[1].valid ? 1 : 0, (unsigned long)age1, (long)telem[1].rpmHz * 30,
-    (int)lroundf(telem[1].busCurrentA * 10.0f), (int)lroundf(telem[1].voltage * 10.0f),
-    (int)lroundf(telem[1].escTempC), (int)lroundf(telem[1].motorTempC));
+    telem[0].valid ? 1 : 0, (unsigned long)age0,
+    electricalHzToDashboardRpm(telem[0].rpmHz),
+    scaleToDeciInteger(telem[0].busCurrentA), scaleToDeciInteger(telem[0].voltage),
+    roundToWholeInteger(telem[0].escTempC), roundToWholeInteger(telem[0].motorTempC),
+    telem[1].valid ? 1 : 0, (unsigned long)age1,
+    electricalHzToDashboardRpm(telem[1].rpmHz),
+    scaleToDeciInteger(telem[1].busCurrentA), scaleToDeciInteger(telem[1].voltage),
+    roundToWholeInteger(telem[1].escTempC), roundToWholeInteger(telem[1].motorTempC));
   // snprintf returns the length it WOULD have written; clamp to the buffer so
   // callers never read past `body` (Content-Length and write length stay valid
   // even if a frame were ever to overflow `cap`).

--- a/sketches/rc_test/src/telemetry/TelemetryScaling.h
+++ b/sketches/rc_test/src/telemetry/TelemetryScaling.h
@@ -23,7 +23,7 @@ inline int16_t motorSpeedRawToElectricalHz(uint16_t raw) {  // REG_MSPEED 0x02, 
   return (int16_t)raw;
 }
 
-inline float temperatureRawToCelsius(uint16_t raw) { // REG_TESC/TMOT: low byte, raw − 40
+inline float temperatureRawToCelsius(uint16_t raw) {  // REG_TESC/TMOT: low byte, raw − 40
   return (float)(raw & 0xFF) - 40.0f;
 }
 

--- a/sketches/rc_test/src/telemetry/TelemetryScaling.h
+++ b/sketches/rc_test/src/telemetry/TelemetryScaling.h
@@ -1,0 +1,49 @@
+// telemetry/TelemetryScaling.h — pure telemetry scaling math (#117 step 4,
+// #160). Extracted VERBATIM from rc_test.ino: the X.BUS register decode in
+// [TELEMETRY] telemApplyReg() and the compact-integer wire encode in [WIFI]
+// buildTelemJson(). Header-only observer-layer helpers: no Arduino includes,
+// no state — the ONE implementation of the ×10 wire scaling (the dashboard
+// JS divides by 10 on its side; that mapping is documented at the encoder).
+#pragma once
+
+#include <stdint.h>
+#include <math.h>
+
+// ── X.BUS register decode: raw register value → engineering units ────────
+
+inline float vbatRawToVolts(uint16_t raw) {          // REG_VBAT 0x0C, ×0.1 V
+  return raw * 0.1f;
+}
+
+inline float busCurrentRawToAmps(uint16_t raw) {     // REG_IBUS 0x0D, ×0.1 A signed
+  return (int16_t)raw * 0.1f;
+}
+
+inline int16_t motorSpeedRawToElectricalHz(uint16_t raw) {  // REG_MSPEED 0x02, signed
+  return (int16_t)raw;
+}
+
+inline float temperatureRawToCelsius(uint16_t raw) { // REG_TESC/TMOT: low byte, raw − 40
+  return (float)(raw & 0xFF) - 40.0f;
+}
+
+// Exponential moving average fold; the first sample seeds the average.
+inline float emaFold(float previous, float sample, float alpha, bool first) {
+  return first ? sample : previous + alpha * (sample - previous);
+}
+
+// ── wire encode: engineering units → compact SSE/JSON integers ───────────
+// Compact keys and integer values are a deliberate bandwidth decision on the
+// SSE frame budget (naming rules, exception 4).
+
+inline int scaleToDeciInteger(float value) {         // volts/amps → tenths
+  return (int)lroundf(value * 10.0f);
+}
+
+inline int roundToWholeInteger(float value) {        // temperatures → whole °C
+  return (int)lroundf(value);
+}
+
+inline long electricalHzToDashboardRpm(int16_t electricalHz) {
+  return (long)electricalHz * 30;
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,7 +32,8 @@ HARNESS  := $(wildcard stubs/*.h) characterization/FirmwareUnderTest.h \
 TESTS := $(wildcard characterization/test_*.cpp) \
          $(wildcard invariants/test_*.cpp) \
          $(wildcard battery/test_*.cpp) \
-         $(wildcard thermal/test_*.cpp)
+         $(wildcard thermal/test_*.cpp) \
+         $(wildcard telemetry/test_*.cpp)
 BINS  := $(addprefix build/,$(notdir $(TESTS:.cpp=)))
 
 # A duplicate basename across suite directories would silently shadow one
@@ -61,6 +62,10 @@ build/%: battery/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 
 build/%: thermal/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
+	@mkdir -p build
+	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+
+build/%: telemetry/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 

--- a/tests/telemetry/test_telemetry_scaling.cpp
+++ b/tests/telemetry/test_telemetry_scaling.cpp
@@ -1,0 +1,53 @@
+// Pure suite (#117 step 4, #160): src/telemetry/TelemetryScaling.h tested
+// directly on the host — no firmware, no stubs. End-to-end behavior through
+// telemApplyReg()/buildTelemJson() stays covered by
+// tests/characterization/test_telemetry_parse.cpp; this suite locks the
+// scaling contracts at the unit level: register signedness, the low-byte
+// temperature mask and −40 offset, EMA seeding, and the exact integer
+// rounding the wire format carries.
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include "../../sketches/rc_test/src/telemetry/TelemetryScaling.h"
+
+TEST_CASE("VBAT decode: unsigned tenths of a volt") {
+  CHECK(vbatRawToVolts(126) == doctest::Approx(12.6f));
+  CHECK(vbatRawToVolts(0) == doctest::Approx(0.0f));
+}
+
+TEST_CASE("IBUS decode is SIGNED: regenerative current reads negative") {
+  CHECK(busCurrentRawToAmps(105) == doctest::Approx(10.5f));
+  CHECK(busCurrentRawToAmps((uint16_t)0xFFF6) == doctest::Approx(-1.0f));
+}
+
+TEST_CASE("motor speed decode is SIGNED electrical Hz") {
+  CHECK(motorSpeedRawToElectricalHz(200) == 200);
+  CHECK(motorSpeedRawToElectricalHz((uint16_t)0xFF9C) == -100);
+}
+
+TEST_CASE("temperature decode: low byte only, raw minus 40") {
+  CHECK(temperatureRawToCelsius(65) == doctest::Approx(25.0f));
+  CHECK(temperatureRawToCelsius(40) == doctest::Approx(0.0f));
+  // A dirty high byte must not leak into the temperature.
+  CHECK(temperatureRawToCelsius(0xAB41) == doctest::Approx(25.0f));
+}
+
+TEST_CASE("EMA fold: first sample seeds; later samples blend by alpha") {
+  CHECK(emaFold(999.0f, 12.6f, 0.2f, true) == doctest::Approx(12.6f));
+  CHECK(emaFold(10.0f, 20.0f, 0.25f, false) == doctest::Approx(12.5f));
+  CHECK(emaFold(12.5f, 12.5f, 0.25f, false) == doctest::Approx(12.5f));
+}
+
+TEST_CASE("wire encode: deci-integers round half away from zero (lroundf)") {
+  CHECK(scaleToDeciInteger(12.6f) == 126);
+  CHECK(scaleToDeciInteger(12.25f) == 123);   // 122.5 exactly → away from zero
+  CHECK(scaleToDeciInteger(-1.25f) == -13);   // -12.5 exactly → away from zero
+  CHECK(scaleToDeciInteger(0.0f) == 0);
+}
+
+TEST_CASE("wire encode: whole-degree rounding and Hz-to-RPM factor") {
+  CHECK(roundToWholeInteger(84.5f) == 85);
+  CHECK(roundToWholeInteger(-0.5f) == -1);
+  CHECK(electricalHzToDashboardRpm(100) == 3000L);
+  CHECK(electricalHzToDashboardRpm(-50) == -1500L);
+}


### PR DESCRIPTION
Closes #160

## Summary

Phase D step 4 (#117, epic #116): the telemetry scaling math moves VERBATIM into header-only `src/telemetry/TelemetryScaling.h` — the first file in the target's observer `telemetry/` layer.

- **Register decode** (from `[TELEMETRY]` `telemApplyReg()`): `vbatRawToVolts` (×0.1 V), `busCurrentRawToAmps` (×0.1 A, signed), `motorSpeedRawToElectricalHz` (signed), `temperatureRawToCelsius` (low byte − 40), and `emaFold` (first-sample seeding).
- **Wire encode** (from `[WIFI]` `buildTelemJson()`) — the target's "×10 integer scaling — ONE implementation": `scaleToDeciInteger` (`lroundf(v*10)`), `roundToWholeInteger`, `electricalHzToDashboardRpm` (×30).
- `telemApplyReg` and `buildTelemJson` stay in the `.ino` as callers delegating each expression — call sites, the SSE/JSON wire format, and all test expectations unchanged. Full `JsonEncoder`/`CsvEncoder` extraction waits for `SystemSnapshot` (#132), as scoped in the issue.
- New pure suite `tests/telemetry/test_telemetry_scaling.cpp` (7 cases, no stubs): register signedness (negative regen current, negative Hz), the low-byte temperature mask with a dirty high byte, −40 offset, EMA seeding/blending, half-away-from-zero deci rounding at exact .5 boundaries, Hz→RPM factor.
- Architecture-fitness now exercises a non-domain layer for the first time (`telemetry` may include telemetry/domain/config) — OK with the expected migration-window NOTE.

**Behavior preservation:** all 20 host binaries green with zero expectation changes; **flash 116688 bytes BYTE-IDENTICAL to pre-change** (header-only inline functions), RAM 9812 unchanged — the strongest flash-equivalence evidence of the extraction series.

Docs synced same-PR: DECISION-LOG entry, TESTING.md tree, wiki architecture-remediation note, CLAUDE.md file map.

**Role tag:** `[C-Builder]`

## Test plan

- [x] `wsl -e make -C tests run` — all 20 binaries green, zero expectation changes
- [x] `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` — flash 116688 byte-identical, RAM unchanged
- [x] `python scripts/check_architecture.py` OK (expected migration-window NOTE)
- [x] Pre-commit gate passed
- [ ] CI: all workflows green
- [ ] Bench: none applicable (pure move, no hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
