### PR TITLE
V7.35: EscOutputPort + PwmEscAdapter — first infrastructure slice (#172, Phase D step 10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,8 @@ sketches/rc_test/src/domain/operator_input/ — Extracted domain (#117): ExpoCur
 sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes.h + CurvatureDrive.h/.cpp + GearPolicy.h/.cpp + CommandMixer.h/.cpp (curvature mix, gear policy, RC/joystick mixer)
 sketches/rc_test/src/domain/safety/      — Extracted domain (#117): SafetyTypes.h + SafetySupervisor.h/.cpp + OutputGate.h/.cpp (drive allow/deny + FailsafeReason; ACTIVE/HOLD/CUT gate)
 sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (X.BUS register decode + ×10 wire encode, header-only)
+sketches/rc_test/src/ports/              — Hardware contracts as link-time seams (#130): EscOutputPort.h
+sketches/rc_test/src/infrastructure/     — The ONLY layer with hardware includes (#130): arduino/PwmEscAdapter.cpp (owns the Servo objects)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit
 sketches/telem_check/telem_check.ino     — Read-only X.BUS telemetry bench tool (0x50 framing)

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,31 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-13 — Phase D step 10 slice 1: EscOutputPort + PwmEscAdapter (#172)
+
+- First infrastructure slice: `ports/EscOutputPort.h` (link-time seam per
+  #130 — free functions, no virtuals) + `infrastructure/arduino/
+  PwmEscAdapter.cpp`, which now owns the `Servo escL, escR` objects (moved
+  from the `.ino`) and remembers the pins passed at
+  `escOutputInitialize(PIN_ESC_L, PIN_ESC_R)`.
+- Behavior boundaries: the `constrain(SVMIN, SVMAX)` clamp and the
+  `outL`/`outR` globals stay in the `.ino` (application-visible state read
+  by buildTelemJson and the OutputGate shim); only the writeMicroseconds /
+  attach / detach calls go through the port — same call sites, same order.
+- Harness: pure suites now compile `SKETCH_PURE_CPPS` (infrastructure
+  filtered out — hardware includes need the stubs the pure suites
+  deliberately exclude); firmware suites compile everything (stub Servo.h
+  captures unchanged). `FirmwareUnderTest.h` reaches the moved Servo
+  objects via extern declarations. The adapter includes `<Arduino.h>`
+  before `<Servo.h>` (the stub Servo.h uses millis()).
+- Verified: all 25 host binaries green, zero expectation changes; compile
+  clean — flash 117236 (+76), RAM 9824 (+12: the adapter's two remembered
+  pin ints — first RAM delta of the series; memory layout, not behavior).
+  architecture-fitness exercises ports/ + infrastructure/ layer rules for
+  the first time: OK. Remaining adapters (joystick ADC, S.BUS, X.BUS,
+  Wi-Fi, piezo, watchdog, clock) follow in later slices or with the
+  FirmwareApp composition root (step 11).
+
 ## 2026-07-13 — Phase D step 9: OutputGate extracted to src/domain/safety/ (#170)
 
 - `outputUpdate()`'s fail-safe state machine (#88/#65) moved VERBATIM to

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -14,7 +14,8 @@ The production sketch is not modified for testing. Each test binary compiles
 `sketches/rc_test/src/**/*.cpp` domain sources the sketch delegates to as the
 Phase D migration (#117) proceeds. Pure-domain suites (one dir per extracted
 domain, e.g. `battery/`) test the extracted code directly — no firmware, no
-stubs:
+stubs, and no `src/infrastructure/` sources (those include hardware headers
+and are compiled only into the stub-backed firmware suites, #172):
 
 ```text
 tests/

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -29,6 +29,10 @@ drive exactly as before.
   `src/domain/safety/`. All pure logic — no Arduino includes, time passed
   as a parameter, hardware effects returned as actions for the sketch to
   execute; the sketch keeps thin delegates until the composition root lands
+- **First port + adapter** — `src/ports/EscOutputPort.h` (a link-time seam)
+  with `src/infrastructure/arduino/PwmEscAdapter.cpp` owning the Servo
+  objects: infrastructure is the only layer that includes hardware
+  libraries
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -54,7 +54,6 @@
 //   5V ──[10K]──┬──► NPN collector ──► D12 (sbusUart RX)
 
 #include <Arduino.h>
-#include <Servo.h>
 #include <WiFiS3.h>
 #include <WDT.h>        // RA4M1 hardware watchdog — control-loop runaway backstop (#69)
 #include "sbus.h"

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -76,6 +76,7 @@
 #include "src/domain/safety/SafetySupervisor.h"
 #include "src/domain/safety/OutputGate.h"
 #include "src/telemetry/TelemetryScaling.h"
+#include "src/ports/EscOutputPort.h"
 
 
 // Second hardware UART on D11=TX(pin 11) / D12=RX(pin 12) via SCI0.
@@ -560,21 +561,21 @@ DriveCommand mixCommands(DriveCommand rc, int ovr, DriveCommand joy) {
 // [OUTPUT] — ESC servo PWM (non-blocking)
 // ═══════════════════════════════════════════════════════════════
 
-Servo escL, escR;
+// The Servo objects moved to infrastructure/arduino/PwmEscAdapter.cpp
+// behind ports/EscOutputPort.h (#117 step 10 slice 1, #172). The clamp and
+// the outL/outR globals stay HERE — application-visible output state (read
+// by buildTelemJson and the OutputGate shim, reset by the test harness).
 int outL = SVC, outR = SVC;
 
 void outputInit() {
-  escL.attach(PIN_ESC_L);
-  escR.attach(PIN_ESC_R);
-  escL.writeMicroseconds(SVC);
-  escR.writeMicroseconds(SVC);
+  escOutputInitialize(PIN_ESC_L, PIN_ESC_R);
+  escOutputWritePulses(SVC, SVC);
 }
 
 void outputWrite(int left, int right) {
   outL = constrain(left,  SVMIN, SVMAX);
   outR = constrain(right, SVMIN, SVMAX);
-  escL.writeMicroseconds(outL);
-  escR.writeMicroseconds(outR);
+  escOutputWritePulses(outL, outR);
 }
 
 // Fail-safe output gate (#88 / #65). The Arduino drives PWM ONLY when it has a
@@ -614,15 +615,9 @@ void outputUpdate(bool driveAllowed, int mixL, int mixR) {
   outHoldMs = gate.holdStartMs;
   rampFromL = gate.rampFromLeft;
   rampFromR = gate.rampFromRight;
-  if (action.attach) {
-    escL.attach(PIN_ESC_L);
-    escR.attach(PIN_ESC_R);
-  }
+  if (action.attach) escOutputAttach();
   if (action.write) outputWrite(action.leftPulse, action.rightPulse);
-  if (action.detach) {
-    escL.detach();                    // at neutral → stop pulsing → ESCs beep
-    escR.detach();
-  }
+  if (action.detach) escOutputDetach();  // at neutral → stop pulsing → ESCs beep
 }
 
 

--- a/sketches/rc_test/src/infrastructure/arduino/PwmEscAdapter.cpp
+++ b/sketches/rc_test/src/infrastructure/arduino/PwmEscAdapter.cpp
@@ -1,0 +1,38 @@
+// infrastructure/arduino — PWM ESC adapter (#117 step 10 slice 1, #172).
+// The ONE implementation of ports/EscOutputPort.h. Owns the Servo objects
+// (moved from rc_test.ino) — the only ESC-output code that includes a
+// hardware library. Behavior is locked end-to-end by
+// tests/characterization/test_output_gate.cpp via the stub Servo captures.
+#include "../../ports/EscOutputPort.h"
+
+#include <Arduino.h>
+#include <Servo.h>
+
+// External linkage: the test harness (FirmwareUnderTest.h) resets these
+// between cases via an extern declaration.
+Servo escL, escR;
+
+static int escLeftPin = -1;
+static int escRightPin = -1;
+
+void escOutputInitialize(int leftPin, int rightPin) {
+  escLeftPin = leftPin;
+  escRightPin = rightPin;
+  escL.attach(leftPin);
+  escR.attach(rightPin);
+}
+
+void escOutputAttach() {
+  escL.attach(escLeftPin);
+  escR.attach(escRightPin);
+}
+
+void escOutputDetach() {
+  escL.detach();
+  escR.detach();
+}
+
+void escOutputWritePulses(int leftPulse, int rightPulse) {
+  escL.writeMicroseconds(leftPulse);
+  escR.writeMicroseconds(rightPulse);
+}

--- a/sketches/rc_test/src/ports/EscOutputPort.h
+++ b/sketches/rc_test/src/ports/EscOutputPort.h
@@ -1,0 +1,18 @@
+// ports — the ESC output contract (#117 step 10 slice 1, #172).
+// A link-time seam (#130): free functions, ONE linked implementation
+// (infrastructure/arduino/PwmEscAdapter.cpp). Consumed by the application
+// layer; domain/ never includes ports. The caller owns pulse clamping and
+// any application-visible output state — this port only moves pulses.
+#pragma once
+
+// Attach both ESC outputs and remember the pins for later re-attach.
+void escOutputInitialize(int leftPin, int rightPin);
+
+// Re-attach after a cut (the OutputGate's resume-from-CUT edge).
+void escOutputAttach();
+
+// Stop pulsing entirely (the ESCs lose signal and beep).
+void escOutputDetach();
+
+// Emit one servo pulse pair, microseconds. Pulses arrive pre-clamped.
+void escOutputWritePulses(int leftPulse, int rightPulse);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,8 +19,12 @@ DOMAIN_INCLUDES := -Ivendor/doctest
 
 # Phase D (#117): extracted sketch sources are linked into every test binary —
 # the firmware delegates to them, and domain suites test them directly.
+# Infrastructure sources include hardware headers, so only the stub-backed
+# firmware suites compile them; the pure suites take the hardware-free set
+# (an accidental hardware include in domain code still fails loudly, #172).
 SKETCH_SRC_CPPS    := $(shell find ../sketches/rc_test/src -name '*.cpp' 2>/dev/null)
 SKETCH_SRC_HEADERS := $(shell find ../sketches/rc_test/src -name '*.h' 2>/dev/null)
+SKETCH_PURE_CPPS   := $(filter-out ../sketches/rc_test/src/infrastructure/%,$(SKETCH_SRC_CPPS))
 
 FIRMWARE := ../sketches/rc_test/rc_test.ino \
             ../sketches/rc_test/types.h \
@@ -62,27 +66,27 @@ build/%: invariants/%.cpp $(HARNESS) $(FIRMWARE)
 
 build/%: battery/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
-	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
 build/%: thermal/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
-	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
 build/%: telemetry/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
-	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
 build/%: operator_input/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
-	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
 build/%: drive/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
-	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
 build/%: safety/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
-	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
+	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
 run: all
 	@status=0; \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -64,27 +64,27 @@ build/%: invariants/%.cpp $(HARNESS) $(FIRMWARE)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 
-build/%: battery/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
+build/%: battery/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
-build/%: thermal/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
+build/%: thermal/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
-build/%: telemetry/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
+build/%: telemetry/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
-build/%: operator_input/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
+build/%: operator_input/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
-build/%: drive/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
+build/%: drive/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
-build/%: safety/%.cpp $(SKETCH_SRC_CPPS) $(SKETCH_SRC_HEADERS)
+build/%: safety/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 

--- a/tests/characterization/FirmwareUnderTest.h
+++ b/tests/characterization/FirmwareUnderTest.h
@@ -19,6 +19,12 @@
 // globals, and (internal-linkage) constants — is visible to the tests.
 #include "../../sketches/rc_test/rc_test.ino"  // NOLINT(build/include)
 
+// The Servo objects live in infrastructure/arduino/PwmEscAdapter.cpp
+// (#172), linked into every characterization binary; resetFirmwareState()
+// reaches them through these declarations.
+extern Servo escL;
+extern Servo escR;
+
 // Restore every MUTABLE firmware global to its boot value. Must be kept in
 // sync with rc_test.ino: when a PR adds a mutable global there, it adds the
 // reset here (the firmware-without-tests commit guard forces the pairing).
@@ -43,6 +49,8 @@ inline void resetFirmwareState() {
   lastAdcTime = 0;
   // [OUTPUT] — fresh Servo objects too: a stale pin binding from a previous
   // test case would otherwise let outputWrite() log into the cleared capture.
+  // The objects live in infrastructure/arduino/PwmEscAdapter.cpp (#172);
+  // the extern declarations sit above resetFirmwareState().
   escL = Servo{};
   escR = Servo{};
   outL = SVC;


### PR DESCRIPTION
Closes #172

## Summary

Phase D step 10, slice 1 (#117/#130, epic #116): the first port + infrastructure adapter, deliberately minimal — the one hardware contract with a concrete consumer today.

- **`src/ports/EscOutputPort.h`** — the ESC output contract as a link-time seam (free functions, no virtuals, per #130): `escOutputInitialize(leftPin, rightPin)` / `escOutputAttach()` / `escOutputDetach()` / `escOutputWritePulses(left, right)`.
- **`src/infrastructure/arduino/PwmEscAdapter.cpp`** — the ONE linked implementation; owns the `Servo escL, escR` objects (moved out of the `.ino`) and remembers the pins. The only ESC-output code that includes hardware headers (`Arduino.h` before `Servo.h` — the stub `Servo.h` uses `millis()`).
- **Behavior boundaries (covenant):** the `constrain(SVMIN, SVMAX)` clamp and the `outL`/`outR` globals stay in the `.ino` — application-visible state read by `buildTelemJson` and the OutputGate shim. Only the `writeMicroseconds`/attach/detach calls route through the port, at the same call sites in the same order (attach → write → detach).
- **Harness:** pure suites now compile `SKETCH_PURE_CPPS` (infrastructure sources filtered out — they need the stubs the pure suites deliberately exclude, so an accidental hardware include in domain code still fails loudly); firmware suites compile everything and the stub `Servo.h` captures are unchanged; `FirmwareUnderTest.h` reaches the moved Servo objects via `extern` declarations (test-surface wiring, ZERO expectation changes).
- Architecture-fitness exercises the `ports/` and `infrastructure/` layer rules on real files for the first time — OK.
- **Remaining adapters** (joystick ADC, S.BUS, X.BUS, Wi-Fi, piezo, watchdog, clock) follow in later slices or land with the FirmwareApp composition root (step 11), as scoped in the issue.

**Behavior preservation:** all 25 host binaries green with ZERO expectation changes. Flash 117236 (+76); RAM 9824 (+12 — the adapter's two remembered pin ints, the first RAM delta of the series; memory layout, not behavior).

Docs synced same-PR: DECISION-LOG entry, TESTING.md, wiki architecture-remediation note, CLAUDE.md file map.

**Role tag:** `[C-Builder]`

## Test plan

- [x] `wsl -e make -C tests run` — all 25 binaries green, zero expectation changes
- [x] `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` — flash 117236 (+76), RAM 9824 (+12, documented)
- [x] `python scripts/check_architecture.py` OK (first real ports/ + infrastructure/ trees; expected migration-window NOTE)
- [x] Pre-commit gate + cpplint two-space pre-check passed
- [ ] CI: all workflows green
- [ ] Bench: none applicable (same pulses, same order; no hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved ESC output handling by separating hardware-specific control from application logic.
  * Preserved existing output clamping, pulse updates, and fail-safe attach/detach behavior.

* **Testing**
  * Updated test builds to distinguish hardware-backed firmware suites from pure-domain suites.
  * Enhanced characterization tests to reset ESC output state reliably.

* **Documentation**
  * Documented the new ESC output boundaries, architecture, testing scope, and design decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->