### PR TITLE
V7.35: extract OutputGate to src/domain/safety/ (#170, Phase D step 9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ sketches/rc_test/src/domain/battery/     — Extracted domain (#117): BatteryTyp
 sketches/rc_test/src/domain/thermal/     — Extracted domain (#117): ThermalTypes.h + ThermalHysteresis.h/.cpp + ThermalDerating.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/operator_input/ — Extracted domain (#117): ExpoCurve.h/.cpp + DeadbandPolicy.h/.cpp (pure input shaping, host-testable)
 sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes.h + CurvatureDrive.h/.cpp + GearPolicy.h/.cpp + CommandMixer.h/.cpp (curvature mix, gear policy, RC/joystick mixer)
-sketches/rc_test/src/domain/safety/      — Extracted domain (#117): SafetyTypes.h + SafetySupervisor.h/.cpp (drive allow/deny decision + FailsafeReason)
+sketches/rc_test/src/domain/safety/      — Extracted domain (#117): SafetyTypes.h + SafetySupervisor.h/.cpp + OutputGate.h/.cpp (drive allow/deny + FailsafeReason; ACTIVE/HOLD/CUT gate)
 sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (X.BUS register decode + ×10 wire encode, header-only)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,31 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-13 — Phase D step 9: OutputGate extracted to src/domain/safety/ (#170)
+
+- `outputUpdate()`'s fail-safe state machine (#88/#65) moved VERBATIM to
+  `src/domain/safety/OutputGate.h/.cpp` as `outputGateStep(OutputGateState&,
+  driveAllowed, commanded, current, nowMs, neutralPulse, holdDurationMs) →
+  OutputGateAction {attach, write, pulses, detach}`. The pure machine owns
+  the ACTIVE/HOLD/CUT transitions and the exact float ease-out ramp
+  (zero-duration guard, >1 clamp, `rampFrom + (int)((neutral−rampFrom)·t)`);
+  the shim executes the hardware actions in the original order — attach,
+  write, detach — so the ESCs still see the final neutral write before
+  losing signal.
+- Behavior laws carried and unit-locked: ease-out starts from the LIVE
+  outputs snapshot; detach only after the ramp completes; resume-from-CUT
+  re-attaches while recovery mid-HOLD does NOT (ESCs were never detached);
+  CUT emits nothing. OutState↔OutputGateMode value correspondence
+  static_asserted in the shim (the GearLevel↔Gear pattern).
+- SVC and CUTOFF_HOLD_MS stay `[CONFIG]`, passed as parameters; millis()
+  read by the shim. Gate globals (outState/outHoldMs/rampFromL/R) stay in
+  the .ino, mirrored via the state struct — harness resets untouched.
+- Verified: all 25 host binaries green, zero expectation changes (new
+  `tests/safety/test_output_gate_domain.cpp`, 5 cases); compile clean —
+  flash 117160 (+160 vs 117000), RAM unchanged 9812. This completes the
+  DOMAIN extractions (§9 steps 1–9); steps 10–11 are infrastructure
+  adapters + the FirmwareApp composition root.
+
 ## 2026-07-12 — Phase D step 8: SafetySupervisor extracted to src/domain/safety/ (#168)
 
 - The inline drive gate in `loop()` — `driveAllowed = sbusValid &&

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -46,8 +46,9 @@ tests/
 ├── drive/                      pure-domain suites for src/domain/drive/ (#117)
 │   ├── test_curvature_drive_domain.cpp
 │   └── test_gear_mixer_domain.cpp
-└── safety/                     pure-domain suite for src/domain/safety/ (#117)
-    └── test_safety_supervisor_domain.cpp
+└── safety/                     pure-domain suites for src/domain/safety/ (#117)
+    ├── test_safety_supervisor_domain.cpp
+    └── test_output_gate_domain.cpp
 ```
 
 The stub headers shadow the real Arduino/library headers via include order

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -24,10 +24,11 @@ drive exactly as before.
   expo curve and center-snap deadband live in `src/domain/operator_input/`;
   the curvature tank mix — the propulsion-path core — plus the gear policy
   and the RC/joystick command mixer live in `src/domain/drive/`; the drive
-  allow/deny supervisor (SafetyDecision + FailsafeReason) lives in
+  allow/deny supervisor (SafetyDecision + FailsafeReason) and the
+  ACTIVE/HOLD/CUT [output gate](output-gate.md) state machine live in
   `src/domain/safety/`. All pure logic — no Arduino includes, time passed
-  as a parameter, host-tested directly; the sketch keeps thin delegates
-  until the composition root lands
+  as a parameter, hardware effects returned as actions for the sketch to
+  execute; the sketch keeps thin delegates until the composition root lands
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -74,6 +74,7 @@
 #include "src/domain/drive/GearPolicy.h"
 #include "src/domain/drive/CommandMixer.h"
 #include "src/domain/safety/SafetySupervisor.h"
+#include "src/domain/safety/OutputGate.h"
 #include "src/telemetry/TelemetryScaling.h"
 
 
@@ -592,36 +593,36 @@ uint32_t outHoldMs  = 0;
 int      rampFromL  = SVC;   // output captured when the gate closed (ease-out start)
 int      rampFromR  = SVC;
 
+// The state machine is extracted to src/domain/safety/OutputGate.* (#117
+// step 9, #170); this delegate mirrors the gate globals, reads the clock,
+// and executes the returned hardware actions in the original order:
+// attach, then write, then detach (the final neutral write precedes the
+// detach, so the ESCs see neutral before losing signal). The enum values
+// correspond — proven at compile time:
+static_assert((int)OUT_ACTIVE == (int)OUTPUT_GATE_ACTIVE &&
+              (int)OUT_HOLD == (int)OUTPUT_GATE_HOLD &&
+              (int)OUT_CUT == (int)OUTPUT_GATE_CUT,
+              "OutState and domain OutputGateMode values must correspond");
+
 void outputUpdate(bool driveAllowed, int mixL, int mixR) {
-  uint32_t nowMs = millis();
-  if (driveAllowed) {
-    if (outState == OUT_CUT) {        // resume after an RC-loss cut
-      escL.attach(PIN_ESC_L);
-      escR.attach(PIN_ESC_R);
-    }
-    outState = OUT_ACTIVE;
-    outputWrite(mixL, mixR);
-    return;
+  OutputGateState gate{(OutputGateMode)outState, outHoldMs, rampFromL,
+                       rampFromR};
+  OutputGateAction action =
+      outputGateStep(gate, driveAllowed, mixL, mixR, outL, outR, millis(),
+                     SVC, CUTOFF_HOLD_MS);
+  outState = (OutState)gate.mode;
+  outHoldMs = gate.holdStartMs;
+  rampFromL = gate.rampFromLeft;
+  rampFromR = gate.rampFromRight;
+  if (action.attach) {
+    escL.attach(PIN_ESC_L);
+    escR.attach(PIN_ESC_R);
   }
-  // Disallowed: ease out to neutral from the live command, then cut the PWM.
-  if (outState == OUT_ACTIVE) {
-    outState = OUT_HOLD;
-    outHoldMs = nowMs;
-    rampFromL = outL;                 // ease out FROM wherever the tracks are
-    rampFromR = outR;
+  if (action.write) outputWrite(action.leftPulse, action.rightPulse);
+  if (action.detach) {
+    escL.detach();                    // at neutral → stop pulsing → ESCs beep
+    escR.detach();
   }
-  if (outState == OUT_HOLD) {
-    float t = (CUTOFF_HOLD_MS > 0) ? (float)(nowMs - outHoldMs) / (float)CUTOFF_HOLD_MS : 1.0f;
-    if (t > 1.0f) t = 1.0f;
-    outputWrite(rampFromL + (int)((SVC - rampFromL) * t),
-                rampFromR + (int)((SVC - rampFromR) * t));
-    if (t >= 1.0f) {
-      escL.detach();                  // at neutral → stop pulsing → ESCs beep
-      escR.detach();
-      outState = OUT_CUT;
-    }
-  }
-  // OUT_CUT: emit nothing (no writes while detached).
 }
 
 

--- a/sketches/rc_test/src/domain/safety/OutputGate.cpp
+++ b/sketches/rc_test/src/domain/safety/OutputGate.cpp
@@ -21,7 +21,8 @@ OutputGateAction outputGateStep(OutputGateState& gate, bool driveAllowed,
     action.rightPulse = commandedRight;
     return action;
   }
-  // Disallowed: ease out to neutral from the live command, then cut the PWM.
+  // Disallowed: ease out to neutral from the live last-written outputs,
+  // then cut the PWM.
   if (gate.mode == OUTPUT_GATE_ACTIVE) {
     gate.mode = OUTPUT_GATE_HOLD;
     gate.holdStartMs = nowMs;

--- a/sketches/rc_test/src/domain/safety/OutputGate.cpp
+++ b/sketches/rc_test/src/domain/safety/OutputGate.cpp
@@ -1,0 +1,48 @@
+// domain/safety — the fail-safe output gate (#117 step 9, #170).
+// Logic copied VERBATIM from rc_test.ino [OUTPUT] outputUpdate(); behavior
+// is locked by tests/characterization/test_output_gate.cpp, the
+// output-bounds / cutoff-dominates / stale-RC invariants and
+// tests/safety/test_output_gate_domain.cpp.
+#include "OutputGate.h"
+
+OutputGateAction outputGateStep(OutputGateState& gate, bool driveAllowed,
+                                int commandedLeft, int commandedRight,
+                                int currentLeft, int currentRight,
+                                uint32_t nowMs, int neutralPulse,
+                                uint32_t holdDurationMs) {
+  OutputGateAction action{false, false, 0, 0, false};
+  if (driveAllowed) {
+    if (gate.mode == OUTPUT_GATE_CUT) {  // resume after an RC-loss cut
+      action.attach = true;
+    }
+    gate.mode = OUTPUT_GATE_ACTIVE;
+    action.write = true;
+    action.leftPulse = commandedLeft;
+    action.rightPulse = commandedRight;
+    return action;
+  }
+  // Disallowed: ease out to neutral from the live command, then cut the PWM.
+  if (gate.mode == OUTPUT_GATE_ACTIVE) {
+    gate.mode = OUTPUT_GATE_HOLD;
+    gate.holdStartMs = nowMs;
+    gate.rampFromLeft = currentLeft;    // ease out FROM wherever the tracks are
+    gate.rampFromRight = currentRight;
+  }
+  if (gate.mode == OUTPUT_GATE_HOLD) {
+    float t = (holdDurationMs > 0)
+                  ? (float)(nowMs - gate.holdStartMs) / (float)holdDurationMs
+                  : 1.0f;
+    if (t > 1.0f) t = 1.0f;
+    action.write = true;
+    action.leftPulse =
+        gate.rampFromLeft + (int)((neutralPulse - gate.rampFromLeft) * t);
+    action.rightPulse =
+        gate.rampFromRight + (int)((neutralPulse - gate.rampFromRight) * t);
+    if (t >= 1.0f) {
+      action.detach = true;             // at neutral → stop pulsing → ESCs beep
+      gate.mode = OUTPUT_GATE_CUT;
+    }
+  }
+  // OUTPUT_GATE_CUT: emit nothing (no writes while detached).
+  return action;
+}

--- a/sketches/rc_test/src/domain/safety/OutputGate.h
+++ b/sketches/rc_test/src/domain/safety/OutputGate.h
@@ -1,0 +1,49 @@
+// domain/safety — the fail-safe output gate (#117 step 9, #170).
+// Extracted VERBATIM from rc_test.ino [OUTPUT] outputUpdate() (#88/#65).
+// ACTIVE / HOLD (ease to neutral) / CUT (no pulses): "Get a command → pass
+// it. Get nothing → ease to a stop, then pass nothing." Pure domain: time,
+// the neutral pulse and the hold duration arrive as parameters; hardware
+// effects come back as an action for the caller to execute — domain code
+// never touches the Servo objects.
+#pragma once
+
+#include <stdint.h>
+
+// Gate modes. Numeric values intentionally MATCH the sketch's OutState
+// enum (OUT_ACTIVE/OUT_HOLD/OUT_CUT = 0/1/2) — the delegate shim casts
+// between them and static_asserts the correspondence.
+enum OutputGateMode : uint8_t {
+  OUTPUT_GATE_ACTIVE = 0,
+  OUTPUT_GATE_HOLD   = 1,
+  OUTPUT_GATE_CUT    = 2,
+};
+
+// The gate's mutable state, held by the application layer (today: mirrored
+// to/from the rc_test.ino globals by the delegate shim).
+struct OutputGateState {
+  OutputGateMode mode;
+  uint32_t holdStartMs;   // when the ease-out began
+  int rampFromLeft;       // outputs captured when the gate closed (ease-out start)
+  int rampFromRight;
+};
+
+// What the caller must do this pass, in this order: attach, then write,
+// then detach (the final neutral write precedes the detach, so the ESCs
+// see neutral before losing signal).
+struct OutputGateAction {
+  bool attach;      // re-attach the ESCs (resume-from-CUT edge only)
+  bool write;       // write leftPulse/rightPulse this pass
+  int leftPulse;
+  int rightPulse;
+  bool detach;      // stop pulsing (ease-out completed)
+};
+
+// One gate pass. currentLeft/currentRight are the LIVE last-written outputs
+// (the ease-out starts from wherever the tracks are, never from a stale
+// command). Recovery mid-HOLD needs no re-attach — the ESCs were never
+// detached (locked law).
+OutputGateAction outputGateStep(OutputGateState& gate, bool driveAllowed,
+                                int commandedLeft, int commandedRight,
+                                int currentLeft, int currentRight,
+                                uint32_t nowMs, int neutralPulse,
+                                uint32_t holdDurationMs);

--- a/tests/safety/test_output_gate_domain.cpp
+++ b/tests/safety/test_output_gate_domain.cpp
@@ -1,0 +1,97 @@
+// Pure-domain suite (#117 step 9, #170): src/domain/safety/OutputGate
+// tested directly on the host — no firmware, no stubs, time/neutral/hold
+// duration passed explicitly. End-to-end behavior through outputUpdate()
+// (with the real Servo attach/detach) stays covered by
+// tests/characterization/test_output_gate.cpp and the output-bounds /
+// cutoff-dominates / stale-RC invariants; this suite locks the state
+// machine's laws at the unit level.
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include "../../sketches/rc_test/src/domain/safety/OutputGate.h"
+
+// Values mirror SVC / CUTOFF_HOLD_MS — parameters here.
+const int NEUTRAL = 1500;
+const uint32_t HOLD_MS = 500;
+
+inline OutputGateState activeGate() {
+  return OutputGateState{OUTPUT_GATE_ACTIVE, 0, NEUTRAL, NEUTRAL};
+}
+
+TEST_CASE("allowed: commands pass through, no hardware edges while ACTIVE") {
+  OutputGateState gate = activeGate();
+  OutputGateAction action =
+      outputGateStep(gate, true, 1700, 1300, 1700, 1300, 1000, NEUTRAL,
+                     HOLD_MS);
+  CHECK(action.write == true);
+  CHECK(action.leftPulse == 1700);
+  CHECK(action.rightPulse == 1300);
+  CHECK(action.attach == false);
+  CHECK(action.detach == false);
+  CHECK(gate.mode == OUTPUT_GATE_ACTIVE);
+}
+
+TEST_CASE("deny from ACTIVE: HOLD snapshots the LIVE outputs and eases toward neutral") {
+  OutputGateState gate = activeGate();
+  // Live outputs 1800/1200 (passed as current), stale command irrelevant.
+  OutputGateAction start =
+      outputGateStep(gate, false, 1700, 1300, 1800, 1200, 1000, NEUTRAL,
+                     HOLD_MS);
+  CHECK(gate.mode == OUTPUT_GATE_HOLD);
+  CHECK(gate.rampFromLeft == 1800);
+  CHECK(start.write == true);
+  CHECK(start.leftPulse == 1800);        // t = 0: still at the snapshot
+  CHECK(start.detach == false);
+  // Halfway through the hold window: midpoint of the ramp.
+  OutputGateAction mid =
+      outputGateStep(gate, false, 0, 0, 1800, 1200, 1250, NEUTRAL, HOLD_MS);
+  CHECK(mid.leftPulse == 1650);          // 1800 + (1500-1800)*0.5
+  CHECK(mid.rightPulse == 1350);
+  CHECK(mid.detach == false);
+  // Past the window: final neutral write AND the detach edge, then CUT.
+  OutputGateAction done =
+      outputGateStep(gate, false, 0, 0, 1800, 1200, 1600, NEUTRAL, HOLD_MS);
+  CHECK(done.write == true);
+  CHECK(done.leftPulse == NEUTRAL);
+  CHECK(done.detach == true);
+  CHECK(gate.mode == OUTPUT_GATE_CUT);
+}
+
+TEST_CASE("zero hold duration cuts immediately with one neutral write") {
+  OutputGateState gate = activeGate();
+  OutputGateAction action =
+      outputGateStep(gate, false, 0, 0, 1900, 1100, 1000, NEUTRAL, 0);
+  CHECK(action.write == true);
+  CHECK(action.leftPulse == NEUTRAL);
+  CHECK(action.detach == true);
+  CHECK(gate.mode == OUTPUT_GATE_CUT);
+}
+
+TEST_CASE("CUT is inert: no writes, no edges, while denied") {
+  OutputGateState gate{OUTPUT_GATE_CUT, 1000, 1800, 1200};
+  OutputGateAction action =
+      outputGateStep(gate, false, 1700, 1300, NEUTRAL, NEUTRAL, 5000,
+                     NEUTRAL, HOLD_MS);
+  CHECK(action.write == false);
+  CHECK(action.attach == false);
+  CHECK(action.detach == false);
+  CHECK(gate.mode == OUTPUT_GATE_CUT);
+}
+
+TEST_CASE("resume from CUT re-attaches; recovery mid-HOLD does NOT (never detached)") {
+  OutputGateState cut{OUTPUT_GATE_CUT, 1000, 1800, 1200};
+  OutputGateAction resumed =
+      outputGateStep(cut, true, 1600, 1400, NEUTRAL, NEUTRAL, 6000, NEUTRAL,
+                     HOLD_MS);
+  CHECK(resumed.attach == true);         // RC-loss recovery re-attaches
+  CHECK(resumed.write == true);
+  CHECK(cut.mode == OUTPUT_GATE_ACTIVE);
+  OutputGateState hold{OUTPUT_GATE_HOLD, 1000, 1800, 1200};
+  OutputGateAction recovered =
+      outputGateStep(hold, true, 1600, 1400, 1650, 1350, 1200, NEUTRAL,
+                     HOLD_MS);
+  CHECK(recovered.attach == false);      // ESCs were never detached
+  CHECK(recovered.write == true);
+  CHECK(recovered.leftPulse == 1600);
+  CHECK(hold.mode == OUTPUT_GATE_ACTIVE);
+}


### PR DESCRIPTION
Closes #170

## Summary

Phase D step 9 (#117, epic #116): `outputUpdate()`'s fail-safe gate — the last piece of pure domain logic in the extraction order — moves VERBATIM into `src/domain/safety/OutputGate.h/.cpp`. **This completes the domain extractions (§9 steps 1–9)**; what remains is infrastructure adapters (step 10) and the FirmwareApp composition root (step 11).

- **Pure machine → domain**: `outputGateStep(OutputGateState&, driveAllowed, commanded, current, nowMs, neutralPulse, holdDurationMs)` owns the ACTIVE / HOLD (ease to neutral) / CUT transitions and the exact float ramp (zero-duration guard, `>1` clamp, `rampFrom + (int)((neutral − rampFrom) · t)`).
- **Hardware effects → an action struct**: `{attach, write, leftPulse, rightPulse, detach}`, executed by the `.ino` shim in the original order — attach, then write, then detach — so the ESCs still see the final neutral write before losing signal.
- **Behavior laws carried and unit-locked**: ease-out starts from the LIVE output snapshot (never the stale command); detach only after the ramp completes; resume-from-CUT re-attaches while **recovery mid-HOLD does not** (the ESCs were never detached); CUT emits nothing while denied.
- `OutState` ↔ `OutputGateMode` value correspondence is `static_assert`ed in the shim (the #166 pattern); the gate globals stay in the `.ino` (harness resets untouched); `SVC`/`CUTOFF_HOLD_MS` stay `[CONFIG]`, passed as parameters; `millis()` read by the shim.
- New pure suite `tests/safety/test_output_gate_domain.cpp` (5 cases, no stubs): pass-through, HOLD snapshot + ramp at start/mid/end with exact pulse values, zero-duration immediate cut, CUT inertness, and the attach-edge asymmetry law.

**Behavior preservation:** all 25 host binaries green with ZERO expectation changes — `test_output_gate.cpp` and the output-bounds / cutoff-dominates / stale-RC invariants exercise this machine end-to-end. Flash 117160 (+160: cross-TU call + action struct), RAM 9812 unchanged.

Docs synced same-PR: DECISION-LOG entry, TESTING.md tree, wiki architecture-remediation note, CLAUDE.md file map.

**Role tag:** `[C-Builder]`

## Test plan

- [x] `wsl -e make -C tests run` — all 25 binaries green, zero expectation changes
- [x] `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` — flash 117160 (+160), RAM unchanged
- [x] `python scripts/check_architecture.py` OK (expected migration-window NOTE)
- [x] Pre-commit gate passed
- [ ] CI: all workflows green
- [ ] Bench: none applicable (pure move, no hardware); the series' bench re-verification pass remains queued (BENCH-VERIFICATION-DEFERRED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
