### PR TITLE
V7.35: TelemetrySource port + XbusTelemetryAdapter — infrastructure slice 4 (#178, Phase D step 10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ bfs::SbusRx sbusRx(&sbusUart);
 ### Telemetry (live)
 
 `src/ports/TelemetrySource.h` defines `EscTelem { voltage, busCurrentA, rpmHz,
-escTempC, motorTempC, lastGoodMs, valid }` (re-exported via `types.h`, #178).
+motorTempC, escTempC, lastGoodMs, valid }` (re-exported via `types.h`, #178).
 The X.BUS poller lives in `src/infrastructure/xc/XbusTelemetryAdapter.cpp`
 behind that port; the sketch's `[TELEMETRY]` shim owns the `telem[]` array and
 polls via `telemetrySourceUpdate()` on Serial1 (D0/D1):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,8 +175,11 @@ bfs::SbusRx sbusRx(&sbusUart);
 
 ### Telemetry (live)
 
-`types.h` defines `EscTelem { voltage, busCurrentA, rpmHz, escTempC, motorTempC,
-lastGoodMs, valid }`. The `[TELEMETRY]` module polls it on Serial1 (D0/D1):
+`src/ports/TelemetrySource.h` defines `EscTelem { voltage, busCurrentA, rpmHz,
+escTempC, motorTempC, lastGoodMs, valid }` (re-exported via `types.h`, #178).
+The X.BUS poller lives in `src/infrastructure/xc/XbusTelemetryAdapter.cpp`
+behind that port; the sketch's `[TELEMETRY]` shim owns the `telem[]` array and
+polls via `telemetrySourceUpdate()` on Serial1 (D0/D1):
 
 - **X.BUS Read Register (func 0x10), NOT Throttle (0x50).** 0x10 is
   point-to-point service control — it never puts the ESC into BUS_MODE, so PWM
@@ -298,15 +301,15 @@ and the Arduino-side filter was double-smoothing the stream (operator felt
 PROJECT-PLAN.md                          — Full technical specification
 OPERATOR-GUIDE.md                        — User guide for Jason (RC) and Malaki (joystick)
 sketches/rc_test/rc_test.ino             — Main Arduino sketch (version: FIRMWARE_VERSION in [CONFIG]; GL10 FOC + telemetry + Wi-Fi + alarms + safety)
-sketches/rc_test/types.h                 — Shared structs (JoystickState, EscTelem, ...)
+sketches/rc_test/types.h                 — Shared structs (JoystickState, ...; EscTelem re-exported from ports/TelemetrySource.h)
 sketches/rc_test/src/domain/battery/     — Extracted domain (#117): BatteryTypes.h + VoltagePlausibility.h/.cpp + BatteryLadder.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/thermal/     — Extracted domain (#117): ThermalTypes.h + ThermalHysteresis.h/.cpp + ThermalDerating.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/operator_input/ — Extracted domain (#117): ExpoCurve.h/.cpp + DeadbandPolicy.h/.cpp (pure input shaping, host-testable)
 sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes.h + CurvatureDrive.h/.cpp + GearPolicy.h/.cpp + CommandMixer.h/.cpp (curvature mix, gear policy, RC/joystick mixer)
 sketches/rc_test/src/domain/safety/      — Extracted domain (#117): SafetyTypes.h + SafetySupervisor.h/.cpp + OutputGate.h/.cpp (drive allow/deny + FailsafeReason; ACTIVE/HOLD/CUT gate)
-sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (X.BUS register decode + ×10 wire encode, header-only)
-sketches/rc_test/src/ports/              — Hardware contracts as link-time seams (#130): EscOutputPort.h + JoystickPort.h + AlertOutputPort.h + RcInputPort.h (RcFrame)
-sketches/rc_test/src/infrastructure/     — The ONLY layer with hardware includes (#130): arduino/PwmEscAdapter.cpp (owns the Servos) + arduino/AdcJoystickAdapter.cpp (ADC settle sequence) + arduino/PiezoAdapter.cpp + radiolink/SbusReceiverAdapter.cpp (owns sbusUart + the S.BUS parser)
+sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (×10 wire encode, header-only; register decode moved to infrastructure/xc/, #178)
+sketches/rc_test/src/ports/              — Hardware contracts as link-time seams (#130): EscOutputPort.h + JoystickPort.h + AlertOutputPort.h + RcInputPort.h (RcFrame) + TelemetrySource.h (EscTelem)
+sketches/rc_test/src/infrastructure/     — The ONLY layer with hardware includes (#130): arduino/PwmEscAdapter.cpp (owns the Servos) + arduino/AdcJoystickAdapter.cpp (ADC settle sequence) + arduino/PiezoAdapter.cpp + radiolink/SbusReceiverAdapter.cpp (owns sbusUart + the S.BUS parser) + xc/XbusTelemetryAdapter.h/.cpp (X.BUS 0x10 poller + register decode)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
 sketches/rc_test/web_page.h              — GENERATED from dashboard/index.html (scripts/generate_web_page.py) — never hand-edit
 sketches/telem_check/telem_check.ino     — Read-only X.BUS telemetry bench tool (0x50 framing)

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,39 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-13 — Phase D step 10 slice 4: TelemetrySource + XbusTelemetryAdapter (#178)
+
+- `ports/TelemetrySource.h` now owns the `EscTelem` struct (moved verbatim
+  from `types.h`; types.h re-includes the port so every consumer still
+  resolves it) + `telemetrySourceInitialize()` /
+  `telemetrySourceUpdate(EscTelem*, escCount)`. The CALLER keeps owning the
+  `telem[]` array — [ALERT], [SAFETY], the dashboard JSON and debug all read
+  it sketch-side; the adapter owns only the bus + poll state.
+- `infrastructure/xc/XbusTelemetryAdapter.h/.cpp` (first `xc/` folder): the
+  whole 0x10 poller moved VERBATIM — protocol constants, checksum, request
+  framing, echo-skipping parse, EMA fold, alternating poll state machine,
+  per-ESC staleness watchdog, `Serial1.begin`. The header is host-pure
+  (constants + inline scaling + extern state for the harness).
+- Register DECODE + `emaFold` moved from `telemetry/TelemetryScaling.h`
+  into the adapter header — forced by the dependency table (infrastructure/
+  may not include telemetry/) and semantically right (decode = X.BUS
+  register semantics). The ×10 wire ENCODE stays in TelemetryScaling.h.
+  Each function still has exactly ONE implementation.
+- Naming fixed on move (naming.md applies to MOVED code): `telemEsc` →
+  `telemetryPolledEscIndex`, `telemWaiting` → `telemetryAwaitingResponse`,
+  `telRx/telRxLen` → `telemetryReceiveBuffer/Length`, `telDbg*` →
+  `telemetryDebug*`, `telemSendRequest` → `telemetrySendReadRequest`,
+  `TELEM_*` → `TELEMETRY_*`, `XBUS_HDR_*` → `XBUS_HEADER_*`, `REG_*` →
+  `REGISTER_*` full words. EscTelem FIELD names unchanged (dozens of
+  untouched consumers — mass-rename prohibited). Tests updated mechanically;
+  `telemUpdate()` stays as the .ino shim (loop call site + suite entry
+  unchanged). `telDbgPrintPrevMs` found to be write-never-read (bring-up
+  leftover) — moved as-is, no behavior question.
+- Verified: all 25 host binaries green, ZERO expectation changes; compile
+  clean — flash 117324 (−32 vs 117356), RAM 9836 (+4; layout). Remaining
+  step-10 adapter: Wi-Fi/network; watchdog + clock land with FirmwareApp
+  (step 11).
+
 ## 2026-07-13 — Phase D step 10 slice 3: RcInputPort + SbusReceiverAdapter (#176)
 
 - `ports/RcInputPort.h` defines the RC input contract in domain types:

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -30,12 +30,14 @@ drive exactly as before.
   as a parameter, hardware effects returned as actions for the sketch to
   execute; the sketch keeps thin delegates until the composition root lands
 - **Ports + adapters** — `src/ports/` link-time seams (ESC output,
-  joystick ADC, piezo alert, RC input) with their `src/infrastructure/`
-  adapters (`arduino/` + `radiolink/`) owning the Servo objects, the ADC
-  settle sequence, the piezo pin, and the S.BUS UART + parser:
-  infrastructure is the only layer that includes hardware libraries, and
-  vendor types (the bfs S.BUS frame) are translated to domain types
-  (`RcFrame`) at the port boundary
+  joystick ADC, piezo alert, RC input, ESC telemetry) with their
+  `src/infrastructure/` adapters (`arduino/` + `radiolink/` + `xc/`)
+  owning the Servo objects, the ADC settle sequence, the piezo pin, the
+  S.BUS UART + parser, and the [X.BUS telemetry](xbus-telemetry.md)
+  poller: infrastructure is the only layer that includes hardware
+  libraries, vendor types (the bfs S.BUS frame) are translated to domain
+  types (`RcFrame`) at the port boundary, and the telemetry port owns the
+  `EscTelem` type it delivers while the sketch keeps owning the array
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/docs/wiki/xbus-telemetry.md
+++ b/docs/wiki/xbus-telemetry.md
@@ -13,7 +13,7 @@ throttle-over-bus function would fight our PWM and is never used.
   [CLAUDE.md](../../CLAUDE.md) "Telemetry"
 - Code home: the poller (framing, checksum, parse, EMA, poll state machine)
   is `src/infrastructure/xc/XbusTelemetryAdapter` behind
-  `ports/TelemetrySource.h`; the sketch owns the telemetry array
+  `src/ports/TelemetrySource.h`; the sketch owns the telemetry array
   ([architecture remediation](architecture-remediation.md), slice 4)
 - Consumers: the [battery ladder](battery-ladder.md),
   [thermal derating](thermal-derating.md), and the

--- a/docs/wiki/xbus-telemetry.md
+++ b/docs/wiki/xbus-telemetry.md
@@ -11,6 +11,10 @@ throttle-over-bus function would fight our PWM and is never used.
   [XBUS-PROTOCOL](../XBUS-PROTOCOL.md) (canonical)
 - Current registers polled, cadence, smoothing, and freshness watchdog:
   [CLAUDE.md](../../CLAUDE.md) "Telemetry"
+- Code home: the poller (framing, checksum, parse, EMA, poll state machine)
+  is `src/infrastructure/xc/XbusTelemetryAdapter` behind
+  `ports/TelemetrySource.h`; the sketch owns the telemetry array
+  ([architecture remediation](architecture-remediation.md), slice 4)
 - Consumers: the [battery ladder](battery-ladder.md),
   [thermal derating](thermal-derating.md), and the
   [Wi-Fi dashboard](wifi-dashboard.md) — monitoring-only by permanent

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -634,7 +634,7 @@ EscTelem telem[NUM_ESCS] = {};
 extern uint32_t telemetryDebugReceiveTotal;
 extern uint32_t telemetryDebugEchoCount;
 extern uint32_t telemetryDebugSlaveCount;
-extern uint8_t  telemetryDebugSnapshot[16];
+extern uint8_t  telemetryDebugSnapshot[];  // unsized: bound owned by the adapter
 extern int      telemetryDebugSnapshotLength;
 
 // Poll the bus; the adapter owns cadence, timeout and staleness internally.

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -78,6 +78,7 @@
 #include "src/ports/JoystickPort.h"
 #include "src/ports/AlertOutputPort.h"
 #include "src/ports/RcInputPort.h"
+#include "src/ports/TelemetrySource.h"
 
 
 // The second hardware UART (SCI0, D11/D12), the S.BUS parser and their pin
@@ -169,7 +170,7 @@ const uint32_t ECO_LOCK_DEBOUNCE_MS = 15000UL;  // sustained below thresh before
 // must resume automatically, so each stage releases on its own (lower) threshold
 // rather than latching to power-cycle like the battery ladder. Source = HOTTEST
 // of all 4 sensors (ESC + motor temp on BOTH ESCs), already EMA-smoothed
-// (TELEM_A_TEMP) + a short trip debounce so a single spike / dropped frame can't
+// (TELEMETRY_EMA_ALPHA_TEMPERATURE) + a short trip debounce so a single spike / dropped frame can't
 // flip a stage. A telemetry dropout (no fresh valid reading) HOLDS the last state
 // — it never triggers a cut.
 //   Warning beep  >= 80 C  (release < 78 C) : trill, motors keep running
@@ -616,171 +617,28 @@ void outputUpdate(bool driveAllowed, int mixL, int mixR) {
 
 
 // ═══════════════════════════════════════════════════════════════
-// [TELEMETRY] — X.BUS Read Register (0x10) on Serial1 (D0/D1)
+// [TELEMETRY] — X.BUS telemetry via ports/TelemetrySource.h
 // ═══════════════════════════════════════════════════════════════
-// Non-blocking, READ-ONLY. Uses func 0x10 (point-to-point service read),
-// NOT 0x50 — so the ESC never enters BUS_MODE and PWM control is fully
-// preserved. One request per ESC returns all registers; we alternate
-// ESC0/ESC1, EMA-smooth the slow signals, keep RPM instantaneous, and run
-// an independent per-ESC freshness watchdog. Both ESCs share the one
-// half-duplex bus on D0/D1 (idle HIGH, standard UART polarity — no inverter).
+// The 0x10 poller (framing, checksum, parse, EMA fold, poll state machine)
+// lives in src/infrastructure/xc/XbusTelemetryAdapter.cpp (#117 step 10
+// slice 4, #178) behind ports/TelemetrySource.h. READ-ONLY bus — PWM
+// control authority is never affected. The sketch owns the telemetry
+// array: [ALERT], [SAFETY], the dashboard JSON and debug all read telem[].
 
-const uint8_t  XBUS_HDR_MASTER = 0x0F;
-const uint8_t  XBUS_HDR_SLAVE  = 0xF0;
-const uint8_t  XBUS_FUNC_READ  = 0x10;
-const uint8_t  NUM_ESCS        = 2;
-
-// Registers read every poll (one request returns all of them).
-const uint8_t  REG_VBAT   = 0x0C;  // ×0.1 V
-const uint8_t  REG_IBUS   = 0x0D;  // ×0.1 A (signed)
-const uint8_t  REG_MSPEED = 0x02;  // electrical Hz (signed)
-const uint8_t  REG_TESC   = 0x20;  // raw − 40 = °C
-const uint8_t  REG_TMOT   = 0x22;  // raw − 40 = °C
-const uint8_t  TELEM_REGS[] = {REG_VBAT, REG_IBUS, REG_MSPEED, REG_TESC, REG_TMOT};
-const uint8_t  TELEM_NREG    = sizeof(TELEM_REGS);
-
-const uint32_t TELEM_POLL_MS    = 10;     // short gap; alternating → ~30-40 Hz/ESC
-const uint32_t TELEM_TIMEOUT_US = 6000;   // GL10 replies in ~2-3ms; 6ms = margin + fast give-up
-                                          // on a silent ESC (so a flaky one barely stalls the good one)
-const uint32_t TELEM_STALE_MS   = 5000;   // mark invalid after this long with no good read
-
-// EMA new-sample weights. Slow signals smoothed; RPM is instantaneous.
-const float TELEM_A_VOLT = 0.30f;
-const float TELEM_A_CURR = 0.50f;
-const float TELEM_A_TEMP = 0.10f;
+const uint8_t NUM_ESCS = 2;
 
 EscTelem telem[NUM_ESCS] = {};
 
-uint8_t  telemEsc        = 0;       // ESC currently being polled
-bool     telemWaiting    = false;   // true = request sent, awaiting response
-uint32_t telemLastPollMs = 0;
-uint32_t telemReqStartUs = 0;
-uint8_t  telRx[64];
-int      telRxLen = 0;
+// X.BUS RX byte-level diagnostics owned by the adapter; printed (and the
+// snapshot reset) by the [WIFI] wifiDebug() block below.
+extern uint32_t telemetryDebugReceiveTotal;
+extern uint32_t telemetryDebugEchoCount;
+extern uint32_t telemetryDebugSlaveCount;
+extern uint8_t  telemetryDebugSnapshot[16];
+extern int      telemetryDebugSnapshotLength;
 
-// ---- X.BUS RX byte-level diagnostics (temporary, post-solder bring-up) ----
-uint32_t telDbgRxTotal    = 0;  // total bytes ever seen on D0 (Serial1 RX)
-uint32_t telDbgEchoCount  = 0;  // count of 0x0F bytes (our own TX seen on bus)
-uint32_t telDbgSlaveCount = 0;  // count of 0xF0 bytes (ESC response header)
-uint8_t  telDbgSnap[16]   = {0};
-int      telDbgSnapLen    = 0;
-uint32_t telDbgPrintPrevMs = 0;
-
-// Checksum = low 8 bits of the sum of bytes [1 .. len-2] (header & checksum
-// excluded). Matches the framing confirmed on the bench during X.BUS bring-up.
-uint8_t xbusChecksum(const uint8_t *f, int len) {
-  uint8_t s = 0;
-  for (int i = 1; i < len - 1; i++) s += f[i];
-  return s;
-}
-
-void telemSendRequest(uint8_t esc) {
-  uint8_t tx[6 + TELEM_NREG];
-  int n = 0;
-  tx[n++] = XBUS_HDR_MASTER;
-  tx[n++] = esc;             // point-to-point slave address
-  tx[n++] = 0x00;            // extra byte — ignored in service control
-  tx[n++] = XBUS_FUNC_READ;
-  tx[n++] = TELEM_NREG;      // data length = number of register addresses
-  for (uint8_t i = 0; i < TELEM_NREG; i++) tx[n++] = TELEM_REGS[i];
-  tx[n] = xbusChecksum(tx, n + 1);
-  n++;
-  while (Serial1.available()) Serial1.read();  // drop stale RX / prior echo
-  Serial1.write(tx, n);                        // non-blocking (no flush())
-  telRxLen = 0;
-}
-
-// Fold one register value into the telem struct for ESC index e. Scaling and
-// EMA math extracted to src/telemetry/TelemetryScaling.h (#117 step 4, #160).
-void telemApplyReg(uint8_t e, uint8_t reg, uint16_t raw) {
-  EscTelem *t = &telem[e];
-  bool first = !t->valid;
-  switch (reg) {
-    case REG_VBAT: {
-      float v = vbatRawToVolts(raw);
-      t->voltage = emaFold(t->voltage, v, TELEM_A_VOLT, first);
-      break;
-    }
-    case REG_IBUS: {
-      float a = busCurrentRawToAmps(raw);
-      t->busCurrentA = emaFold(t->busCurrentA, a, TELEM_A_CURR, first);
-      break;
-    }
-    case REG_MSPEED:
-      t->rpmHz = motorSpeedRawToElectricalHz(raw);  // instantaneous
-      break;
-    case REG_TESC: {
-      float c = temperatureRawToCelsius(raw);       // temp is the low byte, raw − 40
-      t->escTempC = emaFold(t->escTempC, c, TELEM_A_TEMP, first);
-      break;
-    }
-    case REG_TMOT: {
-      float c = temperatureRawToCelsius(raw);
-      t->motorTempC = emaFold(t->motorTempC, c, TELEM_A_TEMP, first);
-      break;
-    }
-  }
-}
-
-// Scan the RX buffer for a valid 0x10 response from `esc`; parse if complete.
-// Skips our own half-duplex TX echo (which starts with 0x0F, not 0xF0).
-bool telemTryParse(uint8_t esc, uint32_t nowMs) {
-  for (int i = 0; i + 6 <= telRxLen; i++) {
-    if (telRx[i]     != XBUS_HDR_SLAVE) continue;
-    if (telRx[i + 1] != esc)            continue;
-    if (telRx[i + 3] != XBUS_FUNC_READ) continue;
-    uint8_t dlen = telRx[i + 4];
-    if (dlen == 0 || dlen % 3 != 0) continue;       // each reg = addr + 2 bytes
-    if (i + 5 + dlen > telRxLen)    continue;        // full data not in yet
-    const uint8_t *d = &telRx[i + 5];
-    for (uint8_t g = 0; g + 3 <= dlen; g += 3) {
-      uint16_t val = d[g + 1] | (d[g + 2] << 8);
-      telemApplyReg(esc, d[g], val);
-    }
-    telem[esc].lastGoodMs = nowMs;
-    telem[esc].valid = true;
-    return true;
-  }
-  return false;
-}
-
-// Call every loop iteration. Sends one request at a time, alternating ESCs,
-// and never blocks: it drains RX across iterations and times out on silence.
-void telemUpdate() {
-  uint32_t nowMs = millis();
-
-  // Drain available bytes every iteration (cheap).
-  while (Serial1.available() && telRxLen < (int)sizeof(telRx)) {
-    uint8_t b = Serial1.read();
-    telRx[telRxLen++] = b;
-    telDbgRxTotal++;                                   // any byte on D0
-    if (b == XBUS_HDR_MASTER) telDbgEchoCount++;       // 0x0F = our own TX echo
-    if (b == XBUS_HDR_SLAVE)  telDbgSlaveCount++;      // 0xF0 = ESC reply
-    if (telDbgSnapLen < 16) telDbgSnap[telDbgSnapLen++] = b;
-  }
-
-  if (telemWaiting) {
-    if (telemTryParse(telemEsc, nowMs)) {
-      telemWaiting = false;
-      telemEsc = (telemEsc + 1) % NUM_ESCS;
-    } else if ((micros() - telemReqStartUs) > TELEM_TIMEOUT_US) {
-      telemWaiting = false;                          // no/late response — move on
-      telemEsc = (telemEsc + 1) % NUM_ESCS;
-    }
-  } else if ((nowMs - telemLastPollMs) >= TELEM_POLL_MS) {
-    telemLastPollMs = nowMs;
-    telemSendRequest(telemEsc);
-    telemReqStartUs = micros();
-    telemWaiting = true;
-  }
-
-  // Per-ESC freshness watchdog.
-  for (uint8_t i = 0; i < NUM_ESCS; i++) {
-    if (telem[i].valid && (nowMs - telem[i].lastGoodMs) > TELEM_STALE_MS) {
-      telem[i].valid = false;
-    }
-  }
-}
+// Poll the bus; the adapter owns cadence, timeout and staleness internally.
+void telemUpdate() { telemetrySourceUpdate(telem, NUM_ESCS); }
 
 
 // ═══════════════════════════════════════════════════════════════
@@ -1157,15 +1015,15 @@ void wifiDebug(uint32_t nowUs) {
   Serial.print(" clients_seq="); Serial.println(wifiSeq);
 
   // X.BUS RX byte-level diagnostics — tells us whether D0 sees anything at all.
-  Serial.print("# XBUS rx_total="); Serial.print(telDbgRxTotal);
-  Serial.print(" echo(0x0F)=");     Serial.print(telDbgEchoCount);
-  Serial.print(" slave(0xF0)=");    Serial.print(telDbgSlaveCount);
+  Serial.print("# XBUS rx_total="); Serial.print(telemetryDebugReceiveTotal);
+  Serial.print(" echo(0x0F)=");     Serial.print(telemetryDebugEchoCount);
+  Serial.print(" slave(0xF0)=");    Serial.print(telemetryDebugSlaveCount);
   Serial.print(" snap=[");
-  for (int i = 0; i < telDbgSnapLen; i++) {
-    char hex[4]; snprintf(hex, sizeof(hex), "%02X ", telDbgSnap[i]); Serial.print(hex);
+  for (int i = 0; i < telemetryDebugSnapshotLength; i++) {
+    char hex[4]; snprintf(hex, sizeof(hex), "%02X ", telemetryDebugSnapshot[i]); Serial.print(hex);
   }
   Serial.println("]");
-  telDbgSnapLen = 0;   // reset for next window's snapshot
+  telemetryDebugSnapshotLength = 0;   // reset for next window's snapshot
 }
 
 // Build the telemetry JSON into body; returns its length. Shared by the
@@ -1460,7 +1318,7 @@ void setup() {
   beeperInit();
   alertInit();
   debugInit();
-  Serial1.begin(115200);  // X.BUS telemetry bus on D0/D1 (read-only, 0x10)
+  telemetrySourceInitialize();  // X.BUS telemetry bus on D0/D1 (read-only, 0x10)
   wifiInit();             // Wi-Fi AP + telemetry server (monitoring only)
 
   // Arm the hardware watchdog LAST — after the slow Wi-Fi AP bring-up — so init

--- a/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.cpp
+++ b/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.cpp
@@ -1,0 +1,136 @@
+// infrastructure/xc — the ONE implementation of ports/TelemetrySource.h
+// (#117 step 10 slice 4, #178). The 0x10 poller moved VERBATIM from
+// rc_test.ino [TELEMETRY]: non-blocking, read-only, one request in flight,
+// alternating ESCs, per-ESC staleness watchdog. Both ESCs share the one
+// half-duplex bus on Serial1/D0-D1 (idle HIGH, standard UART polarity — no
+// inverter). Behavior is locked end-to-end by the characterization suite
+// via the stub Serial1 byte scripting.
+#include "XbusTelemetryAdapter.h"
+
+#include <Arduino.h>
+
+uint8_t  telemetryPolledEscIndex   = 0;
+bool     telemetryAwaitingResponse = false;
+uint32_t telemetryLastPollMs       = 0;
+uint32_t telemetryRequestStartUs   = 0;
+uint8_t  telemetryReceiveBuffer[64];
+int      telemetryReceiveLength    = 0;
+
+uint32_t telemetryDebugReceiveTotal    = 0;
+uint32_t telemetryDebugEchoCount       = 0;
+uint32_t telemetryDebugSlaveCount      = 0;
+uint8_t  telemetryDebugSnapshot[16]    = {0};
+int      telemetryDebugSnapshotLength  = 0;
+uint32_t telemetryDebugPrintPreviousMs = 0;
+
+void telemetrySourceInitialize() {
+  Serial1.begin(115200);  // X.BUS telemetry bus on D0/D1 (read-only, 0x10)
+}
+
+void telemetrySendReadRequest(uint8_t esc) {
+  uint8_t tx[6 + TELEMETRY_REGISTER_COUNT];
+  int n = 0;
+  tx[n++] = XBUS_HEADER_MASTER;
+  tx[n++] = esc;             // point-to-point slave address
+  tx[n++] = 0x00;            // extra byte — ignored in service control
+  tx[n++] = XBUS_FUNCTION_READ;
+  tx[n++] = TELEMETRY_REGISTER_COUNT;  // data length = number of register addresses
+  for (uint8_t i = 0; i < TELEMETRY_REGISTER_COUNT; i++) tx[n++] = TELEMETRY_REGISTERS[i];
+  tx[n] = xbusChecksum(tx, n + 1);
+  n++;
+  while (Serial1.available()) Serial1.read();  // drop stale RX / prior echo
+  Serial1.write(tx, n);                        // non-blocking (no flush())
+  telemetryReceiveLength = 0;
+}
+
+// Fold one register value into the caller's EscTelem for one ESC.
+static void applyRegister(EscTelem *t, uint8_t reg, uint16_t raw) {
+  bool first = !t->valid;
+  switch (reg) {
+    case REGISTER_BATTERY_VOLTAGE: {
+      float v = vbatRawToVolts(raw);
+      t->voltage = emaFold(t->voltage, v, TELEMETRY_EMA_ALPHA_VOLTAGE, first);
+      break;
+    }
+    case REGISTER_BUS_CURRENT: {
+      float a = busCurrentRawToAmps(raw);
+      t->busCurrentA = emaFold(t->busCurrentA, a, TELEMETRY_EMA_ALPHA_CURRENT, first);
+      break;
+    }
+    case REGISTER_MOTOR_SPEED:
+      t->rpmHz = motorSpeedRawToElectricalHz(raw);  // instantaneous
+      break;
+    case REGISTER_ESC_TEMPERATURE: {
+      float c = temperatureRawToCelsius(raw);       // temp is the low byte, raw − 40
+      t->escTempC = emaFold(t->escTempC, c, TELEMETRY_EMA_ALPHA_TEMPERATURE, first);
+      break;
+    }
+    case REGISTER_MOTOR_TEMPERATURE: {
+      float c = temperatureRawToCelsius(raw);
+      t->motorTempC = emaFold(t->motorTempC, c, TELEMETRY_EMA_ALPHA_TEMPERATURE, first);
+      break;
+    }
+  }
+}
+
+// Scan the RX buffer for a valid 0x10 response from `esc`; parse if complete.
+// Skips our own half-duplex TX echo (which starts with 0x0F, not 0xF0).
+static bool tryParseResponse(EscTelem *telemetry, uint8_t esc, uint32_t nowMs) {
+  for (int i = 0; i + 6 <= telemetryReceiveLength; i++) {
+    if (telemetryReceiveBuffer[i]     != XBUS_HEADER_SLAVE)  continue;
+    if (telemetryReceiveBuffer[i + 1] != esc)                continue;
+    if (telemetryReceiveBuffer[i + 3] != XBUS_FUNCTION_READ) continue;
+    uint8_t dlen = telemetryReceiveBuffer[i + 4];
+    if (dlen == 0 || dlen % 3 != 0) continue;                 // each reg = addr + 2 bytes
+    if (i + 5 + dlen > telemetryReceiveLength) continue;      // full data not in yet
+    const uint8_t *d = &telemetryReceiveBuffer[i + 5];
+    for (uint8_t g = 0; g + 3 <= dlen; g += 3) {
+      uint16_t val = d[g + 1] | (d[g + 2] << 8);
+      applyRegister(&telemetry[esc], d[g], val);
+    }
+    telemetry[esc].lastGoodMs = nowMs;
+    telemetry[esc].valid = true;
+    return true;
+  }
+  return false;
+}
+
+// Call every loop iteration. Sends one request at a time, alternating ESCs,
+// and never blocks: it drains RX across iterations and times out on silence.
+void telemetrySourceUpdate(EscTelem *telemetry, uint8_t escCount) {
+  uint32_t nowMs = millis();
+
+  // Drain available bytes every iteration (cheap).
+  while (Serial1.available() && telemetryReceiveLength < (int)sizeof(telemetryReceiveBuffer)) {
+    uint8_t b = Serial1.read();
+    telemetryReceiveBuffer[telemetryReceiveLength++] = b;
+    telemetryDebugReceiveTotal++;                        // any byte on D0
+    if (b == XBUS_HEADER_MASTER) telemetryDebugEchoCount++;   // 0x0F = our own TX echo
+    if (b == XBUS_HEADER_SLAVE)  telemetryDebugSlaveCount++;  // 0xF0 = ESC reply
+    if (telemetryDebugSnapshotLength < 16) {
+      telemetryDebugSnapshot[telemetryDebugSnapshotLength++] = b;
+    }
+  }
+
+  if (telemetryAwaitingResponse) {
+    if (tryParseResponse(telemetry, telemetryPolledEscIndex, nowMs)) {
+      telemetryAwaitingResponse = false;
+      telemetryPolledEscIndex = (telemetryPolledEscIndex + 1) % escCount;
+    } else if ((micros() - telemetryRequestStartUs) > TELEMETRY_TIMEOUT_US) {
+      telemetryAwaitingResponse = false;             // no/late response — move on
+      telemetryPolledEscIndex = (telemetryPolledEscIndex + 1) % escCount;
+    }
+  } else if ((nowMs - telemetryLastPollMs) >= TELEMETRY_POLL_MS) {
+    telemetryLastPollMs = nowMs;
+    telemetrySendReadRequest(telemetryPolledEscIndex);
+    telemetryRequestStartUs = micros();
+    telemetryAwaitingResponse = true;
+  }
+
+  // Per-ESC freshness watchdog.
+  for (uint8_t i = 0; i < escCount; i++) {
+    if (telemetry[i].valid && (nowMs - telemetry[i].lastGoodMs) > TELEMETRY_STALE_MS) {
+      telemetry[i].valid = false;
+    }
+  }
+}

--- a/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.cpp
+++ b/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.cpp
@@ -115,7 +115,7 @@ void telemetrySourceUpdate(EscTelem *telemetry, uint8_t escCount) {
     telemetryDebugReceiveTotal++;                        // any byte on D0
     if (b == XBUS_HEADER_MASTER) telemetryDebugEchoCount++;   // 0x0F = our own TX echo
     if (b == XBUS_HEADER_SLAVE)  telemetryDebugSlaveCount++;  // 0xF0 = ESC reply
-    if (telemetryDebugSnapshotLength < 16) {
+    if (telemetryDebugSnapshotLength < (int)sizeof(telemetryDebugSnapshot)) {
       telemetryDebugSnapshot[telemetryDebugSnapshotLength++] = b;
     }
   }

--- a/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.cpp
+++ b/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.cpp
@@ -99,6 +99,13 @@ static bool tryParseResponse(EscTelem *telemetry, uint8_t esc, uint32_t nowMs) {
 // and never blocks: it drains RX across iterations and times out on silence.
 void telemetrySourceUpdate(EscTelem *telemetry, uint8_t escCount) {
   if (escCount == 0) return;  // the alternation modulo would divide by zero
+  if (telemetryPolledEscIndex >= escCount) {
+    // Caller-provided count shrank below the adapter-owned index (never in
+    // this firmware — escCount is always NUM_ESCS): restart the rotation
+    // rather than index the caller's array out of bounds.
+    telemetryPolledEscIndex = 0;
+    telemetryAwaitingResponse = false;
+  }
   uint32_t nowMs = millis();
 
   // Drain available bytes every iteration (cheap).

--- a/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.cpp
+++ b/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.cpp
@@ -98,6 +98,7 @@ static bool tryParseResponse(EscTelem *telemetry, uint8_t esc, uint32_t nowMs) {
 // Call every loop iteration. Sends one request at a time, alternating ESCs,
 // and never blocks: it drains RX across iterations and times out on silence.
 void telemetrySourceUpdate(EscTelem *telemetry, uint8_t escCount) {
+  if (escCount == 0) return;  // the alternation modulo would divide by zero
   uint32_t nowMs = millis();
 
   // Drain available bytes every iteration (cheap).

--- a/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.h
+++ b/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.h
@@ -33,8 +33,8 @@ const uint8_t TELEMETRY_REGISTER_COUNT =
 
 // ── poll cadence / freshness ─────────────────────────────────────────────
 const uint32_t TELEMETRY_POLL_MS    = 10;     // short gap; alternating → ~30-40 Hz/ESC
-const uint32_t TELEMETRY_TIMEOUT_US = 6000;   // GL10 replies in ~2-3ms; 6ms = margin +
-                                              // fast give-up on a silent ESC
+const uint32_t TELEMETRY_TIMEOUT_US = 6000;   // GL10 replies in ~2-3 ms; 6 ms gives
+                                              // margin yet gives up fast on a silent ESC
 const uint32_t TELEMETRY_STALE_MS   = 5000;   // mark invalid after this long unheard
 
 // EMA new-sample weights. Slow signals smoothed; RPM is instantaneous.

--- a/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.h
+++ b/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.h
@@ -28,7 +28,8 @@ const uint8_t REGISTER_MOTOR_TEMPERATURE = 0x22;  // raw − 40 = °C
 const uint8_t TELEMETRY_REGISTERS[] = {
     REGISTER_BATTERY_VOLTAGE, REGISTER_BUS_CURRENT, REGISTER_MOTOR_SPEED,
     REGISTER_ESC_TEMPERATURE, REGISTER_MOTOR_TEMPERATURE};
-const uint8_t TELEMETRY_REGISTER_COUNT = sizeof(TELEMETRY_REGISTERS);
+const uint8_t TELEMETRY_REGISTER_COUNT =
+    sizeof(TELEMETRY_REGISTERS) / sizeof(TELEMETRY_REGISTERS[0]);
 
 // ── poll cadence / freshness ─────────────────────────────────────────────
 const uint32_t TELEMETRY_POLL_MS    = 10;     // short gap; alternating → ~30-40 Hz/ESC

--- a/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.h
+++ b/sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.h
@@ -1,0 +1,96 @@
+// infrastructure/xc — X.BUS telemetry poller: protocol constants, register
+// scaling and the poll machine's contract (#117 step 10 slice 4, #178).
+// Implementation (and the only Serial1 use) is in XbusTelemetryAdapter.cpp;
+// this header is host-pure so the characterization and pure suites can
+// include it directly. Poll state is declared extern so the test harness
+// can reset and inspect the machine (the escL/escR / sbusRx precedent).
+//
+// The bus is READ-ONLY: function 0x10 is point-to-point service control —
+// it never puts the ESC into BUS_MODE, so PWM control authority is fully
+// preserved (0x50 would fight our PWM; see docs/XBUS-PROTOCOL.md).
+#pragma once
+
+#include <stdint.h>
+
+#include "../../ports/TelemetrySource.h"
+
+// ── X.BUS wire protocol (framing confirmed on the bench at bring-up) ─────
+const uint8_t XBUS_HEADER_MASTER = 0x0F;
+const uint8_t XBUS_HEADER_SLAVE  = 0xF0;
+const uint8_t XBUS_FUNCTION_READ = 0x10;
+
+// Registers read every poll (one request returns all of them).
+const uint8_t REGISTER_BATTERY_VOLTAGE   = 0x0C;  // ×0.1 V
+const uint8_t REGISTER_BUS_CURRENT       = 0x0D;  // ×0.1 A (signed)
+const uint8_t REGISTER_MOTOR_SPEED       = 0x02;  // electrical Hz (signed)
+const uint8_t REGISTER_ESC_TEMPERATURE   = 0x20;  // raw − 40 = °C
+const uint8_t REGISTER_MOTOR_TEMPERATURE = 0x22;  // raw − 40 = °C
+const uint8_t TELEMETRY_REGISTERS[] = {
+    REGISTER_BATTERY_VOLTAGE, REGISTER_BUS_CURRENT, REGISTER_MOTOR_SPEED,
+    REGISTER_ESC_TEMPERATURE, REGISTER_MOTOR_TEMPERATURE};
+const uint8_t TELEMETRY_REGISTER_COUNT = sizeof(TELEMETRY_REGISTERS);
+
+// ── poll cadence / freshness ─────────────────────────────────────────────
+const uint32_t TELEMETRY_POLL_MS    = 10;     // short gap; alternating → ~30-40 Hz/ESC
+const uint32_t TELEMETRY_TIMEOUT_US = 6000;   // GL10 replies in ~2-3ms; 6ms = margin +
+                                              // fast give-up on a silent ESC
+const uint32_t TELEMETRY_STALE_MS   = 5000;   // mark invalid after this long unheard
+
+// EMA new-sample weights. Slow signals smoothed; RPM is instantaneous.
+const float TELEMETRY_EMA_ALPHA_VOLTAGE     = 0.30f;
+const float TELEMETRY_EMA_ALPHA_CURRENT     = 0.50f;
+const float TELEMETRY_EMA_ALPHA_TEMPERATURE = 0.10f;
+
+// Checksum = low 8 bits of the sum of bytes [1 .. len-2] (header & checksum
+// excluded). Matches the framing confirmed on the bench during bring-up.
+inline uint8_t xbusChecksum(const uint8_t *frame, int length) {
+  uint8_t sum = 0;
+  for (int i = 1; i < length - 1; i++) sum += frame[i];
+  return sum;
+}
+
+// ── register decode: raw register value → engineering units ──────────────
+// Moved from telemetry/TelemetryScaling.h (#178): infrastructure/ may not
+// include telemetry/ (dependency table §3), and the decode belongs to the
+// X.BUS register semantics. The ×10 wire ENCODE stays in TelemetryScaling.h.
+
+inline float vbatRawToVolts(uint16_t raw) {          // 0x0C, ×0.1 V
+  return raw * 0.1f;
+}
+
+inline float busCurrentRawToAmps(uint16_t raw) {     // 0x0D, ×0.1 A signed
+  return (int16_t)raw * 0.1f;
+}
+
+inline int16_t motorSpeedRawToElectricalHz(uint16_t raw) {  // 0x02, signed
+  return (int16_t)raw;
+}
+
+inline float temperatureRawToCelsius(uint16_t raw) {  // 0x20/0x22: low byte, raw − 40
+  return (float)(raw & 0xFF) - 40.0f;
+}
+
+// Exponential moving average fold; the first sample seeds the average.
+inline float emaFold(float previous, float sample, float alpha, bool first) {
+  return first ? sample : previous + alpha * (sample - previous);
+}
+
+// ── poll machine state (owned by the adapter; extern for the harness) ────
+extern uint8_t  telemetryPolledEscIndex;   // ESC currently being polled
+extern bool     telemetryAwaitingResponse;  // true = request sent, awaiting reply
+extern uint32_t telemetryLastPollMs;
+extern uint32_t telemetryRequestStartUs;
+extern uint8_t  telemetryReceiveBuffer[64];
+extern int      telemetryReceiveLength;
+
+// X.BUS RX byte-level diagnostics (temporary, post-solder bring-up).
+extern uint32_t telemetryDebugReceiveTotal;      // total bytes ever seen on D0
+extern uint32_t telemetryDebugEchoCount;         // 0x0F bytes (our own TX echo)
+extern uint32_t telemetryDebugSlaveCount;        // 0xF0 bytes (ESC response header)
+extern uint8_t  telemetryDebugSnapshot[16];
+extern int      telemetryDebugSnapshotLength;
+extern uint32_t telemetryDebugPrintPreviousMs;
+
+// Frame and send one 0x10 read of all five registers to `esc` (drops any
+// stale RX first). Exposed for the characterization suite.
+void telemetrySendReadRequest(uint8_t esc);

--- a/sketches/rc_test/src/ports/TelemetrySource.h
+++ b/sketches/rc_test/src/ports/TelemetrySource.h
@@ -25,4 +25,7 @@ void telemetrySourceInitialize();
 
 // Poll the bus (non-blocking; call every loop pass). Fills/refreshes the
 // caller's telemetry array and runs the per-ESC staleness watchdog.
+// Contract: the caller value-initializes the array before the first call
+// (e.g. `EscTelem telem[N] = {};`) — `valid` must start false, since the
+// first sample of each ESC seeds the EMA instead of folding into it.
 void telemetrySourceUpdate(EscTelem* telemetry, uint8_t escCount);

--- a/sketches/rc_test/src/ports/TelemetrySource.h
+++ b/sketches/rc_test/src/ports/TelemetrySource.h
@@ -1,0 +1,28 @@
+// ports — the ESC telemetry input contract (#117 step 10 slice 4, #178).
+// A link-time seam (#130): free functions, ONE linked implementation
+// (infrastructure/xc/XbusTelemetryAdapter.cpp). The CALLER owns the
+// EscTelem array — alerts, safety, the dashboard JSON and debug all read
+// it application-side; the adapter owns only the bus and its poll state.
+#pragma once
+
+#include <stdint.h>
+
+// Telemetry sample from one ESC (via X.BUS Read Register 0x10). Moved
+// verbatim from types.h (#178) — the port speaks the type it delivers;
+// types.h includes this header so every existing consumer still resolves it.
+struct EscTelem {
+  float    voltage;     // V (battery / bus voltage, EMA smoothed)
+  float    busCurrentA;  // A (bus current, EMA smoothed)
+  int16_t  rpmHz;       // electrical Hz (instantaneous; ~×30 = mech RPM)
+  float    motorTempC;  // degC (EMA smoothed)
+  float    escTempC;    // degC (EMA smoothed)
+  uint32_t lastGoodMs;  // millis() of last successful read
+  bool     valid;       // fresh reading within the staleness window
+};
+
+// Start the telemetry bus.
+void telemetrySourceInitialize();
+
+// Poll the bus (non-blocking; call every loop pass). Fills/refreshes the
+// caller's telemetry array and runs the per-ESC staleness watchdog.
+void telemetrySourceUpdate(EscTelem* telemetry, uint8_t escCount);

--- a/sketches/rc_test/src/telemetry/TelemetryScaling.h
+++ b/sketches/rc_test/src/telemetry/TelemetryScaling.h
@@ -1,36 +1,15 @@
-// telemetry/TelemetryScaling.h — pure telemetry scaling math (#117 step 4,
-// #160). Extracted VERBATIM from rc_test.ino: the X.BUS register decode in
-// [TELEMETRY] telemApplyReg() and the compact-integer wire encode in [WIFI]
-// buildTelemJson(). Header-only observer-layer helpers: no Arduino includes,
-// no state — the ONE implementation of the ×10 wire scaling (the dashboard
-// JS divides by 10 on its side; that mapping is documented at the encoder).
+// telemetry/TelemetryScaling.h — pure wire-encode math (#117 step 4, #160).
+// Extracted VERBATIM from rc_test.ino [WIFI] buildTelemJson(). Header-only
+// observer-layer helpers: no Arduino includes, no state — the ONE
+// implementation of the ×10 wire scaling (the dashboard JS divides by 10 on
+// its side; that mapping is documented at the encoder). The X.BUS register
+// DECODE half moved to infrastructure/xc/XbusTelemetryAdapter.h (#178):
+// infrastructure/ may not include telemetry/, and the decode belongs with
+// the X.BUS register semantics.
 #pragma once
 
 #include <stdint.h>
 #include <math.h>
-
-// ── X.BUS register decode: raw register value → engineering units ────────
-
-inline float vbatRawToVolts(uint16_t raw) {          // REG_VBAT 0x0C, ×0.1 V
-  return raw * 0.1f;
-}
-
-inline float busCurrentRawToAmps(uint16_t raw) {     // REG_IBUS 0x0D, ×0.1 A signed
-  return (int16_t)raw * 0.1f;
-}
-
-inline int16_t motorSpeedRawToElectricalHz(uint16_t raw) {  // REG_MSPEED 0x02, signed
-  return (int16_t)raw;
-}
-
-inline float temperatureRawToCelsius(uint16_t raw) {  // REG_TESC/TMOT: low byte, raw − 40
-  return (float)(raw & 0xFF) - 40.0f;
-}
-
-// Exponential moving average fold; the first sample seeds the average.
-inline float emaFold(float previous, float sample, float alpha, bool first) {
-  return first ? sample : previous + alpha * (sample - previous);
-}
 
 // ── wire encode: engineering units → compact SSE/JSON integers ───────────
 // Compact keys and integer values are a deliberate bandwidth decision on the

--- a/sketches/rc_test/types.h
+++ b/sketches/rc_test/types.h
@@ -2,6 +2,11 @@
 #pragma once
 #include <Arduino.h>
 
+// EscTelem moved to the TelemetrySource port (#178) — the port speaks the
+// type it delivers; included here so every existing consumer keeps
+// resolving it through types.h.
+#include "src/ports/TelemetrySource.h"
+
 // Joystick ADC reading after deadband + expo curve, normalized to -1..+1
 struct JoystickState {
   int   rawY, rawX;     // Raw 14-bit ADC values
@@ -25,17 +30,6 @@ struct WheelSpeeds {
 struct ServoOutput {
   int left;             // microseconds
   int right;
-};
-
-// Telemetry sample from one ESC (via X.BUS Read Register 0x10)
-struct EscTelem {
-  float    voltage;     // V (battery / bus voltage, EMA smoothed)
-  float    busCurrentA;  // A (bus current, EMA smoothed)
-  int16_t  rpmHz;       // electrical Hz (instantaneous; ~×30 = mech RPM)
-  float    motorTempC;  // degC (EMA smoothed)
-  float    escTempC;    // degC (EMA smoothed)
-  uint32_t lastGoodMs;  // millis() of last successful read
-  bool     valid;       // fresh reading within the staleness window
 };
 
 // CH4 gear position. Caps the post-curvatureDrive wheel speeds; the

--- a/tests/characterization/FirmwareUnderTest.h
+++ b/tests/characterization/FirmwareUnderTest.h
@@ -19,6 +19,10 @@
 // globals, and (internal-linkage) constants — is visible to the tests.
 #include "../../sketches/rc_test/rc_test.ino"  // NOLINT(build/include)
 
+// X.BUS poller constants + extern state (#178): the poll machine lives in
+// infrastructure/xc/, linked into every characterization binary.
+#include "../../sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.h"
+
 // The Servo objects live in infrastructure/arduino/PwmEscAdapter.cpp
 // (#172), linked into every characterization binary; resetFirmwareState()
 // reaches them through these declarations. Same pattern for the S.BUS
@@ -65,19 +69,19 @@ inline void resetFirmwareState() {
   outHoldMs = 0;
   rampFromL = SVC;
   rampFromR = SVC;
-  // [TELEMETRY]
+  // [TELEMETRY] — poll-machine state lives in the X.BUS adapter (#178)
   telem[0] = EscTelem{};
   telem[1] = EscTelem{};
-  telemEsc = 0;
-  telemWaiting = false;
-  telemLastPollMs = 0;
-  telemReqStartUs = 0;
-  telRxLen = 0;
-  telDbgRxTotal = 0;
-  telDbgEchoCount = 0;
-  telDbgSlaveCount = 0;
-  telDbgSnapLen = 0;
-  telDbgPrintPrevMs = 0;
+  telemetryPolledEscIndex = 0;
+  telemetryAwaitingResponse = false;
+  telemetryLastPollMs = 0;
+  telemetryRequestStartUs = 0;
+  telemetryReceiveLength = 0;
+  telemetryDebugReceiveTotal = 0;
+  telemetryDebugEchoCount = 0;
+  telemetryDebugSlaveCount = 0;
+  telemetryDebugSnapshotLength = 0;
+  telemetryDebugPrintPreviousMs = 0;
   // [BEEPER]
   hornActive = false;
   alarmOutputOn = false;

--- a/tests/characterization/test_telemetry_parse.cpp
+++ b/tests/characterization/test_telemetry_parse.cpp
@@ -9,8 +9,8 @@
 // Build a well-formed 0x10 response for `esc` carrying all five registers.
 static std::vector<uint8_t> responseFrame(uint8_t esc, uint16_t vbatRaw, uint16_t ibusRaw,
                                           uint16_t speedRaw, uint16_t tescRaw, uint16_t tmotRaw) {
-  std::vector<uint8_t> f = {XBUS_HDR_SLAVE, esc, 0x00, XBUS_FUNC_READ, 15};
-  const uint8_t regs[5] = {REG_VBAT, REG_IBUS, REG_MSPEED, REG_TESC, REG_TMOT};
+  std::vector<uint8_t> f = {XBUS_HEADER_SLAVE, esc, 0x00, XBUS_FUNCTION_READ, 15};
+  const uint8_t regs[5] = {REGISTER_BATTERY_VOLTAGE, REGISTER_BUS_CURRENT, REGISTER_MOTOR_SPEED, REGISTER_ESC_TEMPERATURE, REGISTER_MOTOR_TEMPERATURE};
   const uint16_t vals[5] = {vbatRaw, ibusRaw, speedRaw, tescRaw, tmotRaw};
   for (int i = 0; i < 5; i++) {
     f.push_back(regs[i]);
@@ -23,32 +23,32 @@ static std::vector<uint8_t> responseFrame(uint8_t esc, uint16_t vbatRaw, uint16_
 
 // Drive telemUpdate through one full request→response cycle for ESC `esc`.
 static void completePoll(uint8_t esc, const std::vector<uint8_t>& response) {
-  stub::advanceMillis(TELEM_POLL_MS);
+  stub::advanceMillis(TELEMETRY_POLL_MS);
   telemUpdate();                                 // sends the request
-  REQUIRE(telemWaiting);
-  REQUIRE(telemEsc == esc);
+  REQUIRE(telemetryAwaitingResponse);
+  REQUIRE(telemetryPolledEscIndex == esc);
   Serial1.scriptRxBytes(response.data(), response.size());
   telemUpdate();                                 // drains + parses
-  REQUIRE_FALSE(telemWaiting);
+  REQUIRE_FALSE(telemetryAwaitingResponse);
 }
 
 // Let the poll of ESC `esc` time out (silent ESC).
 static void timeoutPoll(uint8_t esc) {
-  stub::advanceMillis(TELEM_POLL_MS);
+  stub::advanceMillis(TELEMETRY_POLL_MS);
   telemUpdate();
-  REQUIRE(telemWaiting);
-  REQUIRE(telemEsc == esc);
-  stub::advanceMicros(TELEM_TIMEOUT_US + 1);
+  REQUIRE(telemetryAwaitingResponse);
+  REQUIRE(telemetryPolledEscIndex == esc);
+  stub::advanceMicros(TELEMETRY_TIMEOUT_US + 1);
   telemUpdate();
-  REQUIRE_FALSE(telemWaiting);
+  REQUIRE_FALSE(telemetryAwaitingResponse);
 }
 
-TEST_CASE("telemSendRequest frames a 0x10 read of all five registers") {
+TEST_CASE("telemetrySendReadRequest frames a 0x10 read of all five registers") {
   resetHarness();
   uint8_t stale[3] = {0xAA, 0xBB, 0xCC};
   Serial1.scriptRxBytes(stale, 3);               // stale echo on the bus
 
-  telemSendRequest(0);
+  telemetrySendReadRequest(0);
   CHECK(Serial1.rxQueue.empty());                // stale RX dropped first
   std::vector<uint8_t> expected = {0x0F, 0x00, 0x00, 0x10, 0x05,
                                    0x0C, 0x0D, 0x02, 0x20, 0x22, 0x72};
@@ -65,7 +65,7 @@ TEST_CASE("first samples land unfiltered; later samples are EMA-smoothed") {
   CHECK(telem[0].rpmHz == -10);
   CHECK(telem[0].escTempC == doctest::Approx(25.0f));
   CHECK(telem[0].motorTempC == doctest::Approx(65.0f));
-  CHECK(telemEsc == 1);                          // alternates to the other ESC
+  CHECK(telemetryPolledEscIndex == 1);                          // alternates to the other ESC
 
   timeoutPoll(1);                                // ESC1 silent this round
 
@@ -79,9 +79,9 @@ TEST_CASE("first samples land unfiltered; later samples are EMA-smoothed") {
 
 TEST_CASE("parser skips the half-duplex TX echo and other ESC's frames") {
   resetHarness();
-  stub::advanceMillis(TELEM_POLL_MS);
+  stub::advanceMillis(TELEMETRY_POLL_MS);
   telemUpdate();                                 // request to ESC0 in flight
-  REQUIRE(telemEsc == 0);
+  REQUIRE(telemetryPolledEscIndex == 0);
 
   // The bus carries our own echo, then a frame addressed to ESC1, then ESC0's.
   std::vector<uint8_t> bus = {0x0F, 0x00, 0x00, 0x10, 0x05, 0x0C, 0x0D, 0x02, 0x20, 0x22, 0x72};
@@ -101,7 +101,7 @@ TEST_CASE("silent ESC times out fast and polling moves on") {
   resetHarness();
   timeoutPoll(0);
   CHECK_FALSE(telem[0].valid);
-  CHECK(telemEsc == 1);                          // a flaky ESC barely stalls the good one
+  CHECK(telemetryPolledEscIndex == 1);                          // a flaky ESC barely stalls the good one
 }
 
 TEST_CASE("per-ESC staleness watchdog invalidates after 5 s without a good read") {
@@ -109,7 +109,7 @@ TEST_CASE("per-ESC staleness watchdog invalidates after 5 s without a good read"
   completePoll(0, responseFrame(0, 116, 25, 0, 65, 65));
   REQUIRE(telem[0].valid);
 
-  stub::advanceMillis(TELEM_STALE_MS + 1);
+  stub::advanceMillis(TELEMETRY_STALE_MS + 1);
   telemUpdate();                                 // no new responses
   CHECK_FALSE(telem[0].valid);
 }

--- a/tests/characterization/test_telemetry_parse.cpp
+++ b/tests/characterization/test_telemetry_parse.cpp
@@ -10,7 +10,9 @@
 static std::vector<uint8_t> responseFrame(uint8_t esc, uint16_t vbatRaw, uint16_t ibusRaw,
                                           uint16_t speedRaw, uint16_t tescRaw, uint16_t tmotRaw) {
   std::vector<uint8_t> f = {XBUS_HEADER_SLAVE, esc, 0x00, XBUS_FUNCTION_READ, 15};
-  const uint8_t regs[5] = {REGISTER_BATTERY_VOLTAGE, REGISTER_BUS_CURRENT, REGISTER_MOTOR_SPEED, REGISTER_ESC_TEMPERATURE, REGISTER_MOTOR_TEMPERATURE};
+  const uint8_t regs[5] = {REGISTER_BATTERY_VOLTAGE, REGISTER_BUS_CURRENT,
+                           REGISTER_MOTOR_SPEED, REGISTER_ESC_TEMPERATURE,
+                           REGISTER_MOTOR_TEMPERATURE};
   const uint16_t vals[5] = {vbatRaw, ibusRaw, speedRaw, tescRaw, tmotRaw};
   for (int i = 0; i < 5; i++) {
     f.push_back(regs[i]);

--- a/tests/telemetry/test_telemetry_scaling.cpp
+++ b/tests/telemetry/test_telemetry_scaling.cpp
@@ -1,6 +1,8 @@
-// Pure suite (#117 step 4, #160): src/telemetry/TelemetryScaling.h tested
-// directly on the host — no firmware, no stubs. End-to-end behavior through
-// telemApplyReg()/buildTelemJson() stays covered by
+// Pure suite (#117 step 4, #160): telemetry scaling tested directly on the
+// host — no firmware, no stubs. The X.BUS register DECODE + EMA fold live
+// in infrastructure/xc/XbusTelemetryAdapter.h (host-pure header, #178); the
+// ×10 wire ENCODE stays in src/telemetry/TelemetryScaling.h. End-to-end
+// behavior through the poller/buildTelemJson() stays covered by
 // tests/characterization/test_telemetry_parse.cpp; this suite locks the
 // scaling contracts at the unit level: register signedness, the low-byte
 // temperature mask and −40 offset, EMA seeding, and the exact integer
@@ -8,6 +10,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
+#include "../../sketches/rc_test/src/infrastructure/xc/XbusTelemetryAdapter.h"
 #include "../../sketches/rc_test/src/telemetry/TelemetryScaling.h"
 
 TEST_CASE("VBAT decode: unsigned tenths of a volt") {


### PR DESCRIPTION
Closes #178

## Summary

Phase D step 10, slice 4 (#117/#130) — the X.BUS telemetry poller moves behind the target's `TelemetrySource` port into `infrastructure/xc/XbusTelemetryAdapter` ("0x10 poller, framing, checksum" per ARCHITECTURE-TARGET §2). `[C-Builder]`

- **`src/ports/TelemetrySource.h`** — owns the `EscTelem` struct (moved VERBATIM from `types.h`; `types.h` re-includes the port so every existing consumer keeps resolving it — the port speaks the type it delivers, the `RcFrame` precedent). API: `telemetrySourceInitialize()` + `telemetrySourceUpdate(EscTelem*, escCount)`. **The caller keeps owning the `telem[]` array** — `[ALERT]`, `[SAFETY]`, `buildTelemJson` and debug all read it sketch-side; the adapter owns only the bus + poll state.
- **`src/infrastructure/xc/XbusTelemetryAdapter.h/.cpp`** — first `xc/` folder. The whole poller moved VERBATIM: protocol constants, checksum, request framing, echo-skipping parse, EMA fold, the alternating non-blocking poll state machine, the per-ESC staleness watchdog, and `Serial1.begin`. The header is host-pure (constants + inline scaling + extern state for the harness); only the `.cpp` touches `Serial1`.
- **Register DECODE + `emaFold` moved from `telemetry/TelemetryScaling.h` into the adapter header** — forced by the dependency table (`infrastructure/` may not include `telemetry/`, enforced by architecture-fitness) and semantically right (decode = X.BUS register semantics). The ×10 wire ENCODE stays in `TelemetryScaling.h` (used by `buildTelemJson`). Every function keeps exactly ONE implementation.
- **Naming fixed on move** (naming.md: full words apply to MOVED code; extraction is the sanctioned rename point):

  | old | new |
  |---|---|
  | `telemEsc` / `telemWaiting` | `telemetryPolledEscIndex` / `telemetryAwaitingResponse` |
  | `telemLastPollMs` / `telemReqStartUs` | `telemetryLastPollMs` / `telemetryRequestStartUs` |
  | `telRx` / `telRxLen` | `telemetryReceiveBuffer` / `telemetryReceiveLength` |
  | `telDbg*` | `telemetryDebug*` (full words) |
  | `telemSendRequest` / `telemTryParse` / `telemApplyReg` | `telemetrySendReadRequest` / `tryParseResponse` (static) / `applyRegister` (static) |
  | `TELEM_*`, `XBUS_HDR_*`, `REG_*` | `TELEMETRY_*`, `XBUS_HEADER_*`, `REGISTER_*` full words |

  `xbusChecksum` keeps its name (XBUS is a listed acronym). **`EscTelem` FIELD names unchanged** — dozens of untouched consumers; naming.md prohibits mass-renaming untouched code.
- **`.ino`** — `[TELEMETRY]` shrinks to `NUM_ESCS` + `telem[]` + the `telemUpdate()` shim (loop call site and the characterization suite's entry point unchanged) + extern debug-counter declarations for the `[WIFI]` diagnostics print. `setup()` calls `telemetrySourceInitialize()`.
- **Harness lockstep** — `FirmwareUnderTest.h` includes the adapter header (constants + externs resolve as before); reset lines and `test_telemetry_parse.cpp` take the new names (identifier renames only); the pure scaling suite includes the adapter header for decode/EMA cases.
- **Docs same-PR** — CLAUDE.md (Telemetry section + file map ×4 lines), DECISION-LOG entry, wiki `xbus-telemetry` + `architecture-remediation` notes.

## Behavior preservation

Zero observable change — covenant PR. The poll machine, framing bytes, EMA math, alternation, timeout and staleness semantics are line-for-line the `[TELEMETRY]` code they replace; the only mechanical substitutions are `NUM_ESCS` → the `escCount` parameter (same value passed) and the caller's array pointer replacing the global. One finding, no behavior question: `telDbgPrintPrevMs` was write-never-read (bring-up leftover) — moved as-is (`telemetryDebugPrintPreviousMs`).

## Test plan

- Host suite: **all 25 binaries green, ZERO expectation changes** (`wsl -e make -C tests run`) — framing bytes (checksum 0x72 case), EMA weights, alternation, fast-timeout, 5 s staleness all locked as-is
- `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` clean — flash 117324 (−32), RAM 9836 (+4; linkage/layout of the moved state, not behavior)
- `python scripts/check_architecture.py` — OK (first `infrastructure/xc/` files exercise the layer rules)
- cpplint pre-checked on all new/changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a telemetry adapter API via `TelemetrySource` and moved X.BUS 0x10 polling/parsing into the adapter layer for ESC voltage, current, speed, and temperatures.
  * Added per-ESC freshness/valid tracking with a staleness watchdog and non-blocking updates.
  * Exposed adapter diagnostics (receive/echo/slave counts and snapshots) for telemetry debugging.
* **Documentation**
  * Updated the telemetry wiki and architecture/decision docs to reflect the new ownership and polling location.
* **Tests**
  * Updated telemetry parse/scaling and related timeout/echo/watchdog tests to use the new adapter state and constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->