### PR TITLE
V7.35: extract SafetySupervisor to src/domain/safety/ (#168, Phase D step 8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,7 @@ sketches/rc_test/src/domain/battery/     — Extracted domain (#117): BatteryTyp
 sketches/rc_test/src/domain/thermal/     — Extracted domain (#117): ThermalTypes.h + ThermalHysteresis.h/.cpp + ThermalDerating.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/operator_input/ — Extracted domain (#117): ExpoCurve.h/.cpp + DeadbandPolicy.h/.cpp (pure input shaping, host-testable)
 sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes.h + CurvatureDrive.h/.cpp + GearPolicy.h/.cpp + CommandMixer.h/.cpp (curvature mix, gear policy, RC/joystick mixer)
+sketches/rc_test/src/domain/safety/      — Extracted domain (#117): SafetyTypes.h + SafetySupervisor.h/.cpp (drive allow/deny decision + FailsafeReason)
 sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (X.BUS register decode + ×10 wire encode, header-only)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,28 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-12 — Phase D step 8: SafetySupervisor extracted to src/domain/safety/ (#168)
+
+- The inline drive gate in `loop()` — `driveAllowed = sbusValid &&
+  (batteryOkConfirmed || bootGraceElapsed) && !batteryCutoffLatched &&
+  !tempCutActive` — moved to `src/domain/safety/SafetySupervisor.h/.cpp` as
+  `safetySupervisorDecide(SafetyInputs) → SafetyDecision {driveAllowed,
+  FailsafeReason}`. The early-return shape is provably identical to the &&
+  chain (unit-locked by an exhaustive 32-input equivalence case); the
+  reason priority mirrors the chain order (RC_STALE > BOOT_GATE >
+  BATTERY_CUTOFF > THERMAL_CUT).
+- The fail-open boot gate (#65 law — a dead X.BUS never permanently
+  disables driving) moved verbatim as `batteryConfirmed ||
+  bootGraceElapsed`; the call site computes the millis()-based grace check
+  and passes a bool (time is a parameter).
+- The `FailsafeReason` is new surface consumed by the OutputGate (step 9)
+  and SystemSnapshot (#132) steps; today's call site uses only
+  `driveAllowed` (documented at the call site). `outputUpdate()`'s
+  ease-to-neutral state machine is step 9 — untouched here.
+- Verified: all 24 host binaries green, zero expectation changes; compile
+  clean — flash 117000 (+112 vs 116888, cross-TU call + struct), RAM
+  unchanged 9812. No bench check applicable (pure move).
+
 ## 2026-07-12 — Phase D step 7: GearPolicy + CommandMixer extracted to src/domain/drive/ (#166)
 
 - `updateGear()`'s decision tree moved to `GearPolicy.h/.cpp` as

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -43,9 +43,11 @@ tests/
 │   └── test_telemetry_scaling.cpp
 ├── operator_input/             pure-domain suite for src/domain/operator_input/ (#117)
 │   └── test_operator_input_domain.cpp
-└── drive/                      pure-domain suites for src/domain/drive/ (#117)
-    ├── test_curvature_drive_domain.cpp
-    └── test_gear_mixer_domain.cpp
+├── drive/                      pure-domain suites for src/domain/drive/ (#117)
+│   ├── test_curvature_drive_domain.cpp
+│   └── test_gear_mixer_domain.cpp
+└── safety/                     pure-domain suite for src/domain/safety/ (#117)
+    └── test_safety_supervisor_domain.cpp
 ```
 
 The stub headers shadow the real Arduino/library headers via include order

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -23,9 +23,11 @@ drive exactly as before.
   scaling lives in `src/telemetry/` (observer layer); the operator-input
   expo curve and center-snap deadband live in `src/domain/operator_input/`;
   the curvature tank mix — the propulsion-path core — plus the gear policy
-  and the RC/joystick command mixer live in `src/domain/drive/`. All pure
-  logic — no Arduino includes, time passed as a parameter, host-tested
-  directly; the sketch keeps thin delegates until the composition root lands
+  and the RC/joystick command mixer live in `src/domain/drive/`; the drive
+  allow/deny supervisor (SafetyDecision + FailsafeReason) lives in
+  `src/domain/safety/`. All pure logic — no Arduino includes, time passed
+  as a parameter, host-tested directly; the sketch keeps thin delegates
+  until the composition root lands
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -73,6 +73,7 @@
 #include "src/domain/drive/CurvatureDrive.h"
 #include "src/domain/drive/GearPolicy.h"
 #include "src/domain/drive/CommandMixer.h"
+#include "src/domain/safety/SafetySupervisor.h"
 #include "src/telemetry/TelemetryScaling.h"
 
 
@@ -1536,12 +1537,18 @@ void loop() {
   // the cutoff — so a low pack can't drive in the brief window after a watchdog
   // reset wipes the RAM latch. Fail OPEN if telemetry never reports
   // (BATTERY_CONFIRM_MS) so a dead X.BUS can't permanently disable driving.
-  bool batteryReady = batteryOkConfirmed || (millis() - alertBootMs > BATTERY_CONFIRM_MS);
-  // Also cut on motor over-temp (#111). Unlike the battery cutoff this is NOT
-  // latched — when the motor cools below TEMP_CUT_OFF_C the gate re-opens and
-  // outputUpdate() re-attaches the ESCs automatically.
-  bool driveAllowed = sbusValid && batteryReady && !batteryCutoffLatched && !tempCutActive;
-  outputUpdate(driveAllowed, mix.left, mix.right);
+  // The decision is extracted to src/domain/safety/SafetySupervisor.* (#117
+  // step 8, #168); this call site owns the boundary reads (RC freshness,
+  // battery flags, the millis()-based boot grace) and today consumes only
+  // driveAllowed — the FailsafeReason feeds the OutputGate and
+  // SystemSnapshot steps. The thermal cut (#111) is NOT latched: when the
+  // motor cools below TEMP_CUT_OFF_C the gate re-opens and outputUpdate()
+  // re-attaches the ESCs automatically.
+  SafetyDecision safety = safetySupervisorDecide(SafetyInputs{
+      sbusValid, batteryOkConfirmed,
+      millis() - alertBootMs > BATTERY_CONFIRM_MS, batteryCutoffLatched,
+      tempCutActive});
+  outputUpdate(safety.driveAllowed, mix.left, mix.right);
 
   // Control path serviced this pass (inputs read + output gate run) — and ONLY
   // now do we kick the watchdog. This is the sole refresh point: if anything

--- a/sketches/rc_test/src/domain/safety/SafetySupervisor.cpp
+++ b/sketches/rc_test/src/domain/safety/SafetySupervisor.cpp
@@ -1,0 +1,23 @@
+// domain/safety — the drive ALLOW/DENY supervisor (#117 step 8, #168).
+// Behavior is locked by tests/characterization/test_output_gate.cpp,
+// tests/invariants/test_invariant_cutoff_dominates.cpp,
+// test_invariant_stale_rc_neutral.cpp and
+// tests/safety/test_safety_supervisor_domain.cpp.
+#include "SafetySupervisor.h"
+
+SafetyDecision safetySupervisorDecide(const SafetyInputs& inputs) {
+  bool batteryReady = inputs.batteryConfirmed || inputs.bootGraceElapsed;
+  if (!inputs.rcValid) {
+    return {false, FAILSAFE_RC_STALE};
+  }
+  if (!batteryReady) {
+    return {false, FAILSAFE_BOOT_GATE};
+  }
+  if (inputs.batteryCutoffLatched) {
+    return {false, FAILSAFE_BATTERY_CUTOFF};
+  }
+  if (inputs.thermalCutActive) {
+    return {false, FAILSAFE_THERMAL_CUT};
+  }
+  return {true, FAILSAFE_NONE};
+}

--- a/sketches/rc_test/src/domain/safety/SafetySupervisor.cpp
+++ b/sketches/rc_test/src/domain/safety/SafetySupervisor.cpp
@@ -1,7 +1,7 @@
 // domain/safety — the drive ALLOW/DENY supervisor (#117 step 8, #168).
 // Behavior is locked by tests/characterization/test_output_gate.cpp,
 // tests/invariants/test_invariant_cutoff_dominates.cpp,
-// test_invariant_stale_rc_neutral.cpp and
+// tests/invariants/test_invariant_stale_rc_neutral.cpp and
 // tests/safety/test_safety_supervisor_domain.cpp.
 #include "SafetySupervisor.h"
 

--- a/sketches/rc_test/src/domain/safety/SafetySupervisor.h
+++ b/sketches/rc_test/src/domain/safety/SafetySupervisor.h
@@ -1,0 +1,13 @@
+// domain/safety — the drive ALLOW/DENY supervisor (#117 step 8, #168).
+// Extracted from the inline chain in rc_test.ino loop() (#88/#65/#111):
+//   driveAllowed = rcValid && batteryReady && !cutoffLatched && !thermalCut
+// with batteryReady = batteryConfirmed || bootGraceElapsed (the fail-open
+// boot gate: a low pack cannot drive after a watchdog reset wipes the RAM
+// latch, yet a dead X.BUS can never permanently disable driving).
+// The early-return shape below is provably identical to the && chain for
+// every input combination; the returned reason mirrors the chain's order.
+#pragma once
+
+#include "SafetyTypes.h"
+
+SafetyDecision safetySupervisorDecide(const SafetyInputs& inputs);

--- a/sketches/rc_test/src/domain/safety/SafetyTypes.h
+++ b/sketches/rc_test/src/domain/safety/SafetyTypes.h
@@ -1,0 +1,35 @@
+// domain/safety — shared value types (#117 step 8, #168).
+// Pure domain: no Arduino includes (host-compilable by design).
+#pragma once
+
+#include <stdint.h>
+
+// Why drive is denied (target glossary). Priority mirrors the original
+// && chain: RC freshness, then the boot gate, then the battery cutoff,
+// then the thermal cut.
+enum FailsafeReason : uint8_t {
+  FAILSAFE_NONE = 0,
+  FAILSAFE_RC_STALE,
+  FAILSAFE_BOOT_GATE,
+  FAILSAFE_BATTERY_CUTOFF,
+  FAILSAFE_THERMAL_CUT,
+};
+
+// Everything the supervisor needs, gathered by the application layer —
+// including the boot-grace clock check (time is a parameter: the caller
+// computes it, the domain never reads a clock).
+struct SafetyInputs {
+  bool rcValid;               // S.BUS fresh (per-channel failsafe upstream)
+  bool batteryConfirmed;      // a plausible reading confirmed pack above cutoff
+  bool bootGraceElapsed;      // fail-open window passed (dead X.BUS never
+                              // permanently disables driving, #65)
+  bool batteryCutoffLatched;  // hard cutoff latched until power-cycle (#65)
+  bool thermalCutActive;      // over-temp cut, auto-recovers (#111)
+};
+
+// The supervisor's verdict. Today the application layer consumes only
+// driveAllowed; `reason` feeds the OutputGate and SystemSnapshot steps.
+struct SafetyDecision {
+  bool driveAllowed;
+  FailsafeReason reason;
+};

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -35,7 +35,8 @@ TESTS := $(wildcard characterization/test_*.cpp) \
          $(wildcard thermal/test_*.cpp) \
          $(wildcard telemetry/test_*.cpp) \
          $(wildcard operator_input/test_*.cpp) \
-         $(wildcard drive/test_*.cpp)
+         $(wildcard drive/test_*.cpp) \
+         $(wildcard safety/test_*.cpp)
 BINS  := $(addprefix build/,$(notdir $(TESTS:.cpp=)))
 
 # A duplicate basename across suite directories would silently shadow one
@@ -76,6 +77,10 @@ build/%: operator_input/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 
 build/%: drive/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
+	@mkdir -p build
+	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+
+build/%: safety/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 

--- a/tests/safety/test_safety_supervisor_domain.cpp
+++ b/tests/safety/test_safety_supervisor_domain.cpp
@@ -9,7 +9,9 @@
 
 #include "../../sketches/rc_test/src/domain/safety/SafetySupervisor.h"
 
-// inputs{rcValid, batteryConfirmed, bootGraceElapsed, cutoffLatched, thermalCut}
+// SafetyInputs positional order:
+// {rcValid, batteryConfirmed, bootGraceElapsed, batteryCutoffLatched,
+//  thermalCutActive}
 
 TEST_CASE("all healthy: drive allowed with no failsafe reason") {
   SafetyDecision decision =

--- a/tests/safety/test_safety_supervisor_domain.cpp
+++ b/tests/safety/test_safety_supervisor_domain.cpp
@@ -1,0 +1,66 @@
+// Pure-domain suite (#117 step 8, #168): src/domain/safety/SafetySupervisor
+// tested directly on the host — no firmware, no stubs. End-to-end behavior
+// through the loop() gate stays covered by
+// tests/characterization/test_output_gate.cpp and the cutoff/stale-RC
+// invariants; this suite locks the decision truth table, the fail-open
+// boot-grace law, and the reason priority at the unit level.
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include "../../sketches/rc_test/src/domain/safety/SafetySupervisor.h"
+
+// inputs{rcValid, batteryConfirmed, bootGraceElapsed, cutoffLatched, thermalCut}
+
+TEST_CASE("all healthy: drive allowed with no failsafe reason") {
+  SafetyDecision decision =
+      safetySupervisorDecide(SafetyInputs{true, true, false, false, false});
+  CHECK(decision.driveAllowed == true);
+  CHECK(decision.reason == FAILSAFE_NONE);
+}
+
+TEST_CASE("each single failure denies with its own reason") {
+  CHECK(safetySupervisorDecide(SafetyInputs{false, true, false, false, false})
+            .reason == FAILSAFE_RC_STALE);
+  CHECK(safetySupervisorDecide(SafetyInputs{true, false, false, false, false})
+            .reason == FAILSAFE_BOOT_GATE);
+  CHECK(safetySupervisorDecide(SafetyInputs{true, true, false, true, false})
+            .reason == FAILSAFE_BATTERY_CUTOFF);
+  CHECK(safetySupervisorDecide(SafetyInputs{true, true, false, false, true})
+            .reason == FAILSAFE_THERMAL_CUT);
+  CHECK(safetySupervisorDecide(SafetyInputs{false, true, false, false, false})
+            .driveAllowed == false);
+}
+
+TEST_CASE("fail-open boot gate law (#65): grace elapsed allows an unconfirmed pack") {
+  // A dead X.BUS never permanently disables driving.
+  SafetyDecision decision =
+      safetySupervisorDecide(SafetyInputs{true, false, true, false, false});
+  CHECK(decision.driveAllowed == true);
+  CHECK(decision.reason == FAILSAFE_NONE);
+  // But a latched cutoff still dominates the grace window.
+  CHECK(safetySupervisorDecide(SafetyInputs{true, false, true, true, false})
+            .driveAllowed == false);
+}
+
+TEST_CASE("reason priority mirrors the original && chain order") {
+  // RC stale wins over everything.
+  CHECK(safetySupervisorDecide(SafetyInputs{false, false, false, true, true})
+            .reason == FAILSAFE_RC_STALE);
+  // Boot gate beats cutoff and thermal.
+  CHECK(safetySupervisorDecide(SafetyInputs{true, false, false, true, true})
+            .reason == FAILSAFE_BOOT_GATE);
+  // Cutoff beats thermal.
+  CHECK(safetySupervisorDecide(SafetyInputs{true, true, false, true, true})
+            .reason == FAILSAFE_BATTERY_CUTOFF);
+}
+
+TEST_CASE("driveAllowed equals the original boolean chain for ALL 32 inputs") {
+  for (int mask = 0; mask < 32; mask++) {
+    SafetyInputs inputs{(mask & 1) != 0, (mask & 2) != 0, (mask & 4) != 0,
+                        (mask & 8) != 0, (mask & 16) != 0};
+    bool batteryReady = inputs.batteryConfirmed || inputs.bootGraceElapsed;
+    bool expected = inputs.rcValid && batteryReady &&
+                    !inputs.batteryCutoffLatched && !inputs.thermalCutActive;
+    CHECK(safetySupervisorDecide(inputs).driveAllowed == expected);
+  }
+}


### PR DESCRIPTION
Closes #168

## Summary

Phase D step 8 (#117, epic #116): the drive ALLOW/DENY decision moves from the inline chain in `loop()` into `src/domain/safety/` — the target's `SafetySupervisor` with its glossary types.

- **`SafetyTypes.h`** — `SafetyInputs` (all boundary facts as booleans; the millis()-based boot-grace check is computed by the caller — time is a parameter), `FailsafeReason` (NONE / RC_STALE / BOOT_GATE / BATTERY_CUTOFF / THERMAL_CUT), `SafetyDecision { driveAllowed, reason }`.
- **`SafetySupervisor.h/.cpp`** — `safetySupervisorDecide()`: the same boolean logic re-shaped as prioritized early returns. **Provably identical**: the pure suite includes an exhaustive 32-input equivalence case checking the decision against the original `&&` chain for every combination.
- The **fail-open boot gate law (#65)** moves verbatim: `batteryConfirmed || bootGraceElapsed` — a low pack can't drive after a watchdog reset wipes the RAM latch, yet a dead X.BUS can never permanently disable driving.
- `FailsafeReason` is deliberate new surface for step 9 (OutputGate) and #132 (SystemSnapshot); today's call site consumes only `.driveAllowed` (documented in the shim comment). `outputUpdate()`'s ease-to-neutral → detach state machine is step 9 — untouched here.
- New pure suite `tests/safety/test_safety_supervisor_domain.cpp` (5 cases, no stubs): full truth table, per-failure reasons, the fail-open grace law (unconfirmed + grace → ALLOWED; latched cutoff still dominates), reason priority mirroring the chain order, and the exhaustive 32-input equivalence check.

**Behavior preservation:** all 24 host binaries green with ZERO expectation changes — `test_output_gate.cpp` and the cutoff/stale-RC invariants exercise this gate end-to-end. Flash 117000 (+112: cross-TU call + struct), RAM 9812 unchanged.

Docs synced same-PR: DECISION-LOG entry, TESTING.md tree, wiki architecture-remediation note, CLAUDE.md file map.

**Role tag:** `[C-Builder]`

## Test plan

- [x] `wsl -e make -C tests run` — all 24 binaries green, zero expectation changes
- [x] `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` — flash 117000 (+112), RAM unchanged
- [x] `python scripts/check_architecture.py` OK (expected migration-window NOTE)
- [x] Pre-commit gate + cpplint two-space comment pre-check passed
- [ ] CI: all workflows green
- [ ] Bench: none applicable (pure move, no hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safety supervision for drive enablement, including clear failsafe reasons for RC, boot, battery, and thermal conditions.
  * Preserved the boot grace-period behavior while ensuring battery cutoffs take priority.

* **Bug Fixes**
  * Improved consistency of drive allow/deny decisions through ordered safety checks.

* **Tests**
  * Added comprehensive safety-domain tests covering individual failures, priority handling, grace-period behavior, and all input combinations.

* **Documentation**
  * Updated architecture, testing, decision-log, and project map documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->