### PR TITLE
V7.35: extract CurvatureDrive to src/domain/drive/ (#164, Phase D step 6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,7 @@ sketches/rc_test/types.h                 — Shared structs (JoystickState, EscT
 sketches/rc_test/src/domain/battery/     — Extracted domain (#117): BatteryTypes.h + VoltagePlausibility.h/.cpp + BatteryLadder.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/thermal/     — Extracted domain (#117): ThermalTypes.h + ThermalHysteresis.h/.cpp + ThermalDerating.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/operator_input/ — Extracted domain (#117): ExpoCurve.h/.cpp + DeadbandPolicy.h/.cpp (pure input shaping, host-testable)
+sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes.h + CurvatureDrive.h/.cpp (the curvature tank mix — propulsion-path core)
 sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (X.BUS register decode + ×10 wire encode, header-only)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,33 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-12 — Phase D step 6: CurvatureDrive extracted to src/domain/drive/ (#164)
+
+- The propulsion-path core `curvatureDrive()` (`[DRIVE]`) moved to
+  `src/domain/drive/CurvatureDrive.h/.cpp` as
+  `curvatureDriveStep(xSpeed, zRotation, gearScale, CurvatureParameters)`
+  over `DriveTypes.h` (`TrackCommand` — layout-identical to WheelSpeeds;
+  `CurvatureParameters` carrying pivotCap/taper/blend band/turnTrackCap).
+  The algorithm commentary (#72/#86/#96/#114 laws) moved with the code.
+- Exactly two mechanical substitutions, both float-semantics-identical:
+  Arduino's `constrain()` macro expanded as `clampFloat()` (same ternary),
+  and tunables read from the parameters struct.
+- **State-ownership sin fixed structurally**: `curvatureDrive()` was the
+  documented example of a hidden global read (`currentGear` behind the
+  parameter list). The `.ino` delegate now owns the gear read visibly —
+  `pivotCap = (currentGear == GEAR_LOW) ? PIVOT_SPEED_CAP_LOW :
+  PIVOT_SPEED_CAP` — and passes it in. Same value, same pass. The delegate
+  keeps the exact `curvatureDrive(x, z, gearScale) -> WheelSpeeds`
+  signature, so all 17 test references and both call sites are unchanged.
+- Verified: all 22 host binaries green with ZERO expectation changes — the
+  characterization suite's exact float32 expectations for pivot caps, the
+  smoothstep blend, the faded-ceiling desaturation, and reverse-steering
+  consistency pass unchanged against the extracted implementation. New
+  `tests/drive/` pure suite (7 cases) locks the laws at the unit level.
+  Compile clean — flash 116784 (+48 vs 116736, cross-TU call), RAM
+  unchanged 9812. No bench check applicable (pure move; bench
+  re-verification of the whole series remains queued for hardware return).
+
 ## 2026-07-12 — Phase D step 5: ExpoCurve + DeadbandPolicy extracted to src/domain/operator_input/ (#162)
 
 - `expoCurve()` moved from `[JOYSTICK]` to

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -41,8 +41,10 @@ tests/
 │   └── test_thermal_domain.cpp
 ├── telemetry/                  pure suite for src/telemetry/ (#117)
 │   └── test_telemetry_scaling.cpp
-└── operator_input/             pure-domain suite for src/domain/operator_input/ (#117)
-    └── test_operator_input_domain.cpp
+├── operator_input/             pure-domain suite for src/domain/operator_input/ (#117)
+│   └── test_operator_input_domain.cpp
+└── drive/                      pure-domain suite for src/domain/drive/ (#117)
+    └── test_curvature_drive_domain.cpp
 ```
 
 The stub headers shadow the real Arduino/library headers via include order

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -21,10 +21,11 @@ drive exactly as before.
   selection, and warn/eco/cut staging live in `src/domain/thermal/`; the
   [X.BUS telemetry](xbus-telemetry.md) register-decode and ×10 wire-encode
   scaling lives in `src/telemetry/` (observer layer); the operator-input
-  expo curve and center-snap deadband live in `src/domain/operator_input/`.
-  All pure logic — no Arduino includes, time passed as a parameter,
-  host-tested directly; the sketch keeps thin delegates until the
-  composition root lands
+  expo curve and center-snap deadband live in `src/domain/operator_input/`;
+  the curvature tank mix — the propulsion-path core — lives in
+  `src/domain/drive/`. All pure logic — no Arduino includes, time passed as
+  a parameter, host-tested directly; the sketch keeps thin delegates until
+  the composition root lands
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -70,6 +70,7 @@
 #include "src/domain/thermal/ThermalDerating.h"
 #include "src/domain/operator_input/ExpoCurve.h"
 #include "src/domain/operator_input/DeadbandPolicy.h"
+#include "src/domain/drive/CurvatureDrive.h"
 #include "src/telemetry/TelemetryScaling.h"
 
 
@@ -381,79 +382,20 @@ const size_t   WIFI_PAGE_CHUNK       = 1024;  // dashboard HTML bytes sent per l
 // [DRIVE] — curvatureDrive: proven FRC algorithm (WPILib)
 // ═══════════════════════════════════════════════════════════════
 
-// Gear-aware tank mix. `gearScale` (Eco/Normal/Boost) caps the AVERAGE forward
-// speed — NOT each wheel — so in a turn the outer track may use the headroom up
-// to the ESC limit (±1.0) and the turn keeps its speed instead of slowing (#72).
-// At Boost (gearScale = 1.0) there is no headroom, so the outer simply
-// desaturates at the rail (unchanged behavior). Pivot is gear-scaled so low
-// gears spin gently.
+// The curvature mix is extracted to src/domain/drive/CurvatureDrive.* (#117
+// step 6, #164) — the algorithm and its commentary (#72/#86/#96/#114) moved
+// with it. This delegate keeps the call sites and every test reference
+// unchanged, and owns the one dependency the domain must not read: the
+// gear-selected pivot cap (state-ownership rule — currentGear is read HERE,
+// visibly, instead of hidden behind the parameter list).
 WheelSpeeds curvatureDrive(float xSpeed, float zRotation, float gearScale) {
-  xSpeed    = constrain(xSpeed, -1.0f, 1.0f);
-  zRotation = constrain(zRotation, -1.0f, 1.0f);
-
-  // Pivot output: counter-rotate the tracks (capped), then gear-scale so low
-  // gears pivot gently. Eco uses a looser cap to keep usable pivot authority.
-  float pivotCap = (currentGear == GEAR_LOW) ? PIVOT_SPEED_CAP_LOW : PIVOT_SPEED_CAP;
-  float cappedRotation = constrain(zRotation, -pivotCap, pivotCap);
-  // Throttle is tapered by steering in THIS branch only (#114): while turning,
-  // low throttle no longer shoves both tracks the same way — the
-  // counter-rotation persists and decays smoothly instead of surging.
-  float pivotThr = xSpeed * (1.0f - PIVOT_THROTTLE_TAPER * fabsf(zRotation));
-  float pivotL = (pivotThr - cappedRotation) * gearScale;
-  float pivotR = (pivotThr + cappedRotation) * gearScale;
-
-  // Curvature output: the gear caps the AVERAGE (avg); an ADDITIVE steering term
-  // (delta) forms the inner/outer differential. delta's sign is set by the
-  // STEERING STICK alone — never by the throttle direction — so steering stays
-  // consistent in reverse: stick-left = nose-left going forward AND backward
-  // (#86 Part 1). The old multiply, avg*(1±|z|), scaled the differential by avg,
-  // so when avg went negative (reverse) the inner/outer swapped — that was the
-  // mid-range "steering reverses when backing up" bug. Forward is UNCHANGED:
-  // for avg ≥ 0, avg ∓ delta == avg*(1∓|z|). Peak magnitude is still
-  // |avg|+delta = |avg|·(1+|z|), so the #96 ceiling and #72 headroom are intact.
-  float avg   = xSpeed * gearScale;
-  float delta = fabsf(avg) * fabsf(zRotation);   // symmetric steering term, >= 0
-  float curvL, curvR;
-  // delta is subtracted from the track on the side we steer toward and added to
-  // the other, regardless of travel direction. Forward that means the steer-side
-  // track goes slower (the "inner" track); in reverse the same maths makes it go
-  // harder-reverse — which is what keeps the nose turning the SAME way backward.
-  // (So avoid the forward-only "inner/outer" framing when reasoning about reverse.)
-  if (zRotation > 0) {        // turn LEFT  (nose-left forward AND reverse)
-    curvL = avg - delta;     // left  track: less forward / harder reverse
-    curvR = avg + delta;     // right track: more forward / less reverse
-  } else {                    // turn RIGHT
-    curvL = avg + delta;
-    curvR = avg - delta;
-  }
-  // Outer-track ceiling fades from the ESC rail (gentle turn — both tracks moving)
-  // down to TURN_TRACK_CAP (full steer — inner track stopped). |zRotation| is the
-  // turn-sharpness signal (inner = avg*(1-|z|) → 0 at full steer), so the borrowed
-  // headroom shrinks smoothly as the inner stops — no knee, no RPM feedback (#96).
-  // Straight (|z| = 0) keeps the full rail, so straight-line throttle is unchanged.
-  // Forward AND reverse are treated symmetrically: reverseCap() bounds the reverse
-  // *average* speed upstream, and the outer track then borrows the same turn
-  // headroom forward does — so a reverse turn swings precisely instead of slowing
-  // (operator decision, 2026-06-28). No reverse-specific ceiling special-case.
-  float ceiling = 1.0f - (1.0f - TURN_TRACK_CAP) * fabsf(zRotation);
-  float peak = fmaxf(fabsf(curvL), fabsf(curvR));
-  if (peak > ceiling) {    // desaturate against the faded ceiling, preserving the turn ratio
-    float k = ceiling / peak;
-    curvL *= k;
-    curvR *= k;
-  }
-
-  // Smoothstep blend pivot → curvature as |xSpeed| grows, across a WIDE band so
-  // the pivot↔drive hand-off is gradual (no snap near low throttle, #72). Zero
-  // slope at both endpoints means the operator never feels a mode boundary.
-  float t = (fabsf(xSpeed) - PIVOT_BLEND_START) / (PIVOT_BLEND_END - PIVOT_BLEND_START);
-  t = constrain(t, 0.0f, 1.0f);
-  t = t * t * (3.0f - 2.0f * t);
-
-  return {
-    pivotL * (1.0f - t) + curvL * t,
-    pivotR * (1.0f - t) + curvR * t
-  };
+  float pivotCap = (currentGear == GEAR_LOW) ? PIVOT_SPEED_CAP_LOW
+                                             : PIVOT_SPEED_CAP;
+  TrackCommand command = curvatureDriveStep(
+      xSpeed, zRotation, gearScale,
+      CurvatureParameters{pivotCap, PIVOT_THROTTLE_TAPER, PIVOT_BLEND_START,
+                          PIVOT_BLEND_END, TURN_TRACK_CAP});
+  return {command.left, command.right};
 }
 
 ServoOutput wheelSpeedsToServo(WheelSpeeds ws) {

--- a/sketches/rc_test/src/domain/drive/CurvatureDrive.cpp
+++ b/sketches/rc_test/src/domain/drive/CurvatureDrive.cpp
@@ -1,0 +1,96 @@
+// domain/drive — curvature tank mix (#117 step 6, #164).
+// Body copied VERBATIM from rc_test.ino [DRIVE] curvatureDrive() with two
+// mechanical substitutions only: Arduino's constrain() macro expanded as
+// clampFloat() (identical ternary, identical float semantics), and the
+// tunables read from CurvatureParameters instead of [CONFIG] globals.
+// Behavior is locked by tests/characterization/test_curvature_drive.cpp,
+// test_mixer.cpp, the invariants suites, and
+// tests/drive/test_curvature_drive_domain.cpp.
+#include "CurvatureDrive.h"
+
+#include <math.h>
+
+// Arduino's constrain() macro, expanded with identical float semantics.
+static inline float clampFloat(float value, float low, float high) {
+  return (value < low) ? low : ((value > high) ? high : value);
+}
+
+TrackCommand curvatureDriveStep(float xSpeed, float zRotation,
+                                float gearScale,
+                                const CurvatureParameters& parameters) {
+  xSpeed    = clampFloat(xSpeed, -1.0f, 1.0f);
+  zRotation = clampFloat(zRotation, -1.0f, 1.0f);
+
+  // Pivot output: counter-rotate the tracks (capped), then gear-scale so low
+  // gears pivot gently. Eco uses a looser cap (the caller selects pivotCap)
+  // to keep usable pivot authority.
+  float cappedRotation = clampFloat(zRotation, -parameters.pivotCap,
+                                    parameters.pivotCap);
+  // Throttle is tapered by steering in THIS branch only (#114): while
+  // turning, low throttle no longer shoves both tracks the same way — the
+  // counter-rotation persists and decays smoothly instead of surging.
+  float pivotThr =
+      xSpeed * (1.0f - parameters.pivotThrottleTaper * fabsf(zRotation));
+  float pivotL = (pivotThr - cappedRotation) * gearScale;
+  float pivotR = (pivotThr + cappedRotation) * gearScale;
+
+  // Curvature output: the gear caps the AVERAGE (avg); an ADDITIVE steering
+  // term (delta) forms the inner/outer differential. delta's sign is set by
+  // the STEERING STICK alone — never by the throttle direction — so steering
+  // stays consistent in reverse: stick-left = nose-left going forward AND
+  // backward (#86 Part 1). The old multiply, avg*(1±|z|), scaled the
+  // differential by avg, so when avg went negative (reverse) the inner/outer
+  // swapped — that was the mid-range "steering reverses when backing up"
+  // bug. Forward is UNCHANGED: for avg ≥ 0, avg ∓ delta == avg*(1∓|z|).
+  // Peak magnitude is still |avg|+delta = |avg|·(1+|z|), so the #96 ceiling
+  // and #72 headroom are intact.
+  float avg   = xSpeed * gearScale;
+  float delta = fabsf(avg) * fabsf(zRotation);  // symmetric steering term, >= 0
+  float curvL, curvR;
+  // delta is subtracted from the track on the side we steer toward and added
+  // to the other, regardless of travel direction. Forward that means the
+  // steer-side track goes slower (the "inner" track); in reverse the same
+  // maths makes it go harder-reverse — which is what keeps the nose turning
+  // the SAME way backward. (So avoid the forward-only "inner/outer" framing
+  // when reasoning about reverse.)
+  if (zRotation > 0) {        // turn LEFT  (nose-left forward AND reverse)
+    curvL = avg - delta;      // left  track: less forward / harder reverse
+    curvR = avg + delta;      // right track: more forward / less reverse
+  } else {                    // turn RIGHT
+    curvL = avg + delta;
+    curvR = avg - delta;
+  }
+  // Outer-track ceiling fades from the ESC rail (gentle turn — both tracks
+  // moving) down to turnTrackCap (full steer — inner track stopped).
+  // |zRotation| is the turn-sharpness signal (inner = avg*(1-|z|) → 0 at
+  // full steer), so the borrowed headroom shrinks smoothly as the inner
+  // stops — no knee, no RPM feedback (#96). Straight (|z| = 0) keeps the
+  // full rail, so straight-line throttle is unchanged. Forward AND reverse
+  // are treated symmetrically: reverseCap() bounds the reverse *average*
+  // speed upstream, and the outer track then borrows the same turn headroom
+  // forward does — so a reverse turn swings precisely instead of slowing
+  // (operator decision, 2026-06-28). No reverse-specific ceiling
+  // special-case.
+  float ceiling =
+      1.0f - (1.0f - parameters.turnTrackCap) * fabsf(zRotation);
+  float peak = fmaxf(fabsf(curvL), fabsf(curvR));
+  if (peak > ceiling) {  // desaturate against the faded ceiling, preserving the turn ratio
+    float k = ceiling / peak;
+    curvL *= k;
+    curvR *= k;
+  }
+
+  // Smoothstep blend pivot → curvature as |xSpeed| grows, across a WIDE band
+  // so the pivot↔drive hand-off is gradual (no snap near low throttle, #72).
+  // Zero slope at both endpoints means the operator never feels a mode
+  // boundary.
+  float t = (fabsf(xSpeed) - parameters.pivotBlendStart) /
+            (parameters.pivotBlendEnd - parameters.pivotBlendStart);
+  t = clampFloat(t, 0.0f, 1.0f);
+  t = t * t * (3.0f - 2.0f * t);
+
+  return {
+    pivotL * (1.0f - t) + curvL * t,
+    pivotR * (1.0f - t) + curvR * t
+  };
+}

--- a/sketches/rc_test/src/domain/drive/CurvatureDrive.h
+++ b/sketches/rc_test/src/domain/drive/CurvatureDrive.h
@@ -1,0 +1,20 @@
+// domain/drive — curvature tank mix (#117 step 6, #164).
+// Extracted VERBATIM from rc_test.ino [DRIVE] curvatureDrive() — the
+// propulsion-path core (FRC/WPILib-proven algorithm: smoothstep pivot blend
+// #72, reverse-steering consistency #86, faded turn headroom #96, pivot
+// throttle taper #114). Pure domain: no Arduino includes; every tunable
+// arrives as a parameter, and the gear-selected pivotCap is passed in
+// (state-ownership rule: dependencies are visible in the signature — the
+// currentGear read lives in the caller, fixing the documented sin).
+#pragma once
+
+#include "DriveTypes.h"
+
+// Gear-aware tank mix. gearScale (Eco/Normal/Boost) caps the AVERAGE forward
+// speed — NOT each track — so in a turn the outer track may use the headroom
+// up to the ESC limit (±1.0) and the turn keeps its speed instead of slowing
+// (#72). At Boost (gearScale = 1.0) there is no headroom, so the outer simply
+// desaturates at the rail. Pivot is gear-scaled so low gears spin gently.
+TrackCommand curvatureDriveStep(float xSpeed, float zRotation,
+                                float gearScale,
+                                const CurvatureParameters& parameters);

--- a/sketches/rc_test/src/domain/drive/DriveTypes.h
+++ b/sketches/rc_test/src/domain/drive/DriveTypes.h
@@ -1,0 +1,22 @@
+// domain/drive — shared value types (#117 step 6, #164).
+// Pure domain: no Arduino includes (host-compilable by design).
+#pragma once
+
+// Per-track normalized command, -1..+1 (post-gear, pre-PWM). Layout-identical
+// to the sketch's WheelSpeeds; this is the target-glossary name the domain
+// uses.
+struct TrackCommand {
+  float left;
+  float right;
+};
+
+// The curvature-mix tunables, mirrored from [CONFIG] — parameters here: the
+// domain has no config or global dependency. pivotCap arrives PRE-SELECTED
+// for the current gear (the application layer owns the currentGear read).
+struct CurvatureParameters {
+  float pivotCap;            // pivot counter-rotation cap, gear-selected
+  float pivotThrottleTaper;  // pivot-branch throttle taper by |steering| (#114)
+  float pivotBlendStart;     // |xSpeed| where the pivot→curvature blend begins
+  float pivotBlendEnd;       // |xSpeed| where the blend reaches pure curvature
+  float turnTrackCap;        // outer-track ceiling at full steer (#96)
+};

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -34,7 +34,8 @@ TESTS := $(wildcard characterization/test_*.cpp) \
          $(wildcard battery/test_*.cpp) \
          $(wildcard thermal/test_*.cpp) \
          $(wildcard telemetry/test_*.cpp) \
-         $(wildcard operator_input/test_*.cpp)
+         $(wildcard operator_input/test_*.cpp) \
+         $(wildcard drive/test_*.cpp)
 BINS  := $(addprefix build/,$(notdir $(TESTS:.cpp=)))
 
 # A duplicate basename across suite directories would silently shadow one
@@ -71,6 +72,10 @@ build/%: telemetry/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 
 build/%: operator_input/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
+	@mkdir -p build
+	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+
+build/%: drive/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 

--- a/tests/drive/test_curvature_drive_domain.cpp
+++ b/tests/drive/test_curvature_drive_domain.cpp
@@ -1,0 +1,96 @@
+// Pure-domain suite (#117 step 6, #164): src/domain/drive/CurvatureDrive
+// tested directly on the host — no firmware, no stubs, tunables passed
+// explicitly. End-to-end behavior through the firmware's curvatureDrive()
+// delegate (including the gear-selected pivot cap) stays covered by
+// tests/characterization/test_curvature_drive.cpp and test_mixer.cpp; this
+// suite locks the algorithm's laws at the unit level: straight-line
+// identity, pivot caps as parameters, the pivot throttle taper, reverse
+// steering consistency (#86), faded-ceiling desaturation with ratio
+// preservation (#96), and the smoothstep blend endpoints (#72).
+// (Basename differs from characterization/test_curvature_drive.cpp — the
+// flat build/ directory forbids duplicate test basenames.)
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include <cmath>
+
+#include "../../sketches/rc_test/src/domain/drive/CurvatureDrive.h"
+
+// Values mirror [CONFIG] — parameters here, no config dependency.
+const CurvatureParameters NORMAL_PARAMETERS{0.60f, 0.70f, 0.05f, 0.55f, 0.70f};
+const CurvatureParameters ECO_PARAMETERS{0.725f, 0.70f, 0.05f, 0.55f, 0.70f};
+const float GEAR_ECO   = 0.65f;
+const float GEAR_BOOST = 1.00f;
+
+TEST_CASE("straight line is the identity: both tracks exactly xSpeed*gearScale") {
+  // With zRotation = 0 the pivot and curvature branches agree, the taper is
+  // inert, and the ceiling stays at the full rail — at EVERY throttle.
+  for (float xSpeed : {0.03f, 0.30f, 1.00f, -0.40f}) {
+    TrackCommand command =
+        curvatureDriveStep(xSpeed, 0.0f, GEAR_ECO, NORMAL_PARAMETERS);
+    CHECK(command.left == doctest::Approx(xSpeed * GEAR_ECO));
+    CHECK(command.right == doctest::Approx(xSpeed * GEAR_ECO));
+  }
+}
+
+TEST_CASE("pure pivot at zero throttle counter-rotates at the gear-scaled cap") {
+  TrackCommand command =
+      curvatureDriveStep(0.0f, 1.0f, GEAR_BOOST, NORMAL_PARAMETERS);
+  CHECK(command.left == doctest::Approx(-0.60f));   // cap, full left steer
+  CHECK(command.right == doctest::Approx(0.60f));
+  command = curvatureDriveStep(0.0f, -1.0f, GEAR_ECO, NORMAL_PARAMETERS);
+  CHECK(command.left == doctest::Approx(0.60f * GEAR_ECO));
+  CHECK(command.right == doctest::Approx(-0.60f * GEAR_ECO));
+}
+
+TEST_CASE("the pivot cap is a parameter: Eco's looser cap pivots harder") {
+  TrackCommand normal =
+      curvatureDriveStep(0.0f, 1.0f, GEAR_ECO, NORMAL_PARAMETERS);
+  TrackCommand eco = curvatureDriveStep(0.0f, 1.0f, GEAR_ECO, ECO_PARAMETERS);
+  CHECK(eco.right == doctest::Approx(0.725f * GEAR_ECO));
+  CHECK(eco.right > normal.right);
+}
+
+TEST_CASE("pivot throttle taper: steering bleeds throttle out of the pivot branch") {
+  // Inside the pure-pivot band (|x| <= blend start): throttle term is
+  // x*(1 - taper*|z|); at full steer that is x*0.3.
+  TrackCommand command =
+      curvatureDriveStep(0.05f, 1.0f, GEAR_BOOST, NORMAL_PARAMETERS);
+  float pivotThrottle = 0.05f * (1.0f - 0.70f);
+  CHECK(command.left == doctest::Approx(pivotThrottle - 0.60f));
+  CHECK(command.right == doctest::Approx(pivotThrottle + 0.60f));
+}
+
+TEST_CASE("#86 law: steering keeps the same nose direction in reverse") {
+  // Pure-curvature region (|x| >= blend end), stick left (z > 0): the left
+  // track must be the slower/harder-reverse one BOTH ways.
+  TrackCommand forward =
+      curvatureDriveStep(0.6f, 0.5f, GEAR_BOOST, NORMAL_PARAMETERS);
+  TrackCommand reverse =
+      curvatureDriveStep(-0.6f, 0.5f, GEAR_BOOST, NORMAL_PARAMETERS);
+  CHECK(forward.left < forward.right);
+  CHECK(reverse.left < reverse.right);   // same relation, not flipped
+}
+
+TEST_CASE("#96 law: desaturation against the faded ceiling preserves the turn ratio") {
+  // x=1, z=0.5, Boost: curv pair (0.5, 1.5); ceiling 1-(0.3)(0.5)=0.85.
+  TrackCommand command =
+      curvatureDriveStep(1.0f, 0.5f, GEAR_BOOST, NORMAL_PARAMETERS);
+  CHECK(command.right == doctest::Approx(0.85f));
+  CHECK(command.right / command.left == doctest::Approx(3.0f));  // 1.5/0.5 kept
+}
+
+TEST_CASE("#72 law: smoothstep endpoints — pure pivot below start, pure curvature past end") {
+  // At |x| = blend start the blend factor is exactly 0 (pivot only).
+  TrackCommand atStart =
+      curvatureDriveStep(0.05f, 0.2f, GEAR_BOOST, NORMAL_PARAMETERS);
+  float pivotThrottle = 0.05f * (1.0f - 0.70f * 0.2f);
+  CHECK(atStart.left == doctest::Approx(pivotThrottle - 0.2f));
+  // At |x| >= blend end the factor is exactly 1 (curvature only).
+  TrackCommand pastEnd =
+      curvatureDriveStep(0.55f, 0.2f, GEAR_BOOST, NORMAL_PARAMETERS);
+  float average = 0.55f;
+  float delta = average * 0.2f;
+  CHECK(pastEnd.left == doctest::Approx(average - delta));
+  CHECK(pastEnd.right == doctest::Approx(average + delta));
+}


### PR DESCRIPTION
Closes #164

## Summary

Phase D step 6 (#117, epic #116): **the propulsion-path core moves.** `curvatureDrive()` — smoothstep pivot blend (#72), reverse-steering consistency (#86), faded turn headroom (#96), pivot throttle taper (#114) — extracts VERBATIM to `src/domain/drive/CurvatureDrive.h/.cpp` as `curvatureDriveStep()` over `DriveTypes.h` (`TrackCommand`, layout-identical to `WheelSpeeds`; `CurvatureParameters` carrying the five tunables). The algorithm's full commentary moved with the code.

- **Exactly two mechanical substitutions**, both float-semantics-identical: Arduino's `constrain()` macro expanded as `clampFloat()` (the same ternary), and tunables read from the parameters struct instead of `[CONFIG]` globals.
- **The documented state-ownership sin is fixed structurally**: `curvatureDrive()` was the rule file's own example of a hidden global read — taking `gearScale` while secretly reading `currentGear` for the Eco pivot cap. The `.ino` delegate now owns that read visibly (`pivotCap = (currentGear == GEAR_LOW) ? PIVOT_SPEED_CAP_LOW : PIVOT_SPEED_CAP`) and passes it in. Same value, same pass, zero behavior change.
- The delegate keeps the exact `curvatureDrive(xSpeed, zRotation, gearScale) → WheelSpeeds` signature — **all 17 test references and both call sites untouched**.
- New pure suite `tests/drive/test_curvature_drive_domain.cpp` (7 cases, no stubs) locks the laws at the unit level: straight-line identity at every throttle, gear-scaled pivot caps as parameters (Eco's looser cap), the pivot throttle taper, the #86 same-nose-direction-in-reverse relation, #96 ratio-preserving desaturation against the faded ceiling (exact 0.85 / 3.0 spot values), and the #72 smoothstep endpoints.

**Behavior preservation (strictest gate of the series):** all 22 host binaries green with ZERO expectation changes — the characterization suite's exact float32 expectations for the mix pass unchanged against the extracted implementation. Flash 116784 (+48: cross-TU call), RAM 9812 unchanged.

Docs synced same-PR: DECISION-LOG entry, TESTING.md tree, wiki architecture-remediation note, CLAUDE.md file map.

**Role tag:** `[C-Builder]`

## Test plan

- [x] `wsl -e make -C tests run` — all 22 binaries green, zero expectation changes (characterization float32 laws unchanged)
- [x] `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` — flash 116784 (+48), RAM unchanged
- [x] `python scripts/check_architecture.py` OK (expected migration-window NOTE)
- [x] Pre-commit gate passed
- [ ] CI: all workflows green
- [ ] Bench: none applicable now; the extraction series' one bench re-verification pass remains queued for hardware return (BENCH-VERIFICATION-DEFERRED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
