### PR TITLE
V7.35: extract ExpoCurve + DeadbandPolicy to src/domain/operator_input/ (#162, Phase D step 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,7 @@ sketches/rc_test/rc_test.ino             — Main Arduino sketch (version: FIRMW
 sketches/rc_test/types.h                 — Shared structs (JoystickState, EscTelem, ...)
 sketches/rc_test/src/domain/battery/     — Extracted domain (#117): BatteryTypes.h + VoltagePlausibility.h/.cpp + BatteryLadder.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/thermal/     — Extracted domain (#117): ThermalTypes.h + ThermalHysteresis.h/.cpp + ThermalDerating.h/.cpp (pure logic, host-testable)
+sketches/rc_test/src/domain/operator_input/ — Extracted domain (#117): ExpoCurve.h/.cpp + DeadbandPolicy.h/.cpp (pure input shaping, host-testable)
 sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (X.BUS register decode + ×10 wire encode, header-only)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,28 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-12 — Phase D step 5: ExpoCurve + DeadbandPolicy extracted to src/domain/operator_input/ (#162)
+
+- `expoCurve()` moved from `[JOYSTICK]` to
+  `src/domain/operator_input/ExpoCurve.h/.cpp` with the SAME name and
+  signature — the `.ino` definition was removed and every call site
+  (including the characterization tests) resolves to the domain
+  implementation directly; weights stay `[CONFIG]` parameters.
+- `rcDeadband()` / `joyDeadband()` now delegate to one parameterized
+  `centerSnapDeadband(value, center, width)` in `DeadbandPolicy.h/.cpp` —
+  the two originals were the identical comparison with different constants.
+  Arduino's `abs()` macro is expanded manually in the domain (equivalent
+  for every reachable servo-µs/ADC value).
+- Deliberately deferred: `InputNormalization` (entangled with
+  `currentGear`/`reverseCap()` → extracts with GearPolicy/CommandMixer) and
+  `sbusToServo()` (S.BUS protocol mapping on Arduino `map()` — reimplementing
+  `map()` risks integer-rounding drift; infrastructure adapter territory).
+- Verified: all 21 host binaries green (new `tests/operator_input/` suite:
+  exact [CONFIG] weight-pair math at 0/0.5/1, magnitude-only symmetry,
+  inclusive band edges for both RC and joystick parameterizations), zero
+  expectation changes; compile clean — flash 116736 (+48 vs 116688,
+  cross-TU calls), RAM unchanged 9812. No bench check applicable.
+
 ## 2026-07-12 — Phase D step 4: TelemetryScaling extracted to src/telemetry/ (#160)
 
 - The X.BUS register decode math from `[TELEMETRY]` `telemApplyReg()`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -39,8 +39,10 @@ tests/
 │   └── test_battery_ladder_domain.cpp
 ├── thermal/                    pure-domain suite for src/domain/thermal/ (#117)
 │   └── test_thermal_domain.cpp
-└── telemetry/                  pure suite for src/telemetry/ (#117)
-    └── test_telemetry_scaling.cpp
+├── telemetry/                  pure suite for src/telemetry/ (#117)
+│   └── test_telemetry_scaling.cpp
+└── operator_input/             pure-domain suite for src/domain/operator_input/ (#117)
+    └── test_operator_input_domain.cpp
 ```
 
 The stub headers shadow the real Arduino/library headers via include order

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -20,9 +20,11 @@ drive exactly as before.
   [thermal derating](thermal-derating.md) hysteresis stage, hottest-sensor
   selection, and warn/eco/cut staging live in `src/domain/thermal/`; the
   [X.BUS telemetry](xbus-telemetry.md) register-decode and ×10 wire-encode
-  scaling lives in `src/telemetry/` (observer layer). All pure logic — no
-  Arduino includes, time passed as a parameter, host-tested directly; the
-  sketch keeps thin delegates until the composition root lands
+  scaling lives in `src/telemetry/` (observer layer); the operator-input
+  expo curve and center-snap deadband live in `src/domain/operator_input/`.
+  All pure logic — no Arduino includes, time passed as a parameter,
+  host-tested directly; the sketch keeps thin delegates until the
+  composition root lands
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -68,6 +68,8 @@
 #include "src/domain/battery/BatteryLadder.h"
 #include "src/domain/thermal/ThermalHysteresis.h"
 #include "src/domain/thermal/ThermalDerating.h"
+#include "src/domain/operator_input/ExpoCurve.h"
+#include "src/domain/operator_input/DeadbandPolicy.h"
 #include "src/telemetry/TelemetryScaling.h"
 
 
@@ -478,8 +480,10 @@ int sbusToServo(int raw) {
   return map(constrain(raw, SBUS_MIN, SBUS_MAX), SBUS_MIN, SBUS_MAX, SVMIN, SVMAX);
 }
 
+// Deadband math extracted to src/domain/operator_input/DeadbandPolicy.*
+// (#117 step 5, #162); this delegate keeps every call site unchanged.
 int rcDeadband(int pw) {
-  return (abs(pw - SVC) <= RC_DEADBAND) ? SVC : pw;
+  return centerSnapDeadband(pw, SVC, RC_DEADBAND);
 }
 
 int rcThrottle() { return sbusValid ? rcDeadband(sbusToServo(sbusData.ch[SBUS_CH_THR]))   : SVC; }
@@ -542,13 +546,12 @@ void updateGear() {
 // [JOYSTICK] — ADC, deadband, expo curve
 // ═══════════════════════════════════════════════════════════════
 
-float expoCurve(float x, float linearW, float cubicW) {
-  float a = fabsf(x);
-  return linearW * a + cubicW * a * a * a;
-}
+// expoCurve() now lives in src/domain/operator_input/ExpoCurve.* (#117
+// step 5, #162) — same name and signature, so every call site (and the
+// characterization tests) resolves to the domain implementation directly.
 
 int joyDeadband(int adc) {
-  return (abs(adc - ADC_CENTER) <= JOY_DEADBAND) ? ADC_CENTER : adc;
+  return centerSnapDeadband(adc, ADC_CENTER, JOY_DEADBAND);
 }
 
 JoystickState cachedJoy = {ADC_CENTER, ADC_CENTER, 0.0f, 0.0f};

--- a/sketches/rc_test/src/domain/operator_input/DeadbandPolicy.cpp
+++ b/sketches/rc_test/src/domain/operator_input/DeadbandPolicy.cpp
@@ -1,0 +1,13 @@
+// domain/operator_input — center-snap deadband (#117 step 5, #162).
+// Logic from rc_test.ino [RC] rcDeadband() / [JOYSTICK] joyDeadband() —
+// identical comparisons; Arduino's abs() macro is expanded manually here
+// (equivalent for every reachable servo-µs/ADC value). Behavior is locked
+// by tests/characterization/test_input_shaping.cpp and
+// tests/operator_input/test_operator_input_domain.cpp.
+#include "DeadbandPolicy.h"
+
+int centerSnapDeadband(int value, int center, int width) {
+  int offset = value - center;
+  if (offset < 0) offset = -offset;
+  return (offset <= width) ? center : value;
+}

--- a/sketches/rc_test/src/domain/operator_input/DeadbandPolicy.h
+++ b/sketches/rc_test/src/domain/operator_input/DeadbandPolicy.h
@@ -1,0 +1,9 @@
+// domain/operator_input — center-snap deadband (#117 step 5, #162).
+// The shared math of rc_test.ino's rcDeadband() (servo µs) and
+// joyDeadband() (ADC counts) — identical integer logic, parameterized.
+// Pure domain: center and width arrive as parameters ([CONFIG] owns them).
+#pragma once
+
+// Snaps value to center while within ±width of it (inclusive); passes the
+// value through untouched otherwise.
+int centerSnapDeadband(int value, int center, int width);

--- a/sketches/rc_test/src/domain/operator_input/ExpoCurve.cpp
+++ b/sketches/rc_test/src/domain/operator_input/ExpoCurve.cpp
@@ -1,0 +1,12 @@
+// domain/operator_input — exponential input curve (#117 step 5, #162).
+// Logic copied VERBATIM from rc_test.ino [JOYSTICK]; behavior is locked by
+// tests/characterization/test_input_shaping.cpp and
+// tests/operator_input/test_operator_input_domain.cpp.
+#include "ExpoCurve.h"
+
+#include <math.h>
+
+float expoCurve(float x, float linearWeight, float cubicWeight) {
+  float a = fabsf(x);
+  return linearWeight * a + cubicWeight * a * a * a;
+}

--- a/sketches/rc_test/src/domain/operator_input/ExpoCurve.h
+++ b/sketches/rc_test/src/domain/operator_input/ExpoCurve.h
@@ -1,0 +1,10 @@
+// domain/operator_input — exponential input curve (#117 step 5, #162).
+// Extracted VERBATIM from rc_test.ino [JOYSTICK] expoCurve(). Pure domain:
+// no Arduino includes; weights arrive as parameters ([CONFIG] owns the
+// throttle/steering pairs).
+#pragma once
+
+// Magnitude-only expo shaping: linearWeight·|x| + cubicWeight·|x|³.
+// The CALLER applies the sign (and any direction/gain factors) — this
+// function never returns a negative value.
+float expoCurve(float x, float linearWeight, float cubicWeight);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -33,7 +33,8 @@ TESTS := $(wildcard characterization/test_*.cpp) \
          $(wildcard invariants/test_*.cpp) \
          $(wildcard battery/test_*.cpp) \
          $(wildcard thermal/test_*.cpp) \
-         $(wildcard telemetry/test_*.cpp)
+         $(wildcard telemetry/test_*.cpp) \
+         $(wildcard operator_input/test_*.cpp)
 BINS  := $(addprefix build/,$(notdir $(TESTS:.cpp=)))
 
 # A duplicate basename across suite directories would silently shadow one
@@ -66,6 +67,10 @@ build/%: thermal/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 
 build/%: telemetry/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
+	@mkdir -p build
+	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+
+build/%: operator_input/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 

--- a/tests/operator_input/test_operator_input_domain.cpp
+++ b/tests/operator_input/test_operator_input_domain.cpp
@@ -1,0 +1,64 @@
+// Pure-domain suite (#117 step 5, #162): src/domain/operator_input tested
+// directly on the host — no firmware, no stubs, weights/centers/widths
+// passed explicitly. End-to-end behavior through rcDeadband()/joyDeadband()
+// and the joystick expo path stays covered by
+// tests/characterization/test_input_shaping.cpp; this suite locks the
+// extracted math at the unit level, including the exact [CONFIG] weight
+// pairs and both deadband parameterizations.
+// (Basename differs from characterization/test_input_shaping.cpp — the flat
+// build/ directory forbids duplicate test basenames.)
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include "../../sketches/rc_test/src/domain/operator_input/DeadbandPolicy.h"
+#include "../../sketches/rc_test/src/domain/operator_input/ExpoCurve.h"
+
+// Values mirror the [CONFIG] pairs — parameters here, no config dependency.
+const float EXPO_THROTTLE_LINEAR = 0.4f;
+const float EXPO_THROTTLE_CUBIC  = 0.6f;
+const float EXPO_STEER_LINEAR    = 0.7f;
+const float EXPO_STEER_CUBIC     = 0.3f;
+
+TEST_CASE("expo curve endpoints: zero stays zero, full stick reaches the weight sum") {
+  CHECK(expoCurve(0.0f, EXPO_THROTTLE_LINEAR, EXPO_THROTTLE_CUBIC)
+        == doctest::Approx(0.0f));
+  // Both config pairs sum to 1.0, so full deflection keeps full authority.
+  CHECK(expoCurve(1.0f, EXPO_THROTTLE_LINEAR, EXPO_THROTTLE_CUBIC)
+        == doctest::Approx(1.0f));
+  CHECK(expoCurve(1.0f, EXPO_STEER_LINEAR, EXPO_STEER_CUBIC)
+        == doctest::Approx(1.0f));
+}
+
+TEST_CASE("expo curve mid-stick softening matches the exact weight math") {
+  // 0.4·0.5 + 0.6·0.125 = 0.275 — throttle feels softer around center.
+  CHECK(expoCurve(0.5f, EXPO_THROTTLE_LINEAR, EXPO_THROTTLE_CUBIC)
+        == doctest::Approx(0.275f));
+  // 0.7·0.5 + 0.3·0.125 = 0.3875 — steering stays more direct.
+  CHECK(expoCurve(0.5f, EXPO_STEER_LINEAR, EXPO_STEER_CUBIC)
+        == doctest::Approx(0.3875f));
+}
+
+TEST_CASE("expo curve is magnitude-only: the caller owns the sign") {
+  CHECK(expoCurve(-0.5f, EXPO_THROTTLE_LINEAR, EXPO_THROTTLE_CUBIC)
+        == doctest::Approx(expoCurve(0.5f, EXPO_THROTTLE_LINEAR,
+                                     EXPO_THROTTLE_CUBIC)));
+  CHECK(expoCurve(-1.0f, EXPO_STEER_LINEAR, EXPO_STEER_CUBIC)
+        == doctest::Approx(1.0f));  // never negative
+}
+
+TEST_CASE("deadband snaps to center inside AND exactly at the band edge") {
+  // RC parameterization: servo µs around 1500 ± 50.
+  CHECK(centerSnapDeadband(1500, 1500, 50) == 1500);
+  CHECK(centerSnapDeadband(1550, 1500, 50) == 1500);  // edge inclusive
+  CHECK(centerSnapDeadband(1450, 1500, 50) == 1500);  // edge inclusive, low side
+  CHECK(centerSnapDeadband(1551, 1500, 50) == 1551);  // first count outside
+  CHECK(centerSnapDeadband(1449, 1500, 50) == 1449);
+}
+
+TEST_CASE("deadband holds for joystick-scale parameters too") {
+  // Joystick parameterization: 14-bit ADC counts around center ± width.
+  CHECK(centerSnapDeadband(8192 + 480, 8192, 480) == 8192);
+  CHECK(centerSnapDeadband(8192 - 480, 8192, 480) == 8192);
+  CHECK(centerSnapDeadband(8192 + 481, 8192, 480) == 8192 + 481);
+  CHECK(centerSnapDeadband(0, 8192, 480) == 0);        // full deflection passes
+}


### PR DESCRIPTION
Closes #162

## Summary

Phase D step 5 (#117, epic #116): the pure input-shaping math starts `src/domain/operator_input/`, following the pattern of #151/#154/#158/#160.

- **`ExpoCurve.h/.cpp`** — `expoCurve(x, linearWeight, cubicWeight)` moves VERBATIM with the **same name and signature**, so the `.ino` definition is simply removed and every call site — including `tests/characterization/test_input_shaping.cpp` — resolves to the domain implementation directly. No shim needed. Weights stay `[CONFIG]` parameters.
- **`DeadbandPolicy.h/.cpp`** — `rcDeadband()` (servo µs, `SVC ± RC_DEADBAND`) and `joyDeadband()` (ADC counts, `ADC_CENTER ± JOY_DEADBAND`) were the identical comparison with different constants; both now delegate to one parameterized `centerSnapDeadband(value, center, width)`. Arduino's `abs()` macro is expanded manually in the domain — equivalent for every reachable value (documented in the source).
- **Deliberately deferred** (scoped in the issue): `InputNormalization` is entangled with `currentGear`/`reverseCap()` and extracts with GearPolicy/CommandMixer (§9 steps 6–7); `sbusToServo()` rides Arduino `map()` and belongs to the infrastructure adapter — reimplementing `map()` would risk integer-rounding drift (covenant).
- New pure suite `tests/operator_input/test_operator_input_domain.cpp` (5 cases, no stubs): exact `[CONFIG]` weight-pair math at 0/0.5/1 (0.275 throttle, 0.3875 steer at half stick), magnitude-only symmetry (caller owns the sign), inclusive band edges for both RC and joystick parameterizations.

**Behavior preservation:** all 21 host binaries green, zero expectation changes; flash 116736 (+48: cross-TU calls), RAM 9812 unchanged.

Docs synced same-PR: DECISION-LOG entry, TESTING.md tree, wiki architecture-remediation note, CLAUDE.md file map.

**Role tag:** `[C-Builder]`

## Test plan

- [x] `wsl -e make -C tests run` — all 21 binaries green, zero expectation changes
- [x] `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` — flash 116736 (+48), RAM unchanged
- [x] `python scripts/check_architecture.py` OK (expected migration-window NOTE)
- [x] Pre-commit gate passed
- [ ] CI: all workflows green
- [ ] Bench: none applicable (pure move, no hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized operator-input shaping for exponential curves and center-snap deadbands.
  * RC and joystick controls now use consistent deadband and expo behavior.

* **Tests**
  * Added host-based coverage for curve shaping and deadband edge cases.

* **Documentation**
  * Updated architecture, testing, decision-log, and project file-map documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->