### PR TITLE
V7.35: JoystickPort + AlertOutputPort adapters — infrastructure slice 2 (#174, Phase D step 10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,7 +305,7 @@ sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes
 sketches/rc_test/src/domain/safety/      — Extracted domain (#117): SafetyTypes.h + SafetySupervisor.h/.cpp + OutputGate.h/.cpp (drive allow/deny + FailsafeReason; ACTIVE/HOLD/CUT gate)
 sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (X.BUS register decode + ×10 wire encode, header-only)
 sketches/rc_test/src/ports/              — Hardware contracts as link-time seams (#130): EscOutputPort.h + JoystickPort.h + AlertOutputPort.h
-sketches/rc_test/src/infrastructure/     — The ONLY layer with hardware includes (#130): arduino/ PwmEscAdapter (owns the Servos) + AdcJoystickAdapter (ADC settle sequence) + PiezoAdapter
+sketches/rc_test/src/infrastructure/     — The ONLY layer with hardware includes (#130): arduino/PwmEscAdapter.cpp (owns the Servos) + arduino/AdcJoystickAdapter.cpp (ADC settle sequence) + arduino/PiezoAdapter.cpp
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit
 sketches/telem_check/telem_check.ino     — Read-only X.BUS telemetry bench tool (0x50 framing)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,8 +304,8 @@ sketches/rc_test/src/domain/operator_input/ — Extracted domain (#117): ExpoCur
 sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes.h + CurvatureDrive.h/.cpp + GearPolicy.h/.cpp + CommandMixer.h/.cpp (curvature mix, gear policy, RC/joystick mixer)
 sketches/rc_test/src/domain/safety/      — Extracted domain (#117): SafetyTypes.h + SafetySupervisor.h/.cpp + OutputGate.h/.cpp (drive allow/deny + FailsafeReason; ACTIVE/HOLD/CUT gate)
 sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (X.BUS register decode + ×10 wire encode, header-only)
-sketches/rc_test/src/ports/              — Hardware contracts as link-time seams (#130): EscOutputPort.h
-sketches/rc_test/src/infrastructure/     — The ONLY layer with hardware includes (#130): arduino/PwmEscAdapter.cpp (owns the Servo objects)
+sketches/rc_test/src/ports/              — Hardware contracts as link-time seams (#130): EscOutputPort.h + JoystickPort.h + AlertOutputPort.h
+sketches/rc_test/src/infrastructure/     — The ONLY layer with hardware includes (#130): arduino/ PwmEscAdapter (owns the Servos) + AdcJoystickAdapter (ADC settle sequence) + PiezoAdapter
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit
 sketches/telem_check/telem_check.ino     — Read-only X.BUS telemetry bench tool (0x50 framing)

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,25 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-13 — Phase D step 10 slice 2: JoystickPort + AlertOutputPort adapters (#174)
+
+- `ports/JoystickPort.h` + `infrastructure/arduino/AdcJoystickAdapter.cpp`:
+  the ADC conditioning sequence moved VERBATIM (discard-read → 100 µs mux
+  settle → real read, Y then X — hardware timing at the 100 Hz joystick
+  cache cadence, non-blocking budget unchanged). `updateJoystick()` keeps
+  the cadence guard, deadband/expo/gain pipeline and cachedJoy writes.
+- `ports/AlertOutputPort.h` + `infrastructure/arduino/PiezoAdapter.cpp`:
+  pinMode+LOW at initialize, one digitalWrite per set. The horn/pattern/
+  alarm OR-priority stays in `[BEEPER]` (alert policy, not hardware —
+  destined for the alerts/ layer later); `beeperUpdate()` computes the
+  same boolean and calls `alertOutputSet(...)`.
+- Verified: all 25 host binaries green, zero expectation changes (stub
+  analogRead/GPIO captures now reached through the adapters); compile
+  clean — flash 117304 (+68 vs 117236), RAM 9828 (+4: the piezo pin int).
+  Remaining step-10 adapters: S.BUS receiver, X.BUS telemetry poller,
+  Wi-Fi/network, watchdog + clock (port-less in the target — land with the
+  FirmwareApp composition root, step 11).
+
 ## 2026-07-13 — Phase D step 10 slice 1: EscOutputPort + PwmEscAdapter (#172)
 
 - First infrastructure slice: `ports/EscOutputPort.h` (link-time seam per

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -29,10 +29,10 @@ drive exactly as before.
   `src/domain/safety/`. All pure logic — no Arduino includes, time passed
   as a parameter, hardware effects returned as actions for the sketch to
   execute; the sketch keeps thin delegates until the composition root lands
-- **First port + adapter** — `src/ports/EscOutputPort.h` (a link-time seam)
-  with `src/infrastructure/arduino/PwmEscAdapter.cpp` owning the Servo
-  objects: infrastructure is the only layer that includes hardware
-  libraries
+- **Ports + adapters** — `src/ports/` link-time seams (ESC output,
+  joystick ADC, piezo alert) with their `src/infrastructure/arduino/`
+  adapters owning the Servo objects, the ADC settle sequence and the piezo
+  pin: infrastructure is the only layer that includes hardware libraries
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -76,6 +76,8 @@
 #include "src/domain/safety/OutputGate.h"
 #include "src/telemetry/TelemetryScaling.h"
 #include "src/ports/EscOutputPort.h"
+#include "src/ports/JoystickPort.h"
+#include "src/ports/AlertOutputPort.h"
 
 
 // Second hardware UART on D11=TX(pin 11) / D12=RX(pin 12) via SCI0.
@@ -512,10 +514,10 @@ void updateJoystick(uint32_t now) {
   if ((now - lastAdcTime) < ADC_INTERVAL) return;
   lastAdcTime = now;
 
-  analogRead(PIN_JOY_Y); delayMicroseconds(100);
-  cachedJoy.rawY = analogRead(PIN_JOY_Y);
-  analogRead(PIN_JOY_X); delayMicroseconds(100);
-  cachedJoy.rawX = analogRead(PIN_JOY_X);
+  // The ADC conditioning sequence (discard-read, 100 µs settle, real read)
+  // lives in infrastructure/arduino/AdcJoystickAdapter.cpp behind
+  // ports/JoystickPort.h (#117 step 10 slice 2, #174).
+  joystickReadAxes(PIN_JOY_Y, PIN_JOY_X, &cachedJoy.rawY, &cachedJoy.rawX);
 
   float normY = constrain((float)(joyDeadband(cachedJoy.rawY) - ADC_CENTER) / ADC_CENTER, -1.0f, 1.0f);
   float normX = constrain((float)(joyDeadband(cachedJoy.rawX) - ADC_CENTER) / ADC_CENTER, -1.0f, 1.0f);
@@ -801,7 +803,10 @@ const uint16_t* beepSeq = nullptr;
 int      beepLen = 0, beepIdx = -1;
 uint32_t beepPhaseMs = 0;
 
-void beeperInit() { pinMode(PIN_BEEPER, OUTPUT); digitalWrite(PIN_BEEPER, LOW); }
+// The pin work lives in infrastructure/arduino/PiezoAdapter.cpp behind
+// ports/AlertOutputPort.h (#117 step 10 slice 2, #174); the horn/pattern/
+// alarm priority policy stays here.
+void beeperInit() { alertOutputInitialize(PIN_BEEPER); }
 
 // Queue a non-blocking on/off pattern (durations in ms, starting with ON).
 void beepStart(const uint16_t *seq, int len) {
@@ -819,7 +824,7 @@ void beeperUpdate() {
     patternOn = (beepIdx >= 0 && beepIdx < beepLen) && (beepIdx % 2 == 0);
   }
   // Horn (manual) ORs over one-shot patterns ORs over [ALERT] alarms.
-  digitalWrite(PIN_BEEPER, (hornActive || patternOn || alarmOutputOn) ? HIGH : LOW);
+  alertOutputSet(hornActive || patternOn || alarmOutputOn);
 }
 
 

--- a/sketches/rc_test/src/infrastructure/arduino/AdcJoystickAdapter.cpp
+++ b/sketches/rc_test/src/infrastructure/arduino/AdcJoystickAdapter.cpp
@@ -1,0 +1,19 @@
+// infrastructure/arduino — ADC joystick adapter (#117 step 10 slice 2,
+// #174). The ONE implementation of ports/JoystickPort.h. The conditioning
+// sequence moved VERBATIM from rc_test.ino updateJoystick(): discard-read →
+// 100 µs mux settle → real read, per axis, Y then X. That sequence is
+// hardware timing (14-bit ADC settling) and runs at the 100 Hz joystick
+// cache cadence — not per loop pass — so the non-blocking budget is
+// unchanged. Behavior is locked end-to-end by
+// tests/characterization/test_input_shaping.cpp via the scripted stub
+// analogRead.
+#include "../../ports/JoystickPort.h"
+
+#include <Arduino.h>
+
+void joystickReadAxes(int yPin, int xPin, int* rawY, int* rawX) {
+  analogRead(yPin); delayMicroseconds(100);
+  *rawY = analogRead(yPin);
+  analogRead(xPin); delayMicroseconds(100);
+  *rawX = analogRead(xPin);
+}

--- a/sketches/rc_test/src/infrastructure/arduino/AdcJoystickAdapter.cpp
+++ b/sketches/rc_test/src/infrastructure/arduino/AdcJoystickAdapter.cpp
@@ -12,8 +12,10 @@
 #include <Arduino.h>
 
 void joystickReadAxes(int yPin, int xPin, int* rawY, int* rawX) {
-  analogRead(yPin); delayMicroseconds(100);
+  analogRead(yPin);
+  delayMicroseconds(100);
   *rawY = analogRead(yPin);
-  analogRead(xPin); delayMicroseconds(100);
+  analogRead(xPin);
+  delayMicroseconds(100);
   *rawX = analogRead(xPin);
 }

--- a/sketches/rc_test/src/infrastructure/arduino/PiezoAdapter.cpp
+++ b/sketches/rc_test/src/infrastructure/arduino/PiezoAdapter.cpp
@@ -1,0 +1,19 @@
+// infrastructure/arduino — active-piezo adapter (#117 step 10 slice 2,
+// #174). The ONE implementation of ports/AlertOutputPort.h. Behavior is
+// locked end-to-end by tests/characterization/test_alerts.cpp via the stub
+// GPIO capture.
+#include "../../ports/AlertOutputPort.h"
+
+#include <Arduino.h>
+
+static int alertPin = -1;
+
+void alertOutputInitialize(int pin) {
+  alertPin = pin;
+  pinMode(pin, OUTPUT);
+  digitalWrite(pin, LOW);
+}
+
+void alertOutputSet(bool on) {
+  digitalWrite(alertPin, on ? HIGH : LOW);
+}

--- a/sketches/rc_test/src/ports/AlertOutputPort.h
+++ b/sketches/rc_test/src/ports/AlertOutputPort.h
@@ -1,0 +1,11 @@
+// ports — the alert (piezo) output contract (#117 step 10 slice 2, #174).
+// A link-time seam (#130): free functions, ONE linked implementation
+// (infrastructure/arduino/PiezoAdapter.cpp). The horn/pattern/alarm
+// priority policy stays with the caller — this port only sets the level.
+#pragma once
+
+// Configure the piezo pin as an output, silent.
+void alertOutputInitialize(int pin);
+
+// Drive the piezo: true = sounding, false = silent.
+void alertOutputSet(bool on);

--- a/sketches/rc_test/src/ports/JoystickPort.h
+++ b/sketches/rc_test/src/ports/JoystickPort.h
@@ -1,0 +1,10 @@
+// ports — the joystick input contract (#117 step 10 slice 2, #174).
+// A link-time seam (#130): free functions, ONE linked implementation
+// (infrastructure/arduino/AdcJoystickAdapter.cpp). The caller owns the
+// sampling cadence, deadband, expo and gain pipeline — this port only
+// delivers one conditioned raw ADC pair.
+#pragma once
+
+// Read both axes with the ADC conditioning the hall-effect joystick needs
+// (discard-read, settle, real read — Y axis first, then X).
+void joystickReadAxes(int yPin, int xPin, int* rawY, int* rawX);


### PR DESCRIPTION
Closes #174

## Summary

Phase D step 10, slice 2 (#117/#130, epic #116): the two remaining small Arduino-core seams, following slice 1's pattern (#172/PR #173).

- **`ports/JoystickPort.h` + `infrastructure/arduino/AdcJoystickAdapter.cpp`** — the ADC conditioning sequence moves VERBATIM: discard-read → `delayMicroseconds(100)` mux settle → real read, Y axis then X. That sequence is hardware timing (14-bit ADC settling) and runs at the 100 Hz joystick cache cadence, not per loop pass — the non-blocking budget is unchanged. `updateJoystick()` keeps its cadence guard, deadband/expo/gain pipeline, and `cachedJoy` writes.
- **`ports/AlertOutputPort.h` + `infrastructure/arduino/PiezoAdapter.cpp`** — `pinMode(OUTPUT)`+LOW at initialize, one `digitalWrite` per set. The horn/pattern/alarm OR-priority stays in `[BEEPER]` (it's alert policy, not hardware — destined for the `alerts/` layer in a later step); `beeperUpdate()` computes the identical boolean and calls `alertOutputSet(...)`.
- Pins stay `[CONFIG]`, passed at initialize (the slice-1 pattern). No harness changes needed — the stub `analogRead` scripting and GPIO captures are reached through the adapters unchanged.
- **Remaining step-10 adapters** (S.BUS receiver, X.BUS telemetry poller, Wi-Fi/network) plus the port-less watchdog/clock land in later slices or with the FirmwareApp composition root (step 11), as scoped in the issue.

**Behavior preservation:** all 25 host binaries green with ZERO expectation changes. Flash 117304 (+68); RAM 9828 (+4: the piezo pin int, same class as slice 1's remembered pins).

Docs synced same-PR: DECISION-LOG entry, wiki architecture-remediation note, CLAUDE.md file map.

**Role tag:** `[C-Builder]`

## Test plan

- [x] `wsl -e make -C tests run` — all 25 binaries green, zero expectation changes
- [x] `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` — flash 117304 (+68), RAM 9828 (+4, documented)
- [x] `python scripts/check_architecture.py` OK (expected migration-window NOTE)
- [x] Pre-commit gate + cpplint two-space pre-check passed
- [ ] CI: all workflows green
- [ ] Bench: none applicable (same reads, same settle timing, same pin writes; no hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
