### PR TITLE
V7.35: extract GearPolicy + CommandMixer to src/domain/drive/ (#166, Phase D step 7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,7 @@ sketches/rc_test/types.h                 — Shared structs (JoystickState, EscT
 sketches/rc_test/src/domain/battery/     — Extracted domain (#117): BatteryTypes.h + VoltagePlausibility.h/.cpp + BatteryLadder.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/thermal/     — Extracted domain (#117): ThermalTypes.h + ThermalHysteresis.h/.cpp + ThermalDerating.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/operator_input/ — Extracted domain (#117): ExpoCurve.h/.cpp + DeadbandPolicy.h/.cpp (pure input shaping, host-testable)
-sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes.h + CurvatureDrive.h/.cpp (the curvature tank mix — propulsion-path core)
+sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes.h + CurvatureDrive + GearPolicy + CommandMixer .h/.cpp (curvature mix, gear policy, RC/joystick mixer)
 sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (X.BUS register decode + ×10 wire encode, header-only)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,7 @@ sketches/rc_test/types.h                 — Shared structs (JoystickState, EscT
 sketches/rc_test/src/domain/battery/     — Extracted domain (#117): BatteryTypes.h + VoltagePlausibility.h/.cpp + BatteryLadder.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/thermal/     — Extracted domain (#117): ThermalTypes.h + ThermalHysteresis.h/.cpp + ThermalDerating.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/operator_input/ — Extracted domain (#117): ExpoCurve.h/.cpp + DeadbandPolicy.h/.cpp (pure input shaping, host-testable)
-sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes.h + CurvatureDrive + GearPolicy + CommandMixer .h/.cpp (curvature mix, gear policy, RC/joystick mixer)
+sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes.h + CurvatureDrive.h/.cpp + GearPolicy.h/.cpp + CommandMixer.h/.cpp (curvature mix, gear policy, RC/joystick mixer)
 sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (X.BUS register decode + ×10 wire encode, header-only)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,33 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-12 — Phase D step 7: GearPolicy + CommandMixer extracted to src/domain/drive/ (#166)
+
+- `updateGear()`'s decision tree moved to `GearPolicy.h/.cpp` as
+  `gearPolicySelect(gearPulse, rcValid, forceEco, parameters) →
+  GearSelection` — RC-invalid failsafe, strict CH4 thresholds, forceEco
+  (battery Eco lock OR thermal Eco) overriding last, verbatim. The
+  `reverseCap()`/`outCapToX()` helpers became parameter-visible
+  `reverseCapForGear()`/`trackCapToAxisDomain()`. The `.ino` shims own the
+  boundary reads (sbus CH4, Eco forces) and mirror `gearScale`/`currentGear`.
+- `maxOppose()` (#90) moved keeping its name/signature (definition deleted
+  from the `.ino`, like `expoCurve` in #162); `mixCommands()` delegates to
+  `mixAxisCommands()` with the `OVR_LO`/`OVR_HI` thresholds as parameters —
+  Mode 2's exact-zero rcActive compare preserved verbatim (locked law).
+- Domain `GearLevel` enum (GEAR_ECO/NORMAL/BOOST = 0/1/2) mirrors types.h's
+  `Gear` values; the correspondence is `static_assert`ed in the `.ino`, so
+  the shim casts are compile-time-proven and the SSE gear encoding is
+  untouched. New `AxisCommand` (layout-identical to `DriveCommand`) joins
+  `DriveTypes.h`.
+- Verified: all 23 host binaries green with zero expectation changes (new
+  `tests/drive/test_gear_mixer_domain.cpp`: threshold edges, failsafe and
+  forceEco dominance, per-gear reverse caps, cap-domain conversion,
+  maxOppose truth table, all three mixer modes incl. the exact-zero law).
+  Compile clean — flash 116920 (+136 vs 116784, cross-TU calls), RAM
+  unchanged 9812. Step-6 domain test scale constants renamed
+  (GEAR_ECO→GEAR_ECO_SCALE) to clear the new enum's names — test-file
+  naming only, no expectation changes.
+
 ## 2026-07-12 — Phase D step 6: CurvatureDrive extracted to src/domain/drive/ (#164)
 
 - The propulsion-path core `curvatureDrive()` (`[DRIVE]`) moved to

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -43,8 +43,9 @@ tests/
 │   └── test_telemetry_scaling.cpp
 ├── operator_input/             pure-domain suite for src/domain/operator_input/ (#117)
 │   └── test_operator_input_domain.cpp
-└── drive/                      pure-domain suite for src/domain/drive/ (#117)
-    └── test_curvature_drive_domain.cpp
+└── drive/                      pure-domain suites for src/domain/drive/ (#117)
+    ├── test_curvature_drive_domain.cpp
+    └── test_gear_mixer_domain.cpp
 ```
 
 The stub headers shadow the real Arduino/library headers via include order

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -22,10 +22,10 @@ drive exactly as before.
   [X.BUS telemetry](xbus-telemetry.md) register-decode and ×10 wire-encode
   scaling lives in `src/telemetry/` (observer layer); the operator-input
   expo curve and center-snap deadband live in `src/domain/operator_input/`;
-  the curvature tank mix — the propulsion-path core — lives in
-  `src/domain/drive/`. All pure logic — no Arduino includes, time passed as
-  a parameter, host-tested directly; the sketch keeps thin delegates until
-  the composition root lands
+  the curvature tank mix — the propulsion-path core — plus the gear policy
+  and the RC/joystick command mixer live in `src/domain/drive/`. All pure
+  logic — no Arduino includes, time passed as a parameter, host-tested
+  directly; the sketch keeps thin delegates until the composition root lands
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -71,6 +71,8 @@
 #include "src/domain/operator_input/ExpoCurve.h"
 #include "src/domain/operator_input/DeadbandPolicy.h"
 #include "src/domain/drive/CurvatureDrive.h"
+#include "src/domain/drive/GearPolicy.h"
+#include "src/domain/drive/CommandMixer.h"
 #include "src/telemetry/TelemetryScaling.h"
 
 
@@ -301,15 +303,28 @@ bool tempWarnActive = false;  // hottest sensor >= TEMP_WARN_ON_C → warning tr
 bool tempEcoActive  = false;  // hottest sensor >= TEMP_ECO_ON_C  → force Eco gear
 bool tempCutActive  = false;  // hottest sensor >= TEMP_CUT_ON_C  → cut motors (auto-recovers)
 
+// The cap helpers and gear decision tree are extracted to
+// src/domain/drive/GearPolicy.* (#117 step 7, #166); these delegates keep
+// every call site unchanged and own the global reads (gearScale,
+// currentGear) visibly. The domain GearLevel enum mirrors types.h's Gear
+// values — proven at compile time:
+static_assert((int)GEAR_LOW == (int)GEAR_ECO &&
+              (int)GEAR_MID == (int)GEAR_NORMAL &&
+              (int)GEAR_HIGH == (int)GEAR_BOOST,
+              "types.h Gear and domain GearLevel values must correspond");
+
 // Convert a MAX TRACK-OUTPUT cap (0..1) to the xSpeed domain for the current
 // gear (output = xSpeed * gearScale). Single point of truth for every cap.
-inline float outCapToX(float outCap) { return outCap / gearScale; }
+inline float outCapToX(float outCap) {
+  return trackCapToAxisDomain(outCap, gearScale);
+}
 
 // Per-gear reverse cap (#113): Eco/Normal hold 55%, Boost allows 65%. Single
 // source of truth — both rcCommand() and the joystick clamp read this, so the
 // reverse limit lives in exactly one place.
 inline float reverseCap() {
-  return (currentGear == GEAR_HIGH) ? REVERSE_CAP_BOOST : REVERSE_CAP_STD;
+  return reverseCapForGear((GearLevel)currentGear, REVERSE_CAP_STD,
+                           REVERSE_CAP_BOOST);
 }
 
 // Curvature drive — pivot/curvature blend band.
@@ -456,31 +471,19 @@ DriveCommand rcCommand() {
 // are declared up in [CONFIG] so the drive functions and curvatureDrive
 // can read them for the Eco-only conditional caps.
 
+// The decision tree is extracted to src/domain/drive/GearPolicy.* (#117
+// step 7, #166); this delegate owns the boundary reads — sbus CH4 and the
+// Eco forces (battery Eco lock #65 latched OR thermal Eco #111
+// non-latching, which clears once the motor cools below TEMP_ECO_OFF_C) —
+// and mirrors the gearScale/currentGear globals every caller reads.
 void updateGear() {
-  if (!sbusValid) {
-    gearScale = GEAR_LOW_SCALE;
-    currentGear = GEAR_LOW;
-    return;
-  }
-  int rc4 = sbusToServo(sbusData.ch[SBUS_CH_GEAR]);
-  if (rc4 < OVR_LO) {
-    gearScale = GEAR_LOW_SCALE;
-    currentGear = GEAR_LOW;
-  } else if (rc4 > OVR_HI) {
-    gearScale = GEAR_HIGH_SCALE;
-    currentGear = GEAR_HIGH;
-  } else {
-    gearScale = GEAR_MID_SCALE;
-    currentGear = GEAR_MID;
-  }
-  // Low-battery Eco lockout (#65, latched) OR motor over-temp Eco lock (#111,
-  // non-latching): force Eco regardless of the RC gear switch to ease load on a
-  // draining pack or a hot motor. The thermal lock clears on its own once the
-  // motor cools below TEMP_ECO_OFF_C.
-  if (ecoLockLatched || tempEcoActive) {
-    gearScale = GEAR_LOW_SCALE;
-    currentGear = GEAR_LOW;
-  }
+  GearSelection selection = gearPolicySelect(
+      sbusValid ? sbusToServo(sbusData.ch[SBUS_CH_GEAR]) : 0, sbusValid,
+      ecoLockLatched || tempEcoActive,
+      GearPolicyParameters{GEAR_LOW_SCALE, GEAR_MID_SCALE, GEAR_HIGH_SCALE,
+                           OVR_LO, OVR_HI});
+  gearScale = selection.scale;
+  currentGear = (Gear)selection.level;
 }
 
 
@@ -534,28 +537,18 @@ void updateJoystick(uint32_t now) {
 // [MIXER] — Override switch selects authority
 // ═══════════════════════════════════════════════════════════════
 
-// Max/oppose combine for one axis (#90): the stronger same-direction input wins
-// (NOT summed), opposing inputs subtract. result = max(a,b,0) + min(a,b,0).
-//   same dir  60% & 30% → 60%   (larger wins, no halving)
-//   opposite +100% & −30% → 70% (dominant minus opposing)
-//   single    x & 0 → x         (full range — fixes the old 50/50 halving)
-float maxOppose(float a, float b) {
-  return fmaxf(fmaxf(a, b), 0.0f) + fminf(fminf(a, b), 0.0f);
-}
-
-// Combine RC + joystick at the AXIS level (xSpeed/zRotation), per override mode.
-// curvatureDrive runs ONCE on the result (in loop), so a single operator always
-// gets full range — the old code averaged the final wheel PWMs and halved it.
+// maxOppose() (#90) and the mode selection are extracted to
+// src/domain/drive/CommandMixer.* (#117 step 7, #166) — maxOppose keeps its
+// name and signature, so call sites and tests resolve to the domain
+// directly. This delegate converts DriveCommand ↔ AxisCommand
+// (layout-identical) and passes the [CONFIG] thresholds. curvatureDrive
+// runs ONCE on the result (in loop), so a single operator always gets full
+// range — the old code averaged the final wheel PWMs and halved it.
 DriveCommand mixCommands(DriveCommand rc, int ovr, DriveCommand joy) {
-  if (ovr < OVR_LO) {            // Mode 1 — RC only
-    return rc;
-  } else if (ovr > OVR_HI) {     // Mode 3 — dual: max/oppose per axis
-    return { maxOppose(rc.xSpeed, joy.xSpeed),
-             maxOppose(rc.zRotation, joy.zRotation) };
-  } else {                        // Mode 2 — RC overrides joystick when RC active
-    bool rcActive = (rc.xSpeed != 0.0f) || (rc.zRotation != 0.0f);
-    return rcActive ? rc : joy;
-  }
+  AxisCommand mixed = mixAxisCommands(AxisCommand{rc.xSpeed, rc.zRotation},
+                                      AxisCommand{joy.xSpeed, joy.zRotation},
+                                      ovr, OVR_LO, OVR_HI);
+  return {mixed.xSpeed, mixed.zRotation};
 }
 
 

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -477,11 +477,13 @@ DriveCommand rcCommand() {
 // non-latching, which clears once the motor cools below TEMP_ECO_OFF_C) —
 // and mirrors the gearScale/currentGear globals every caller reads.
 void updateGear() {
+  // Built once — the values are [CONFIG] constants (loop() calls this every
+  // pass, so no per-pass aggregate temporary).
+  static const GearPolicyParameters GEAR_POLICY_PARAMETERS{
+      GEAR_LOW_SCALE, GEAR_MID_SCALE, GEAR_HIGH_SCALE, OVR_LO, OVR_HI};
   GearSelection selection = gearPolicySelect(
       sbusValid ? sbusToServo(sbusData.ch[SBUS_CH_GEAR]) : 0, sbusValid,
-      ecoLockLatched || tempEcoActive,
-      GearPolicyParameters{GEAR_LOW_SCALE, GEAR_MID_SCALE, GEAR_HIGH_SCALE,
-                           OVR_LO, OVR_HI});
+      ecoLockLatched || tempEcoActive, GEAR_POLICY_PARAMETERS);
   gearScale = selection.scale;
   currentGear = (Gear)selection.level;
 }

--- a/sketches/rc_test/src/domain/drive/CommandMixer.cpp
+++ b/sketches/rc_test/src/domain/drive/CommandMixer.cpp
@@ -1,0 +1,25 @@
+// domain/drive — RC/joystick command mixer (#117 step 7, #166).
+// Logic copied VERBATIM from rc_test.ino [MIXER] maxOppose()/mixCommands();
+// behavior is locked by tests/characterization/test_mixer.cpp and
+// tests/drive/test_gear_mixer_domain.cpp.
+#include "CommandMixer.h"
+
+#include <math.h>
+
+float maxOppose(float a, float b) {
+  return fmaxf(fmaxf(a, b), 0.0f) + fminf(fminf(a, b), 0.0f);
+}
+
+AxisCommand mixAxisCommands(AxisCommand rc, AxisCommand joystick,
+                            int overridePulse, int overrideLowThreshold,
+                            int overrideHighThreshold) {
+  if (overridePulse < overrideLowThreshold) {          // Mode 1 — RC only
+    return rc;
+  } else if (overridePulse > overrideHighThreshold) {  // Mode 3 — dual: max/oppose per axis
+    return { maxOppose(rc.xSpeed, joystick.xSpeed),
+             maxOppose(rc.zRotation, joystick.zRotation) };
+  } else {                       // Mode 2 — RC overrides joystick when RC active
+    bool rcActive = (rc.xSpeed != 0.0f) || (rc.zRotation != 0.0f);
+    return rcActive ? rc : joystick;
+  }
+}

--- a/sketches/rc_test/src/domain/drive/CommandMixer.h
+++ b/sketches/rc_test/src/domain/drive/CommandMixer.h
@@ -1,0 +1,22 @@
+// domain/drive — RC/joystick command mixer (#117 step 7, #166).
+// Extracted VERBATIM from rc_test.ino [MIXER]. Pure domain: the override
+// pulse and its thresholds arrive as parameters.
+#pragma once
+
+#include "DriveTypes.h"
+
+// Max/oppose combine for one axis (#90): the stronger same-direction input
+// wins (NOT summed), opposing inputs subtract.
+// result = max(a,b,0) + min(a,b,0).
+//   same dir  60% & 30% → 60%   (larger wins, no halving)
+//   opposite +100% & −30% → 70% (dominant minus opposing)
+//   single    x & 0 → x         (full range — fixes the old 50/50 halving)
+float maxOppose(float a, float b);
+
+// Combine RC + joystick at the AXIS level per override mode: pulse below
+// the low threshold → Mode 1 (RC only); above the high threshold → Mode 3
+// (dual: max/oppose per axis); between → Mode 2 (RC overrides the joystick
+// whenever RC is active — exact-zero compare is locked behavior).
+AxisCommand mixAxisCommands(AxisCommand rc, AxisCommand joystick,
+                            int overridePulse, int overrideLowThreshold,
+                            int overrideHighThreshold);

--- a/sketches/rc_test/src/domain/drive/DriveTypes.h
+++ b/sketches/rc_test/src/domain/drive/DriveTypes.h
@@ -1,6 +1,8 @@
-// domain/drive — shared value types (#117 step 6, #164).
+// domain/drive — shared value types (#117 steps 6-7, #164/#166).
 // Pure domain: no Arduino includes (host-compilable by design).
 #pragma once
+
+#include <stdint.h>
 
 // Per-track normalized command, -1..+1 (post-gear, pre-PWM). Layout-identical
 // to the sketch's WheelSpeeds; this is the target-glossary name the domain
@@ -8,6 +10,37 @@
 struct TrackCommand {
   float left;
   float right;
+};
+
+// Per-axis operator command (pre-mix, pre-curvatureDrive). Layout-identical
+// to the sketch's DriveCommand.
+struct AxisCommand {
+  float xSpeed;
+  float zRotation;
+};
+
+// Gear levels, glossary-named. Numeric values intentionally MATCH the
+// sketch's Gear enum (GEAR_LOW/MID/HIGH = 0/1/2) — the delegate shims cast
+// between them and static_assert the correspondence.
+enum GearLevel : uint8_t {
+  GEAR_ECO    = 0,
+  GEAR_NORMAL = 1,
+  GEAR_BOOST  = 2,
+};
+
+// The gear policy tunables, mirrored from [CONFIG] — parameters here.
+struct GearPolicyParameters {
+  float ecoScale;
+  float normalScale;
+  float boostScale;
+  int selectLowThreshold;   // CH4 pulse below this → Eco
+  int selectHighThreshold;  // CH4 pulse above this → Boost
+};
+
+// One gear decision: the level and its average-speed scale.
+struct GearSelection {
+  GearLevel level;
+  float scale;
 };
 
 // The curvature-mix tunables, mirrored from [CONFIG] — parameters here: the

--- a/sketches/rc_test/src/domain/drive/GearPolicy.cpp
+++ b/sketches/rc_test/src/domain/drive/GearPolicy.cpp
@@ -1,0 +1,36 @@
+// domain/drive — gear selection policy (#117 step 7, #166).
+// Logic copied VERBATIM from rc_test.ino [GEAR]; behavior is locked by
+// tests/characterization/test_gear_and_caps.cpp,
+// tests/invariants/test_invariant_gear_reverse_caps.cpp and
+// tests/drive/test_gear_mixer_domain.cpp.
+#include "GearPolicy.h"
+
+GearSelection gearPolicySelect(int gearPulse, bool rcValid, bool forceEco,
+                               const GearPolicyParameters& parameters) {
+  if (!rcValid) {
+    return {GEAR_ECO, parameters.ecoScale};
+  }
+  GearSelection selection;
+  if (gearPulse < parameters.selectLowThreshold) {
+    selection = {GEAR_ECO, parameters.ecoScale};
+  } else if (gearPulse > parameters.selectHighThreshold) {
+    selection = {GEAR_BOOST, parameters.boostScale};
+  } else {
+    selection = {GEAR_NORMAL, parameters.normalScale};
+  }
+  // Low-battery Eco lockout (#65, latched) OR motor over-temp Eco lock
+  // (#111, non-latching): force Eco regardless of the RC gear switch to
+  // ease load on a draining pack or a hot motor.
+  if (forceEco) {
+    selection = {GEAR_ECO, parameters.ecoScale};
+  }
+  return selection;
+}
+
+float reverseCapForGear(GearLevel level, float standardCap, float boostCap) {
+  return (level == GEAR_BOOST) ? boostCap : standardCap;
+}
+
+float trackCapToAxisDomain(float outputCap, float gearScale) {
+  return outputCap / gearScale;
+}

--- a/sketches/rc_test/src/domain/drive/GearPolicy.h
+++ b/sketches/rc_test/src/domain/drive/GearPolicy.h
@@ -1,0 +1,25 @@
+// domain/drive — gear selection policy (#117 step 7, #166).
+// Extracted VERBATIM from rc_test.ino [GEAR] updateGear() and the
+// reverseCap()/outCapToX() helpers. Pure domain: the RC pulse, validity,
+// safety forces and every tunable arrive as parameters (state-ownership
+// rule — the sbus/safety-flag reads live in the caller).
+#pragma once
+
+#include <stdint.h>
+
+#include "DriveTypes.h"
+
+// The gear decision tree: RC invalid → Eco (failsafe); CH4 pulse below/above
+// the thresholds → Eco/Boost; between → Normal. forceEco (battery Eco lock
+// OR thermal Eco stage) overrides last, regardless of the switch.
+GearSelection gearPolicySelect(int gearPulse, bool rcValid, bool forceEco,
+                               const GearPolicyParameters& parameters);
+
+// Per-gear reverse cap (#113): Boost allows more reverse authority than
+// Eco/Normal. Single source of truth for the reverse limit.
+float reverseCapForGear(GearLevel level, float standardCap, float boostCap);
+
+// Convert a MAX TRACK-OUTPUT cap (0..1) to the xSpeed domain for the given
+// gear scale (output = xSpeed * gearScale). Single point of truth for every
+// cap conversion.
+float trackCapToAxisDomain(float outputCap, float gearScale);

--- a/tests/drive/test_curvature_drive_domain.cpp
+++ b/tests/drive/test_curvature_drive_domain.cpp
@@ -19,35 +19,35 @@
 // Values mirror [CONFIG] — parameters here, no config dependency.
 const CurvatureParameters NORMAL_PARAMETERS{0.60f, 0.70f, 0.05f, 0.55f, 0.70f};
 const CurvatureParameters ECO_PARAMETERS{0.725f, 0.70f, 0.05f, 0.55f, 0.70f};
-const float GEAR_ECO   = 0.65f;
-const float GEAR_BOOST = 1.00f;
+const float GEAR_ECO_SCALE   = 0.65f;
+const float GEAR_BOOST_SCALE = 1.00f;
 
 TEST_CASE("straight line is the identity: both tracks exactly xSpeed*gearScale") {
   // With zRotation = 0 the pivot and curvature branches agree, the taper is
   // inert, and the ceiling stays at the full rail — at EVERY throttle.
   for (float xSpeed : {0.03f, 0.30f, 1.00f, -0.40f}) {
     TrackCommand command =
-        curvatureDriveStep(xSpeed, 0.0f, GEAR_ECO, NORMAL_PARAMETERS);
-    CHECK(command.left == doctest::Approx(xSpeed * GEAR_ECO));
-    CHECK(command.right == doctest::Approx(xSpeed * GEAR_ECO));
+        curvatureDriveStep(xSpeed, 0.0f, GEAR_ECO_SCALE, NORMAL_PARAMETERS);
+    CHECK(command.left == doctest::Approx(xSpeed * GEAR_ECO_SCALE));
+    CHECK(command.right == doctest::Approx(xSpeed * GEAR_ECO_SCALE));
   }
 }
 
 TEST_CASE("pure pivot at zero throttle counter-rotates at the gear-scaled cap") {
   TrackCommand command =
-      curvatureDriveStep(0.0f, 1.0f, GEAR_BOOST, NORMAL_PARAMETERS);
+      curvatureDriveStep(0.0f, 1.0f, GEAR_BOOST_SCALE, NORMAL_PARAMETERS);
   CHECK(command.left == doctest::Approx(-0.60f));   // cap, full left steer
   CHECK(command.right == doctest::Approx(0.60f));
-  command = curvatureDriveStep(0.0f, -1.0f, GEAR_ECO, NORMAL_PARAMETERS);
-  CHECK(command.left == doctest::Approx(0.60f * GEAR_ECO));
-  CHECK(command.right == doctest::Approx(-0.60f * GEAR_ECO));
+  command = curvatureDriveStep(0.0f, -1.0f, GEAR_ECO_SCALE, NORMAL_PARAMETERS);
+  CHECK(command.left == doctest::Approx(0.60f * GEAR_ECO_SCALE));
+  CHECK(command.right == doctest::Approx(-0.60f * GEAR_ECO_SCALE));
 }
 
 TEST_CASE("the pivot cap is a parameter: Eco's looser cap pivots harder") {
   TrackCommand normal =
-      curvatureDriveStep(0.0f, 1.0f, GEAR_ECO, NORMAL_PARAMETERS);
-  TrackCommand eco = curvatureDriveStep(0.0f, 1.0f, GEAR_ECO, ECO_PARAMETERS);
-  CHECK(eco.right == doctest::Approx(0.725f * GEAR_ECO));
+      curvatureDriveStep(0.0f, 1.0f, GEAR_ECO_SCALE, NORMAL_PARAMETERS);
+  TrackCommand eco = curvatureDriveStep(0.0f, 1.0f, GEAR_ECO_SCALE, ECO_PARAMETERS);
+  CHECK(eco.right == doctest::Approx(0.725f * GEAR_ECO_SCALE));
   CHECK(eco.right > normal.right);
 }
 
@@ -55,7 +55,7 @@ TEST_CASE("pivot throttle taper: steering bleeds throttle out of the pivot branc
   // Inside the pure-pivot band (|x| <= blend start): throttle term is
   // x*(1 - taper*|z|); at full steer that is x*0.3.
   TrackCommand command =
-      curvatureDriveStep(0.05f, 1.0f, GEAR_BOOST, NORMAL_PARAMETERS);
+      curvatureDriveStep(0.05f, 1.0f, GEAR_BOOST_SCALE, NORMAL_PARAMETERS);
   float pivotThrottle = 0.05f * (1.0f - 0.70f);
   CHECK(command.left == doctest::Approx(pivotThrottle - 0.60f));
   CHECK(command.right == doctest::Approx(pivotThrottle + 0.60f));
@@ -65,9 +65,9 @@ TEST_CASE("#86 law: steering keeps the same nose direction in reverse") {
   // Pure-curvature region (|x| >= blend end), stick left (z > 0): the left
   // track must be the slower/harder-reverse one BOTH ways.
   TrackCommand forward =
-      curvatureDriveStep(0.6f, 0.5f, GEAR_BOOST, NORMAL_PARAMETERS);
+      curvatureDriveStep(0.6f, 0.5f, GEAR_BOOST_SCALE, NORMAL_PARAMETERS);
   TrackCommand reverse =
-      curvatureDriveStep(-0.6f, 0.5f, GEAR_BOOST, NORMAL_PARAMETERS);
+      curvatureDriveStep(-0.6f, 0.5f, GEAR_BOOST_SCALE, NORMAL_PARAMETERS);
   CHECK(forward.left < forward.right);
   CHECK(reverse.left < reverse.right);   // same relation, not flipped
 }
@@ -75,7 +75,7 @@ TEST_CASE("#86 law: steering keeps the same nose direction in reverse") {
 TEST_CASE("#96 law: desaturation against the faded ceiling preserves the turn ratio") {
   // x=1, z=0.5, Boost: curv pair (0.5, 1.5); ceiling 1-(0.3)(0.5)=0.85.
   TrackCommand command =
-      curvatureDriveStep(1.0f, 0.5f, GEAR_BOOST, NORMAL_PARAMETERS);
+      curvatureDriveStep(1.0f, 0.5f, GEAR_BOOST_SCALE, NORMAL_PARAMETERS);
   CHECK(command.right == doctest::Approx(0.85f));
   CHECK(command.right / command.left == doctest::Approx(3.0f));  // 1.5/0.5 kept
 }
@@ -83,12 +83,12 @@ TEST_CASE("#96 law: desaturation against the faded ceiling preserves the turn ra
 TEST_CASE("#72 law: smoothstep endpoints — pure pivot below start, pure curvature past end") {
   // At |x| = blend start the blend factor is exactly 0 (pivot only).
   TrackCommand atStart =
-      curvatureDriveStep(0.05f, 0.2f, GEAR_BOOST, NORMAL_PARAMETERS);
+      curvatureDriveStep(0.05f, 0.2f, GEAR_BOOST_SCALE, NORMAL_PARAMETERS);
   float pivotThrottle = 0.05f * (1.0f - 0.70f * 0.2f);
   CHECK(atStart.left == doctest::Approx(pivotThrottle - 0.2f));
   // At |x| >= blend end the factor is exactly 1 (curvature only).
   TrackCommand pastEnd =
-      curvatureDriveStep(0.55f, 0.2f, GEAR_BOOST, NORMAL_PARAMETERS);
+      curvatureDriveStep(0.55f, 0.2f, GEAR_BOOST_SCALE, NORMAL_PARAMETERS);
   float average = 0.55f;
   float delta = average * 0.2f;
   CHECK(pastEnd.left == doctest::Approx(average - delta));

--- a/tests/drive/test_gear_mixer_domain.cpp
+++ b/tests/drive/test_gear_mixer_domain.cpp
@@ -1,0 +1,89 @@
+// Pure-domain suite (#117 step 7, #166): src/domain/drive GearPolicy +
+// CommandMixer tested directly on the host — no firmware, no stubs,
+// thresholds/scales passed explicitly. End-to-end behavior through
+// updateGear()/reverseCap()/outCapToX()/mixCommands() stays covered by
+// tests/characterization/test_gear_and_caps.cpp, test_mixer.cpp and
+// tests/invariants/test_invariant_gear_reverse_caps.cpp; this suite locks
+// the decision tree, the caps, the maxOppose truth table and all three
+// override modes at the unit level.
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include "../../sketches/rc_test/src/domain/drive/CommandMixer.h"
+#include "../../sketches/rc_test/src/domain/drive/GearPolicy.h"
+
+// Values mirror [CONFIG] — parameters here, no config dependency.
+const GearPolicyParameters GEAR_PARAMETERS{0.65f, 0.80f, 1.00f, 1400, 1600};
+const float REVERSE_STANDARD = 0.55f;
+const float REVERSE_BOOST    = 0.65f;
+
+TEST_CASE("gear decision tree: thresholds are strict, between is Normal") {
+  CHECK(gearPolicySelect(1200, true, false, GEAR_PARAMETERS).level == GEAR_ECO);
+  CHECK(gearPolicySelect(1400, true, false, GEAR_PARAMETERS).level
+        == GEAR_NORMAL);  // exactly the low threshold is NOT below it
+  CHECK(gearPolicySelect(1500, true, false, GEAR_PARAMETERS).level
+        == GEAR_NORMAL);
+  CHECK(gearPolicySelect(1600, true, false, GEAR_PARAMETERS).level
+        == GEAR_NORMAL);  // exactly the high threshold is NOT above it
+  CHECK(gearPolicySelect(1800, true, false, GEAR_PARAMETERS).level
+        == GEAR_BOOST);
+  CHECK(gearPolicySelect(1800, true, false, GEAR_PARAMETERS).scale
+        == doctest::Approx(1.00f));
+}
+
+TEST_CASE("gear failsafe and Eco forces dominate the switch") {
+  // RC invalid → Eco no matter the pulse.
+  CHECK(gearPolicySelect(1800, false, false, GEAR_PARAMETERS).level
+        == GEAR_ECO);
+  // forceEco (battery Eco lock OR thermal Eco) overrides even Boost.
+  GearSelection forced = gearPolicySelect(1800, true, true, GEAR_PARAMETERS);
+  CHECK(forced.level == GEAR_ECO);
+  CHECK(forced.scale == doctest::Approx(0.65f));
+}
+
+TEST_CASE("reverse cap per gear and the cap-domain conversion") {
+  CHECK(reverseCapForGear(GEAR_ECO, REVERSE_STANDARD, REVERSE_BOOST)
+        == doctest::Approx(0.55f));
+  CHECK(reverseCapForGear(GEAR_NORMAL, REVERSE_STANDARD, REVERSE_BOOST)
+        == doctest::Approx(0.55f));
+  CHECK(reverseCapForGear(GEAR_BOOST, REVERSE_STANDARD, REVERSE_BOOST)
+        == doctest::Approx(0.65f));
+  // outCapToX: a 55% track cap in Eco (scale 0.65) is ~84.6% of xSpeed.
+  CHECK(trackCapToAxisDomain(0.55f, 0.65f) == doctest::Approx(0.55f / 0.65f));
+  CHECK(trackCapToAxisDomain(0.65f, 1.00f) == doctest::Approx(0.65f));
+}
+
+TEST_CASE("maxOppose truth table (#90)") {
+  CHECK(maxOppose(0.6f, 0.3f) == doctest::Approx(0.6f));    // larger wins
+  CHECK(maxOppose(1.0f, -0.3f) == doctest::Approx(0.7f));   // dominant minus opposing
+  CHECK(maxOppose(0.4f, 0.0f) == doctest::Approx(0.4f));    // single passes through
+  CHECK(maxOppose(-0.4f, -0.7f) == doctest::Approx(-0.7f)); // reverse: larger magnitude wins
+  CHECK(maxOppose(0.0f, 0.0f) == doctest::Approx(0.0f));
+}
+
+TEST_CASE("mixer modes: RC-only, RC-overrides, dual max/oppose") {
+  const AxisCommand rc{0.5f, -0.2f};
+  const AxisCommand joystick{0.8f, 0.1f};
+  // Mode 1 (pulse below low threshold): RC only.
+  AxisCommand mode1 = mixAxisCommands(rc, joystick, 1200, 1400, 1600);
+  CHECK(mode1.xSpeed == doctest::Approx(0.5f));
+  CHECK(mode1.zRotation == doctest::Approx(-0.2f));
+  // Mode 3 (pulse above high threshold): max/oppose per axis.
+  AxisCommand mode3 = mixAxisCommands(rc, joystick, 1800, 1400, 1600);
+  CHECK(mode3.xSpeed == doctest::Approx(0.8f));
+  CHECK(mode3.zRotation == doctest::Approx(-0.1f));
+}
+
+TEST_CASE("Mode 2: RC wins whenever ANY RC axis is nonzero (exact-zero law)") {
+  const AxisCommand joystick{0.8f, 0.1f};
+  // Both RC axes exactly zero → the joystick drives.
+  AxisCommand idle = mixAxisCommands(AxisCommand{0.0f, 0.0f}, joystick,
+                                     1500, 1400, 1600);
+  CHECK(idle.xSpeed == doctest::Approx(0.8f));
+  // The slightest RC input takes full authority — the compare is exact-zero
+  // (locked behavior; RC deadband upstream is what makes this safe).
+  AxisCommand touched = mixAxisCommands(AxisCommand{0.001f, 0.0f}, joystick,
+                                        1500, 1400, 1600);
+  CHECK(touched.xSpeed == doctest::Approx(0.001f));
+  CHECK(touched.zRotation == doctest::Approx(0.0f));
+}

--- a/tests/drive/test_gear_mixer_domain.cpp
+++ b/tests/drive/test_gear_mixer_domain.cpp
@@ -57,7 +57,7 @@ TEST_CASE("maxOppose truth table (#90)") {
   CHECK(maxOppose(0.6f, 0.3f) == doctest::Approx(0.6f));    // larger wins
   CHECK(maxOppose(1.0f, -0.3f) == doctest::Approx(0.7f));   // dominant minus opposing
   CHECK(maxOppose(0.4f, 0.0f) == doctest::Approx(0.4f));    // single passes through
-  CHECK(maxOppose(-0.4f, -0.7f) == doctest::Approx(-0.7f)); // reverse: larger magnitude wins
+  CHECK(maxOppose(-0.4f, -0.7f) == doctest::Approx(-0.7f));  // reverse: larger magnitude wins
   CHECK(maxOppose(0.0f, 0.0f) == doctest::Approx(0.0f));
 }
 


### PR DESCRIPTION
Closes #166

## Summary

Phase D step 7 (#117, epic #116): the gear policy and the RC/joystick command mixer move VERBATIM into `src/domain/drive/`, following #164's pattern.

- **`GearPolicy.h/.cpp`** — `updateGear()`'s decision tree as pure `gearPolicySelect(gearPulse, rcValid, forceEco, parameters) → GearSelection`: RC-invalid failsafe → Eco; strict CH4 thresholds (exactly-at-threshold stays Normal); `forceEco` (battery Eco lock #65 OR thermal Eco #111) overrides last. `reverseCap()`/`outCapToX()` become parameter-visible `reverseCapForGear()`/`trackCapToAxisDomain()` — two more hidden-global-read helpers made signature-honest.
- **`CommandMixer.h/.cpp`** — `maxOppose()` (#90) moves keeping its exact name/signature (`.ino` definition deleted; call sites and `test_mixer.cpp` resolve to the domain directly, as `expoCurve` did in #162). `mixCommands()` stays as a converting shim delegating to `mixAxisCommands()` with `OVR_LO`/`OVR_HI` as parameters. **Mode 2's exact-zero `rcActive` compare is preserved verbatim** — that compare is locked behavior law (the upstream RC deadband is what makes it safe).
- **`DriveTypes.h`** gains `AxisCommand` (layout-identical to the sketch's `DriveCommand`) and `GearLevel` (GEAR_ECO/NORMAL/BOOST = 0/1/2, mirroring types.h's `Gear` — the correspondence is `static_assert`ed in the `.ino`, so the shim casts are compile-time-proven and the SSE gear encoding is untouched).
- The `updateGear()` shim owns the boundary reads (sbus CH4 — only evaluated when `sbusValid`, matching the original early return — and the Eco forces) and mirrors the `gearScale`/`currentGear` globals every caller reads.
- New pure suite `tests/drive/test_gear_mixer_domain.cpp` (6 cases, no stubs): threshold edges (1400/1600 exactly → Normal), failsafe + forceEco dominance, per-gear reverse caps, cap-domain conversion, the `maxOppose` truth table, all three mixer modes including the exact-zero law.
- Housekeeping in the same commit: step 6's domain test scale constants renamed (`GEAR_ECO` → `GEAR_ECO_SCALE`) to clear the new enum's names — test-file naming only, zero expectation changes.

**Behavior preservation:** all 23 host binaries green with ZERO expectation changes — including the forced-Eco 1825 µs float32 law and every `test_gear_and_caps.cpp` / `test_mixer.cpp` / `test_invariant_gear_reverse_caps.cpp` expectation. Flash 116920 (+136: cross-TU calls), RAM 9812 unchanged.

Docs synced same-PR: DECISION-LOG entry, TESTING.md tree, wiki architecture-remediation note, CLAUDE.md file map.

**Role tag:** `[C-Builder]`

## Test plan

- [x] `wsl -e make -C tests run` — all 23 binaries green, zero expectation changes
- [x] `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` — flash 116920 (+136), RAM unchanged
- [x] `python scripts/check_architecture.py` OK (expected migration-window NOTE)
- [x] Pre-commit gate passed
- [ ] CI: all workflows green
- [ ] Bench: none applicable (pure move, no hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable Eco, Normal, and Boost gear behavior with safety overrides.
  * Improved RC and joystick command mixing across supported override modes.
  * Added consistent reverse-cap and track-cap handling.

* **Bug Fixes**
  * Preserved exact-zero RC override behavior for predictable command control.

* **Tests**
  * Added coverage for gear selection, cap conversion, and command-mixing behavior.

* **Documentation**
  * Updated architecture, testing, and decision-log documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->