### PR TITLE
V7.35: RcInputPort + SbusReceiverAdapter — infrastructure slice 3 (#176, Phase D step 10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,13 +150,14 @@ GND -> All components (common ground)
 ### UART Architecture (UNO R4 WiFi)
 
 The UNO R4 WiFi exposes Serial1 (SCI2 on D0/D1) plus a second UART that can be
-instantiated on D11 (TX) / D12 (RX) via the RA4M1's SCI0 channel. The sketch
+instantiated on D11 (TX) / D12 (RX) via the RA4M1's SCI0 channel. The S.BUS
+adapter (`src/infrastructure/radiolink/SbusReceiverAdapter.cpp`, #176)
 declares it under a unique name (NOT `Serial2`, which collides with the core's
 pre-declared `_UART2_`, and is also reserved for the ESP32-S3 Wi-Fi bridge):
 
 ```cpp
-const uint8_t PIN_SBUS_TX = 11;  // SCI0 TX (D11) — unused, S.BUS is RX-only
-const uint8_t PIN_SBUS_RX = 12;  // SCI0 RX (D12) — inverted S.BUS in
+static const uint8_t PIN_SBUS_TX = 11;  // SCI0 TX (D11) — unused, S.BUS is RX-only
+static const uint8_t PIN_SBUS_RX = 12;  // SCI0 RX (D12) — inverted S.BUS in
 UART sbusUart(PIN_SBUS_TX, PIN_SBUS_RX);
 bfs::SbusRx sbusRx(&sbusUart);
 ```
@@ -304,8 +305,8 @@ sketches/rc_test/src/domain/operator_input/ — Extracted domain (#117): ExpoCur
 sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes.h + CurvatureDrive.h/.cpp + GearPolicy.h/.cpp + CommandMixer.h/.cpp (curvature mix, gear policy, RC/joystick mixer)
 sketches/rc_test/src/domain/safety/      — Extracted domain (#117): SafetyTypes.h + SafetySupervisor.h/.cpp + OutputGate.h/.cpp (drive allow/deny + FailsafeReason; ACTIVE/HOLD/CUT gate)
 sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (X.BUS register decode + ×10 wire encode, header-only)
-sketches/rc_test/src/ports/              — Hardware contracts as link-time seams (#130): EscOutputPort.h + JoystickPort.h + AlertOutputPort.h
-sketches/rc_test/src/infrastructure/     — The ONLY layer with hardware includes (#130): arduino/PwmEscAdapter.cpp (owns the Servos) + arduino/AdcJoystickAdapter.cpp (ADC settle sequence) + arduino/PiezoAdapter.cpp
+sketches/rc_test/src/ports/              — Hardware contracts as link-time seams (#130): EscOutputPort.h + JoystickPort.h + AlertOutputPort.h + RcInputPort.h (RcFrame)
+sketches/rc_test/src/infrastructure/     — The ONLY layer with hardware includes (#130): arduino/PwmEscAdapter.cpp (owns the Servos) + arduino/AdcJoystickAdapter.cpp (ADC settle sequence) + arduino/PiezoAdapter.cpp + radiolink/SbusReceiverAdapter.cpp (owns sbusUart + the S.BUS parser)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit
 sketches/telem_check/telem_check.ino     — Read-only X.BUS telemetry bench tool (0x50 framing)

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,34 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-13 — Phase D step 10 slice 3: RcInputPort + SbusReceiverAdapter (#176)
+
+- `ports/RcInputPort.h` defines the RC input contract in domain types:
+  `RcFrame {int16_t channels[16]; bool failsafe; bool lostFrame;}` +
+  `rcInputInitialize()` / `rcInputReadFrame(RcFrame*)`. The bfs vendor
+  S.BUS type never crosses the port — first slice to translate a vendor
+  type at the boundary rather than pass it through.
+- `infrastructure/radiolink/SbusReceiverAdapter.cpp` owns `UART
+  sbusUart(11, 12)` (SCI0 — the not-`Serial2` collision detail) and
+  `bfs::SbusRx` (moved from the `.ino`); on `Read()` success it copies 16
+  channels + failsafe/lost_frame into the caller's `RcFrame`. First
+  non-`arduino/` infrastructure folder (vendor-specific: radiolink).
+- The `.ino`'s `bfs::SbusData sbusData` global became `RcFrame rcFrame`;
+  every consumer renamed mechanically (`.ch[` → `.channels[`,
+  `.lost_frame` → `.lostFrame`). The loop() read block keeps its exact
+  freshness semantics (`sbusLastFrame = now` on frame, `SBUS_TIMEOUT`
+  staleness unchanged). `#include "sbus.h"` moved to the adapter
+  (empirically verified — arduino-cli library detection scans src/).
+- Harness: `feedSbusFrame()` now scripts through `rcInputReadFrame()`
+  exactly like loop(); `resetFirmwareState()` resets `rcFrame` and
+  re-creates the extern `sbusRx` (parser residue = power-cycle
+  equivalence). Stub sbus.h frame queue is global, so scripting is
+  unchanged.
+- Verified: all 25 host binaries green, ZERO expectation changes; compile
+  clean — flash 117356 (+52), RAM 9832 (+4; linkage/layout of the moved
+  objects, not behavior). Remaining step-10 adapters: X.BUS telemetry
+  poller, Wi-Fi/network; watchdog + clock land with FirmwareApp (step 11).
+
 ## 2026-07-13 — Phase D step 10 slice 2: JoystickPort + AlertOutputPort adapters (#174)
 
 - `ports/JoystickPort.h` + `infrastructure/arduino/AdcJoystickAdapter.cpp`:

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -30,9 +30,12 @@ drive exactly as before.
   as a parameter, hardware effects returned as actions for the sketch to
   execute; the sketch keeps thin delegates until the composition root lands
 - **Ports + adapters** — `src/ports/` link-time seams (ESC output,
-  joystick ADC, piezo alert) with their `src/infrastructure/arduino/`
-  adapters owning the Servo objects, the ADC settle sequence and the piezo
-  pin: infrastructure is the only layer that includes hardware libraries
+  joystick ADC, piezo alert, RC input) with their `src/infrastructure/`
+  adapters (`arduino/` + `radiolink/`) owning the Servo objects, the ADC
+  settle sequence, the piezo pin, and the S.BUS UART + parser:
+  infrastructure is the only layer that includes hardware libraries, and
+  vendor types (the bfs S.BUS frame) are translated to domain types
+  (`RcFrame`) at the port boundary
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -56,7 +56,6 @@
 #include <Arduino.h>
 #include <WiFiS3.h>
 #include <WDT.h>        // RA4M1 hardware watchdog — control-loop runaway backstop (#69)
-#include "sbus.h"
 #include "types.h"
 #include "web_page.h"   // const char INDEX_HTML[] — the dashboard, served at "/"
 
@@ -78,17 +77,12 @@
 #include "src/ports/EscOutputPort.h"
 #include "src/ports/JoystickPort.h"
 #include "src/ports/AlertOutputPort.h"
+#include "src/ports/RcInputPort.h"
 
 
-// Second hardware UART on D11=TX(pin 11) / D12=RX(pin 12) via SCI0.
-// S.BUS only needs RX; TX is unused. Named `sbusUart` (not Serial2)
-// to avoid the macro collision with the core's pre-declared _UART2_.
-// UNO R4 WiFi: SCI0 is on D11/D12 (Nano R4 used A4/A5 for SCI0).
-// These pin constants live here (not in [CONFIG] below) because sbusUart is a
-// global constructed at static-init time — it must see them before [CONFIG].
-const uint8_t PIN_SBUS_TX = 11;  // SCI0 TX (D11) — unused, S.BUS is RX-only
-const uint8_t PIN_SBUS_RX = 12;  // SCI0 RX (D12) — inverted S.BUS in
-UART sbusUart(PIN_SBUS_TX, PIN_SBUS_RX);
+// The second hardware UART (SCI0, D11/D12), the S.BUS parser and their pin
+// constants moved to infrastructure/radiolink/SbusReceiverAdapter.cpp
+// behind ports/RcInputPort.h (#117 step 10 slice 3, #176).
 
 
 // ═══════════════════════════════════════════════════════════════
@@ -431,8 +425,7 @@ ServoOutput wheelSpeedsToServo(WheelSpeeds ws) {
 // [RC] — S.BUS input on sbusUart / SCI0 (D12 RX, NPN inverter)
 // ═══════════════════════════════════════════════════════════════
 
-bfs::SbusRx sbusRx(&sbusUart);
-bfs::SbusData sbusData;
+RcFrame rcFrame = {};                    // latest received frame (domain type)
 bool sbusValid = false;
 uint32_t sbusLastFrame = 0;
 const uint32_t SBUS_TIMEOUT = 100000UL;  // 100ms
@@ -447,9 +440,9 @@ int rcDeadband(int pw) {
   return centerSnapDeadband(pw, SVC, RC_DEADBAND);
 }
 
-int rcThrottle() { return sbusValid ? rcDeadband(sbusToServo(sbusData.ch[SBUS_CH_THR]))   : SVC; }
-int rcSteering() { return sbusValid ? rcDeadband(sbusToServo(sbusData.ch[SBUS_CH_STEER])) : SVC; }
-int rcOverride() { return sbusValid ? sbusToServo(sbusData.ch[SBUS_CH_OVR]) : SVMIN; }
+int rcThrottle() { return sbusValid ? rcDeadband(sbusToServo(rcFrame.channels[SBUS_CH_THR]))   : SVC; }
+int rcSteering() { return sbusValid ? rcDeadband(sbusToServo(rcFrame.channels[SBUS_CH_STEER])) : SVC; }
+int rcOverride() { return sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_OVR]) : SVMIN; }
 
 // RC axis command (xSpeed/zRotation), post-gain and reverse-limit — pre-mix,
 // pre-curvatureDrive. The mix combines RC + joystick at this axis level (#90),
@@ -471,7 +464,7 @@ DriveCommand rcCommand() {
 // ═══════════════════════════════════════════════════════════════
 //
 // updateGear() is defined here (after [RC]) so it can read sbusValid /
-// sbusData directly. The gearScale and currentGear globals it writes
+// rcFrame directly. The gearScale and currentGear globals it writes
 // are declared up in [CONFIG] so the drive functions and curvatureDrive
 // can read them for the Eco-only conditional caps.
 
@@ -486,7 +479,7 @@ void updateGear() {
   static const GearPolicyParameters GEAR_POLICY_PARAMETERS{
       GEAR_LOW_SCALE, GEAR_MID_SCALE, GEAR_HIGH_SCALE, OVR_LO, OVR_HI};
   GearSelection selection = gearPolicySelect(
-      sbusValid ? sbusToServo(sbusData.ch[SBUS_CH_GEAR]) : 0, sbusValid,
+      sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_GEAR]) : 0, sbusValid,
       ecoLockLatched || tempEcoActive, GEAR_POLICY_PARAMETERS);
   gearScale = selection.scale;
   currentGear = (Gear)selection.level;
@@ -1189,7 +1182,7 @@ int buildTelemJson(char *body, size_t cap) {
     "\"e0\":{\"ok\":%d,\"age\":%lu,\"rpm\":%ld,\"cur\":%d,\"v\":%d,\"tE\":%d,\"tM\":%d},"
     "\"e1\":{\"ok\":%d,\"age\":%lu,\"rpm\":%ld,\"cur\":%d,\"v\":%d,\"tE\":%d,\"tM\":%d}}",
     (unsigned long)nowMs, (unsigned long)wifiSeq, (int)currentGear, wifiMode(),
-    sbusData.failsafe ? 1 : 0, sbusData.lost_frame ? 1 : 0,
+    rcFrame.failsafe ? 1 : 0, rcFrame.lostFrame ? 1 : 0,
     ecoLockLatched ? 1 : 0, batteryCutoffLatched ? 1 : 0,
     tempWarnActive ? 1 : 0, tempEcoActive ? 1 : 0, tempCutActive ? 1 : 0,
     outL, outR,
@@ -1428,10 +1421,10 @@ void debugPrint(uint32_t now) {
   if (!Serial || (now - prevPrint) < PRINT_INTERVAL) return;
   prevPrint = now;
 
-  int rcT = sbusValid ? sbusToServo(sbusData.ch[SBUS_CH_THR])   : SVC;
-  int rcS = sbusValid ? sbusToServo(sbusData.ch[SBUS_CH_STEER]) : SVC;
-  int rc4 = sbusValid ? sbusToServo(sbusData.ch[SBUS_CH_GEAR])  : SVC;
-  int rc5 = sbusValid ? sbusToServo(sbusData.ch[SBUS_CH_OVR])   : SVMIN;
+  int rcT = sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_THR])   : SVC;
+  int rcS = sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_STEER]) : SVC;
+  int rc4 = sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_GEAR])  : SVC;
+  int rc5 = sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_OVR])   : SVMIN;
 
   // Telemetry, integer-scaled so we avoid float printf on this core.
   int v0 = (int)lroundf(telem[0].voltage    * 10.0f);
@@ -1449,7 +1442,7 @@ void debugPrint(uint32_t now) {
            rcT, rcS, rc4, rc5,
            cachedJoy.rawY, cachedJoy.rawX,
            outL, outR, (int)currentGear,
-           sbusData.failsafe, sbusData.lost_frame,
+           rcFrame.failsafe, rcFrame.lostFrame,
            v0, i0, telem[0].rpmHz, e0, m0, telem[0].valid ? 1 : 0,
            v1, i1, telem[1].rpmHz, e1, m1, telem[1].valid ? 1 : 0);
   Serial.println(buf);
@@ -1462,7 +1455,7 @@ void debugPrint(uint32_t now) {
 
 void setup() {
   analogReadResolution(14);
-  sbusRx.Begin();
+  rcInputInitialize();
   outputInit();
   beeperInit();
   alertInit();
@@ -1490,13 +1483,12 @@ void loop() {
   uint32_t now = micros();
 
   // 1. Read inputs
-  if (sbusRx.Read()) {
-    sbusData = sbusRx.data();
+  if (rcInputReadFrame(&rcFrame)) {
     sbusLastFrame = now;
-    sbusValid = !sbusData.failsafe;
+    sbusValid = !rcFrame.failsafe;
   }
   if ((now - sbusLastFrame) > SBUS_TIMEOUT) sbusValid = false;
-  hornActive = sbusValid && (sbusData.ch[SBUS_CH_HORN] > HORN_ON_RAW);
+  hornActive = sbusValid && (rcFrame.channels[SBUS_CH_HORN] > HORN_ON_RAW);
 
   // 1.5 Staged low-battery protection (#65) — evaluate BEFORE gear select so the
   // Eco lock can override it. Stage 1 (~11 V) forces Eco; Stage 2 (10 V) cuts.

--- a/sketches/rc_test/src/infrastructure/radiolink/SbusReceiverAdapter.cpp
+++ b/sketches/rc_test/src/infrastructure/radiolink/SbusReceiverAdapter.cpp
@@ -1,0 +1,40 @@
+// infrastructure/radiolink — S.BUS receiver adapter (#117 step 10 slice 3,
+// #176). The ONE implementation of ports/RcInputPort.h. Owns the second
+// hardware UART and the Bolder Flight Systems S.BUS parser (moved from
+// rc_test.ino) — the inverted-UART detail lives here.
+//
+// UNO R4 WiFi: SCI0 is on D11/D12 (the Nano R4 used A4/A5). S.BUS only
+// needs RX; TX is unused. The UART is named sbusUart (not Serial2) to avoid
+// the macro collision with the core's pre-declared _UART2_. S.BUS idles
+// electrically inverted; the NPN inverter on D12 restores standard UART
+// polarity (wiring: docs/WIRING-GUIDE-V8.md). Behavior is locked end-to-end
+// by the characterization suites via the stub S.BUS frame queue.
+#include "../../ports/RcInputPort.h"
+
+#include <Arduino.h>
+
+#include "sbus.h"
+
+static const uint8_t PIN_SBUS_TX = 11;  // SCI0 TX (D11) — unused, RX-only
+static const uint8_t PIN_SBUS_RX = 12;  // SCI0 RX (D12) — inverted S.BUS in
+
+UART sbusUart(PIN_SBUS_TX, PIN_SBUS_RX);
+
+// External linkage: the test harness scripts frames through the stub sbus.h
+// queue; the object itself is reachable for completeness.
+bfs::SbusRx sbusRx(&sbusUart);
+
+void rcInputInitialize() {
+  sbusRx.Begin();
+}
+
+bool rcInputReadFrame(RcFrame* out) {
+  if (!sbusRx.Read()) return false;
+  bfs::SbusData data = sbusRx.data();
+  for (int i = 0; i < bfs::SbusData::NUM_CH; i++) {
+    out->channels[i] = data.ch[i];
+  }
+  out->failsafe = data.failsafe;
+  out->lostFrame = data.lost_frame;
+  return true;
+}

--- a/sketches/rc_test/src/infrastructure/radiolink/SbusReceiverAdapter.cpp
+++ b/sketches/rc_test/src/infrastructure/radiolink/SbusReceiverAdapter.cpp
@@ -28,10 +28,16 @@ void rcInputInitialize() {
   sbusRx.Begin();
 }
 
+// The copy is bounded by the PORT's channel count; the vendor frame must
+// carry at least that many or this fails to compile (never a silent
+// out-of-bounds read/write if the library's channel count ever changes).
+static_assert(bfs::SbusData::NUM_CH >= RcFrame::CHANNEL_COUNT,
+              "vendor S.BUS frame carries fewer channels than RcFrame");
+
 bool rcInputReadFrame(RcFrame* out) {
   if (!sbusRx.Read()) return false;
   bfs::SbusData data = sbusRx.data();
-  for (int i = 0; i < bfs::SbusData::NUM_CH; i++) {
+  for (int i = 0; i < RcFrame::CHANNEL_COUNT; i++) {
     out->channels[i] = data.ch[i];
   }
   out->failsafe = data.failsafe;

--- a/sketches/rc_test/src/ports/RcInputPort.h
+++ b/sketches/rc_test/src/ports/RcInputPort.h
@@ -1,0 +1,23 @@
+// ports — the RC input contract (#117 step 10 slice 3, #176).
+// A link-time seam (#130): free functions, ONE linked implementation
+// (infrastructure/radiolink/SbusReceiverAdapter.cpp). Domain types only —
+// the vendor S.BUS type never crosses this port. The caller owns the
+// freshness timeout and every per-channel policy.
+#pragma once
+
+#include <stdint.h>
+
+// One received RC frame: 16 raw channel values plus the receiver's own
+// failsafe/lost-frame flags.
+struct RcFrame {
+  int16_t channels[16];
+  bool failsafe;
+  bool lostFrame;
+};
+
+// Start the receiver (UART + S.BUS parser).
+void rcInputInitialize();
+
+// Poll the receiver. Returns true and fills `out` when a complete fresh
+// frame arrived this pass; false (out untouched) otherwise.
+bool rcInputReadFrame(RcFrame* out);

--- a/sketches/rc_test/src/ports/RcInputPort.h
+++ b/sketches/rc_test/src/ports/RcInputPort.h
@@ -10,7 +10,8 @@
 // One received RC frame: 16 raw channel values plus the receiver's own
 // failsafe/lost-frame flags.
 struct RcFrame {
-  int16_t channels[16];
+  static const uint8_t CHANNEL_COUNT = 16;
+  int16_t channels[CHANNEL_COUNT];
   bool failsafe;
   bool lostFrame;
 };

--- a/tests/characterization/FirmwareUnderTest.h
+++ b/tests/characterization/FirmwareUnderTest.h
@@ -21,9 +21,13 @@
 
 // The Servo objects live in infrastructure/arduino/PwmEscAdapter.cpp
 // (#172), linked into every characterization binary; resetFirmwareState()
-// reaches them through these declarations.
+// reaches them through these declarations. Same pattern for the S.BUS
+// receiver objects in infrastructure/radiolink/SbusReceiverAdapter.cpp
+// (#176).
 extern Servo escL;
 extern Servo escR;
+extern UART sbusUart;
+extern bfs::SbusRx sbusRx;
 
 // Restore every MUTABLE firmware global to its boot value. Must be kept in
 // sync with rc_test.ino: when a PR adds a mutable global there, it adds the
@@ -39,8 +43,10 @@ inline void resetFirmwareState() {
   tempWarnActive = false;
   tempEcoActive = false;
   tempCutActive = false;
-  // [RC]
-  sbusData = bfs::SbusData{};
+  // [RC] — the parser object lives in the S.BUS adapter (#176); a fresh one
+  // drops any last-frame residue exactly like a power cycle would.
+  rcFrame = RcFrame{};
+  sbusRx = bfs::SbusRx(&sbusUart);
   sbusValid = false;
   sbusLastFrame = 0;
   // [JOYSTICK]
@@ -127,14 +133,13 @@ inline int leftEscMicroseconds()  { return stub::servoOnPin(PIN_ESC_L).lastMicro
 inline int rightEscMicroseconds() { return stub::servoOnPin(PIN_ESC_R).lastMicroseconds; }
 
 // Queue one S.BUS frame and run the sbus-read portion the way loop() does,
-// so sbusValid/sbusData/sbusLastFrame update exactly as in flight.
+// so sbusValid/rcFrame/sbusLastFrame update exactly as in flight.
 inline void feedSbusFrame(const bfs::SbusData& frame) {
   stub::queueSbusFrame(frame);
   uint32_t now = micros();
-  if (sbusRx.Read()) {
-    sbusData = sbusRx.data();
+  if (rcInputReadFrame(&rcFrame)) {
     sbusLastFrame = now;
-    sbusValid = !sbusData.failsafe;
+    sbusValid = !rcFrame.failsafe;
   }
 }
 


### PR DESCRIPTION
Closes #176

## Summary

Phase D step 10, slice 3 (#117/#130) — the S.BUS receiver moves behind a port. `[C-Builder]`

- **`src/ports/RcInputPort.h`** — the RC input contract in domain types: `RcFrame {int16_t channels[16]; bool failsafe; bool lostFrame;}` + `rcInputInitialize()` / `rcInputReadFrame(RcFrame*)`. First port to translate a vendor type at the boundary — `bfs::SbusData` never crosses it.
- **`src/infrastructure/radiolink/SbusReceiverAdapter.cpp`** — owns `UART sbusUart(11, 12)` (SCI0; the not-`Serial2` collision detail) and `bfs::SbusRx`, moved verbatim from the `.ino`. On `Read()` success it copies 16 channels + failsafe/lost_frame into the caller's `RcFrame`. First non-`arduino/` infrastructure folder (vendor-specific: `radiolink/`).
- **`.ino` sweep (mechanical)** — `bfs::SbusData sbusData` → `RcFrame rcFrame`; every consumer renames (`.ch[` → `.channels[`, `.failsafe`, `.lost_frame` → `.lostFrame`) at the exact same call sites (rcThrottle/rcSteering/rcOverride, updateGear shim, buildTelemJson, debug print, horn). The loop() read block keeps its exact freshness semantics: copy + `sbusLastFrame = now` on frame; `SBUS_TIMEOUT` staleness unchanged. `#include "sbus.h"` moves to the adapter (slice-1 precedent: arduino-cli library detection scans `src/` — verified by compile).
- **Harness lockstep** — `feedSbusFrame()` scripts through `rcInputReadFrame()` exactly like loop(); `resetFirmwareState()` resets `rcFrame = RcFrame{}` and re-creates the extern `sbusRx` (parser residue = power-cycle equivalence). The stub `sbus.h` frame queue is global, so all scripted scenarios are unchanged.
- **Docs same-PR** — CLAUDE.md (UART architecture section + file map), DECISION-LOG entry, wiki `architecture-remediation` ports bullet.

## Behavior preservation

Zero observable change — covenant PR. All consumer reads are renames of the same struct fields; the read/freshness path is line-for-line the loop() block it replaces.

## Test plan

- Host suite: **all 25 binaries green, ZERO expectation changes** (`wsl -e make -C tests run`) — the stale-RC invariant suite exercises the freshness path end-to-end
- `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` clean — flash 117356 (+52), RAM 9832 (+4; linkage/layout of the moved objects, not behavior)
- `python scripts/check_architecture.py` — OK (first `infrastructure/radiolink/` file exercises the layer rules)
- cpplint pre-checked on both new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized RC input interface for receiving channel data and signal-status information.
  * Added S.BUS receiver support for UNO R4 WiFi hardware.
  * RC controls, gear selection, telemetry, and diagnostics now use the unified RC frame data.

* **Documentation**
  * Updated architecture documentation and decision logs to describe the RC input interface, S.BUS adapter, hardware connections, and related file structure.

* **Tests**
  * Updated characterization tooling to feed and reset RC input through the new interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->