### PR TITLE
V7.35: SystemSnapshot — observers read one immutable per-cycle struct (#132)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,7 +307,8 @@ sketches/rc_test/src/domain/thermal/     — Extracted domain (#117): ThermalTyp
 sketches/rc_test/src/domain/operator_input/ — Extracted domain (#117): ExpoCurve.h/.cpp + DeadbandPolicy.h/.cpp (pure input shaping, host-testable)
 sketches/rc_test/src/domain/drive/       — Extracted domain (#117): DriveTypes.h + CurvatureDrive.h/.cpp + GearPolicy.h/.cpp + CommandMixer.h/.cpp (curvature mix, gear policy, RC/joystick mixer)
 sketches/rc_test/src/domain/safety/      — Extracted domain (#117): SafetyTypes.h + SafetySupervisor.h/.cpp + OutputGate.h/.cpp (drive allow/deny + FailsafeReason; ACTIVE/HOLD/CUT gate)
-sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (×10 wire encode, header-only; register decode moved to infrastructure/xc/, #178)
+sketches/rc_test/src/application/        — SystemSnapshot.h (#132): immutable per-cycle observation consumed const& by the observer encoders
+sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (×10 wire encode, header-only; register decode moved to infrastructure/xc/, #178) + JsonEncoder (dashboard JSON frame) + CsvEncoder (debug CSV line) — both read only the SystemSnapshot (#132)
 sketches/rc_test/src/ports/              — Hardware contracts as link-time seams (#130): EscOutputPort.h + JoystickPort.h + AlertOutputPort.h + RcInputPort.h (RcFrame) + TelemetrySource.h (EscTelem)
 sketches/rc_test/src/infrastructure/     — The ONLY layer with hardware includes (#130): arduino/PwmEscAdapter.cpp (owns the Servos) + arduino/AdcJoystickAdapter.cpp (ADC settle sequence) + arduino/PiezoAdapter.cpp + radiolink/SbusReceiverAdapter.cpp (owns sbusUart + the S.BUS parser) + xc/XbusTelemetryAdapter.h/.cpp (X.BUS 0x10 poller + register decode)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,30 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-13 — SystemSnapshot: observers read one immutable per-cycle struct (#132)
+
+- `src/application/SystemSnapshot.h` (first `application/` file — the #150
+  check_ino marker stays dormant until FirmwareApp.h): nowMs, RC servo-µs
+  input view + failsafe/lost, raw joystick pair, outL/outR, gear + override
+  mode, the five safety flags, and per-ESC `EscTelem` copies. Deliberately
+  does NOT include types.h (which pulls Arduino.h) so the pure suites stay
+  stub-free — gear is carried as a plain int.
+- `telemetry/JsonEncoder` + `telemetry/CsvEncoder`: buildTelemJson()'s and
+  debugPrint()'s exact format strings moved VERBATIM; both take
+  `const SystemSnapshot&` and use the TelemetryScaling encode helpers —
+  killing debugPrint's inline lroundf duplication (same math, the #121
+  second half). wifiSeq stays [WIFI]-owned and is passed in.
+- The .ino shims keep names/signatures and build the snapshot AT THE
+  ORIGINAL OBSERVATION POINTS (buildTelemJson reads millis() exactly where
+  it used to) for exact timing parity; the once-per-cycle build moves into
+  FirmwareApp at step 11. Alert presentation deferred to the alerts/
+  extraction with reasoning ([ALERT] owns lowVoltLatched — policy, not a
+  read-only observer; documented on issue #132).
+- NEW pure suite tests/telemetry/test_observer_encoders.cpp locks the EXACT
+  JSON/CSV bytes (previously untested); 26 host binaries green. Compile
+  clean — flash 117580 (+224: the snapshot copy at the observation points;
+  emitted bytes identical), RAM 9836 unchanged.
+
 ## 2026-07-13 — Phase D step 10 slice 4: TelemetrySource + XbusTelemetryAdapter (#178)
 
 - `ports/TelemetrySource.h` now owns the `EscTelem` struct (moved verbatim

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -38,6 +38,11 @@ drive exactly as before.
   libraries, vendor types (the bfs S.BUS frame) are translated to domain
   types (`RcFrame`) at the port boundary, and the telemetry port owns the
   `EscTelem` type it delivers while the sketch keeps owning the array
+- **Observers read a snapshot** — `src/application/SystemSnapshot.h` is the
+  immutable per-cycle observation; the dashboard JSON and debug CSV
+  encoders (`src/telemetry/`) consume it `const&` and can no longer reach
+  into module internals ([telemetry and
+  dashboard](telemetry-and-dashboard.md))
 - **Protection first** — the [characterization and invariant
   suites](testing.md) were built BEFORE any code moves, so every refactor
   step is verified against locked behavior

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -73,7 +73,9 @@
 #include "src/domain/drive/CommandMixer.h"
 #include "src/domain/safety/SafetySupervisor.h"
 #include "src/domain/safety/OutputGate.h"
-#include "src/telemetry/TelemetryScaling.h"
+#include "src/application/SystemSnapshot.h"
+#include "src/telemetry/JsonEncoder.h"
+#include "src/telemetry/CsvEncoder.h"
 #include "src/ports/EscOutputPort.h"
 #include "src/ports/JoystickPort.h"
 #include "src/ports/AlertOutputPort.h"
@@ -1026,38 +1028,41 @@ void wifiDebug(uint32_t nowUs) {
   telemetryDebugSnapshotLength = 0;   // reset for next window's snapshot
 }
 
+// Observe the whole system into one immutable SystemSnapshot (#132). Called
+// by the observer shims at their original observation points for exact
+// timing parity; the once-per-cycle build moves into FirmwareApp (step 11).
+SystemSnapshot buildSystemSnapshot(uint32_t nowMs) {
+  SystemSnapshot snapshot = {};
+  snapshot.nowMs = nowMs;
+  snapshot.rcThrottleUs = sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_THR])   : SVC;
+  snapshot.rcSteeringUs = sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_STEER]) : SVC;
+  snapshot.rcGearUs     = sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_GEAR])  : SVC;
+  snapshot.rcOverrideUs = sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_OVR])   : SVMIN;
+  snapshot.rcFailsafe = rcFrame.failsafe;
+  snapshot.rcLostFrame = rcFrame.lostFrame;
+  snapshot.joystickRawY = cachedJoy.rawY;
+  snapshot.joystickRawX = cachedJoy.rawX;
+  snapshot.outLeftUs = outL;
+  snapshot.outRightUs = outR;
+  snapshot.gear = (int)currentGear;
+  snapshot.overrideMode = wifiMode();
+  snapshot.batteryCutoffLatched = batteryCutoffLatched;
+  snapshot.ecoLockLatched = ecoLockLatched;
+  snapshot.temperatureWarnActive = tempWarnActive;
+  snapshot.temperatureEcoActive = tempEcoActive;
+  snapshot.temperatureCutActive = tempCutActive;
+  snapshot.esc[0] = telem[0];
+  snapshot.esc[1] = telem[1];
+  return snapshot;
+}
+
 // Build the telemetry JSON into body; returns its length. Shared by the
-// one-shot /data endpoint and the SSE stream.
+// one-shot /data endpoint and the SSE stream. Formatting lives in
+// telemetry/JsonEncoder (#132); this shim owns the frame counter and the
+// observation point.
 int buildTelemJson(char *body, size_t cap) {
   wifiSeq++;
-  uint32_t nowMs = millis();
-  // Per-ESC age (ms since last good frame). 0 if never received.
-  uint32_t age0 = telem[0].lastGoodMs ? (nowMs - telem[0].lastGoodMs) : 999999UL;
-  uint32_t age1 = telem[1].lastGoodMs ? (nowMs - telem[1].lastGoodMs) : 999999UL;
-  int n = snprintf(body, cap,
-    "{\"t\":%lu,\"seq\":%lu,\"gear\":%d,\"mode\":%d,\"fs\":%d,\"lost\":%d,"
-    "\"eco\":%d,\"cut\":%d,\"hot\":%d,\"teco\":%d,\"tcut\":%d,\"outL\":%d,\"outR\":%d,"
-    "\"e0\":{\"ok\":%d,\"age\":%lu,\"rpm\":%ld,\"cur\":%d,\"v\":%d,\"tE\":%d,\"tM\":%d},"
-    "\"e1\":{\"ok\":%d,\"age\":%lu,\"rpm\":%ld,\"cur\":%d,\"v\":%d,\"tE\":%d,\"tM\":%d}}",
-    (unsigned long)nowMs, (unsigned long)wifiSeq, (int)currentGear, wifiMode(),
-    rcFrame.failsafe ? 1 : 0, rcFrame.lostFrame ? 1 : 0,
-    ecoLockLatched ? 1 : 0, batteryCutoffLatched ? 1 : 0,
-    tempWarnActive ? 1 : 0, tempEcoActive ? 1 : 0, tempCutActive ? 1 : 0,
-    outL, outR,
-    telem[0].valid ? 1 : 0, (unsigned long)age0,
-    electricalHzToDashboardRpm(telem[0].rpmHz),
-    scaleToDeciInteger(telem[0].busCurrentA), scaleToDeciInteger(telem[0].voltage),
-    roundToWholeInteger(telem[0].escTempC), roundToWholeInteger(telem[0].motorTempC),
-    telem[1].valid ? 1 : 0, (unsigned long)age1,
-    electricalHzToDashboardRpm(telem[1].rpmHz),
-    scaleToDeciInteger(telem[1].busCurrentA), scaleToDeciInteger(telem[1].voltage),
-    roundToWholeInteger(telem[1].escTempC), roundToWholeInteger(telem[1].motorTempC));
-  // snprintf returns the length it WOULD have written; clamp to the buffer so
-  // callers never read past `body` (Content-Length and write length stay valid
-  // even if a frame were ever to overflow `cap`).
-  if (n < 0) return 0;
-  if ((size_t)n >= cap) n = (int)cap - 1;
-  return n;
+  return encodeTelemetryJson(body, cap, buildSystemSnapshot(millis()), wifiSeq);
 }
 
 // One-shot /data JSON. Header + body coalesced into a single write() so the
@@ -1279,30 +1284,10 @@ void debugPrint(uint32_t now) {
   if (!Serial || (now - prevPrint) < PRINT_INTERVAL) return;
   prevPrint = now;
 
-  int rcT = sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_THR])   : SVC;
-  int rcS = sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_STEER]) : SVC;
-  int rc4 = sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_GEAR])  : SVC;
-  int rc5 = sbusValid ? sbusToServo(rcFrame.channels[SBUS_CH_OVR])   : SVMIN;
-
-  // Telemetry, integer-scaled so we avoid float printf on this core.
-  int v0 = (int)lroundf(telem[0].voltage    * 10.0f);
-  int i0 = (int)lroundf(telem[0].busCurrentA * 10.0f);
-  int e0 = (int)lroundf(telem[0].escTempC);
-  int m0 = (int)lroundf(telem[0].motorTempC);
-  int v1 = (int)lroundf(telem[1].voltage    * 10.0f);
-  int i1 = (int)lroundf(telem[1].busCurrentA * 10.0f);
-  int e1 = (int)lroundf(telem[1].escTempC);
-  int m1 = (int)lroundf(telem[1].motorTempC);
-
+  // Formatting (integer-scaled — no float printf on this core) lives in
+  // telemetry/CsvEncoder (#132); this shim owns the cadence and the print.
   char buf[200];
-  snprintf(buf, sizeof(buf),
-           "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d",
-           rcT, rcS, rc4, rc5,
-           cachedJoy.rawY, cachedJoy.rawX,
-           outL, outR, (int)currentGear,
-           rcFrame.failsafe, rcFrame.lostFrame,
-           v0, i0, telem[0].rpmHz, e0, m0, telem[0].valid ? 1 : 0,
-           v1, i1, telem[1].rpmHz, e1, m1, telem[1].valid ? 1 : 0);
+  encodeDebugCsv(buf, sizeof(buf), buildSystemSnapshot(now));
   Serial.println(buf);
 }
 

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -1286,8 +1286,10 @@ void debugPrint(uint32_t now) {
 
   // Formatting (integer-scaled — no float printf on this core) lives in
   // telemetry/CsvEncoder (#132); this shim owns the cadence and the print.
+  // NOTE: `now` is µs (loop clock); the snapshot contract is ms, so read
+  // millis() here — the CSV does not use nowMs, so output is unchanged.
   char buf[200];
-  encodeDebugCsv(buf, sizeof(buf), buildSystemSnapshot(now));
+  encodeDebugCsv(buf, sizeof(buf), buildSystemSnapshot(millis()));
   Serial.println(buf);
 }
 

--- a/sketches/rc_test/src/application/SystemSnapshot.h
+++ b/sketches/rc_test/src/application/SystemSnapshot.h
@@ -1,0 +1,44 @@
+// application — the immutable per-cycle observation of the whole system
+// (#132). Built by the application at the observation point (today: the
+// .ino observer shims, for exact timing parity; the once-per-cycle build
+// moves into FirmwareApp at step 11) and passed const& to the observer
+// encoders (telemetry/JsonEncoder, telemetry/CsvEncoder). Observers cannot
+// write and never reach into module internals — the architecture checker
+// allows exactly this header as the observers' one application/ include.
+#pragma once
+
+#include <stdint.h>
+
+#include "../ports/TelemetrySource.h"
+
+struct SystemSnapshot {
+  uint32_t nowMs;      // observation time (drives the per-ESC age fields)
+
+  // Operator inputs as observed: RC channels in servo-µs view (neutral when
+  // the S.BUS link is invalid — matching what the debug CSV always showed)
+  // plus the raw joystick ADC pair.
+  int rcThrottleUs;
+  int rcSteeringUs;
+  int rcGearUs;
+  int rcOverrideUs;
+  bool rcFailsafe;
+  bool rcLostFrame;
+  int joystickRawY;
+  int joystickRawX;
+
+  // Command outputs + operating mode.
+  int outLeftUs;
+  int outRightUs;
+  int gear;            // Gear enum value as an integer (0 Eco / 1 Normal / 2 Boost)
+  int overrideMode;    // wifiMode() result as the dashboard shows it
+
+  // Safety flags.
+  bool batteryCutoffLatched;
+  bool ecoLockLatched;
+  bool temperatureWarnActive;
+  bool temperatureEcoActive;
+  bool temperatureCutActive;
+
+  // Per-ESC telemetry copies (EscTelem from the TelemetrySource port).
+  EscTelem esc[2];
+};

--- a/sketches/rc_test/src/telemetry/CsvEncoder.cpp
+++ b/sketches/rc_test/src/telemetry/CsvEncoder.cpp
@@ -1,0 +1,31 @@
+// telemetry — the ONE implementation of the debug CSV line (#132). The
+// telemetry columns use the shared TelemetryScaling helpers — the same
+// lroundf math debugPrint() previously inlined (the #121 duplication).
+#include "CsvEncoder.h"
+
+#include <stdio.h>
+
+#include "../application/SystemSnapshot.h"
+#include "TelemetryScaling.h"
+
+int encodeDebugCsv(char *line, size_t capacity, const SystemSnapshot &snapshot) {
+  return snprintf(line, capacity,
+                  "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d",
+                  snapshot.rcThrottleUs, snapshot.rcSteeringUs,
+                  snapshot.rcGearUs, snapshot.rcOverrideUs,
+                  snapshot.joystickRawY, snapshot.joystickRawX,
+                  snapshot.outLeftUs, snapshot.outRightUs, snapshot.gear,
+                  snapshot.rcFailsafe, snapshot.rcLostFrame,
+                  scaleToDeciInteger(snapshot.esc[0].voltage),
+                  scaleToDeciInteger(snapshot.esc[0].busCurrentA),
+                  snapshot.esc[0].rpmHz,
+                  roundToWholeInteger(snapshot.esc[0].escTempC),
+                  roundToWholeInteger(snapshot.esc[0].motorTempC),
+                  snapshot.esc[0].valid ? 1 : 0,
+                  scaleToDeciInteger(snapshot.esc[1].voltage),
+                  scaleToDeciInteger(snapshot.esc[1].busCurrentA),
+                  snapshot.esc[1].rpmHz,
+                  roundToWholeInteger(snapshot.esc[1].escTempC),
+                  roundToWholeInteger(snapshot.esc[1].motorTempC),
+                  snapshot.esc[1].valid ? 1 : 0);
+}

--- a/sketches/rc_test/src/telemetry/CsvEncoder.h
+++ b/sketches/rc_test/src/telemetry/CsvEncoder.h
@@ -1,0 +1,12 @@
+// telemetry — CSV encoder for the USB debug stream (#132). The exact 10 Hz
+// line moved VERBATIM from the .ino's debugPrint(); the column header lives
+// with [DEBUG]'s banner print. Pure formatting: reads only the snapshot.
+#pragma once
+
+#include <stddef.h>
+
+struct SystemSnapshot;
+
+// Encode one debug CSV line into `line` (capacity bytes). Returns the
+// snprintf result (callers historically ignore it and print the buffer).
+int encodeDebugCsv(char *line, size_t capacity, const SystemSnapshot &snapshot);

--- a/sketches/rc_test/src/telemetry/JsonEncoder.cpp
+++ b/sketches/rc_test/src/telemetry/JsonEncoder.cpp
@@ -9,6 +9,7 @@
 
 int encodeTelemetryJson(char *body, size_t capacity,
                         const SystemSnapshot &snapshot, unsigned long sequence) {
+  if (capacity == 0) return 0;  // the overflow clamp below would underflow to -1
   // Per-ESC age (ms since last good frame); 999999 if never received.
   uint32_t age0 = snapshot.esc[0].lastGoodMs
                       ? (snapshot.nowMs - snapshot.esc[0].lastGoodMs) : 999999UL;

--- a/sketches/rc_test/src/telemetry/JsonEncoder.cpp
+++ b/sketches/rc_test/src/telemetry/JsonEncoder.cpp
@@ -1,0 +1,42 @@
+// telemetry — the ONE implementation of the dashboard JSON frame (#132).
+#include "JsonEncoder.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../application/SystemSnapshot.h"
+#include "TelemetryScaling.h"
+
+int encodeTelemetryJson(char *body, size_t capacity,
+                        const SystemSnapshot &snapshot, unsigned long sequence) {
+  // Per-ESC age (ms since last good frame); 999999 if never received.
+  uint32_t age0 = snapshot.esc[0].lastGoodMs
+                      ? (snapshot.nowMs - snapshot.esc[0].lastGoodMs) : 999999UL;
+  uint32_t age1 = snapshot.esc[1].lastGoodMs
+                      ? (snapshot.nowMs - snapshot.esc[1].lastGoodMs) : 999999UL;
+  int n = snprintf(body, capacity,
+    "{\"t\":%lu,\"seq\":%lu,\"gear\":%d,\"mode\":%d,\"fs\":%d,\"lost\":%d,"
+    "\"eco\":%d,\"cut\":%d,\"hot\":%d,\"teco\":%d,\"tcut\":%d,\"outL\":%d,\"outR\":%d,"
+    "\"e0\":{\"ok\":%d,\"age\":%lu,\"rpm\":%ld,\"cur\":%d,\"v\":%d,\"tE\":%d,\"tM\":%d},"
+    "\"e1\":{\"ok\":%d,\"age\":%lu,\"rpm\":%ld,\"cur\":%d,\"v\":%d,\"tE\":%d,\"tM\":%d}}",
+    (unsigned long)snapshot.nowMs, sequence, snapshot.gear, snapshot.overrideMode,
+    snapshot.rcFailsafe ? 1 : 0, snapshot.rcLostFrame ? 1 : 0,
+    snapshot.ecoLockLatched ? 1 : 0, snapshot.batteryCutoffLatched ? 1 : 0,
+    snapshot.temperatureWarnActive ? 1 : 0, snapshot.temperatureEcoActive ? 1 : 0,
+    snapshot.temperatureCutActive ? 1 : 0,
+    snapshot.outLeftUs, snapshot.outRightUs,
+    snapshot.esc[0].valid ? 1 : 0, (unsigned long)age0,
+    electricalHzToDashboardRpm(snapshot.esc[0].rpmHz),
+    scaleToDeciInteger(snapshot.esc[0].busCurrentA), scaleToDeciInteger(snapshot.esc[0].voltage),
+    roundToWholeInteger(snapshot.esc[0].escTempC), roundToWholeInteger(snapshot.esc[0].motorTempC),
+    snapshot.esc[1].valid ? 1 : 0, (unsigned long)age1,
+    electricalHzToDashboardRpm(snapshot.esc[1].rpmHz),
+    scaleToDeciInteger(snapshot.esc[1].busCurrentA), scaleToDeciInteger(snapshot.esc[1].voltage),
+    roundToWholeInteger(snapshot.esc[1].escTempC), roundToWholeInteger(snapshot.esc[1].motorTempC));
+  // snprintf returns the length it WOULD have written; clamp to the buffer so
+  // callers never read past `body` (Content-Length and write length stay valid
+  // even if a frame were ever to overflow `capacity`).
+  if (n < 0) return 0;
+  if ((size_t)n >= capacity) n = (int)capacity - 1;
+  return n;
+}

--- a/sketches/rc_test/src/telemetry/JsonEncoder.h
+++ b/sketches/rc_test/src/telemetry/JsonEncoder.h
@@ -1,0 +1,16 @@
+// telemetry — JSON encoder for the dashboard (#132). The exact SSE / /data
+// payload moved VERBATIM from the .ino's buildTelemJson(). Compact keys and
+// integer values are a deliberate bandwidth decision on the SSE frame budget
+// (naming rules, exception 4); the dashboard JS divides by 10 on its side.
+// Pure formatting: reads only the snapshot.
+#pragma once
+
+#include <stddef.h>
+
+struct SystemSnapshot;
+
+// Encode one telemetry frame into body (capacity bytes). Returns the body
+// length, clamped so callers never read past the buffer. `sequence` is the
+// caller-owned frame counter ([WIFI]'s wifiSeq).
+int encodeTelemetryJson(char *body, size_t capacity,
+                        const SystemSnapshot &snapshot, unsigned long sequence);

--- a/tests/telemetry/test_observer_encoders.cpp
+++ b/tests/telemetry/test_observer_encoders.cpp
@@ -1,0 +1,73 @@
+// Pure suite (#132): the observer encoders tested directly on the host — no
+// firmware, no stubs. Locks the EXACT dashboard JSON and debug CSV bytes the
+// firmware emitted before the extraction (formats moved verbatim from
+// buildTelemJson()/debugPrint()); a changed byte here is a behavior change
+// and needs its own issue.
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include <cstring>
+#include <string>
+
+#include "../../sketches/rc_test/src/application/SystemSnapshot.h"
+#include "../../sketches/rc_test/src/telemetry/CsvEncoder.h"
+#include "../../sketches/rc_test/src/telemetry/JsonEncoder.h"
+
+// A fully-populated snapshot with distinct, hand-checkable values.
+static SystemSnapshot exampleSnapshot() {
+  SystemSnapshot s = {};
+  s.nowMs = 1000;
+  s.rcThrottleUs = 1500;
+  s.rcSteeringUs = 1600;
+  s.rcGearUs = 1200;
+  s.rcOverrideUs = 1000;
+  s.rcFailsafe = false;
+  s.rcLostFrame = true;
+  s.joystickRawY = 8192;
+  s.joystickRawX = 4096;
+  s.outLeftUs = 1500;
+  s.outRightUs = 1735;
+  s.gear = 2;
+  s.overrideMode = 1;
+  s.batteryCutoffLatched = false;
+  s.ecoLockLatched = true;
+  s.temperatureWarnActive = true;
+  s.temperatureEcoActive = false;
+  s.temperatureCutActive = false;
+  s.esc[0].voltage = 12.6f;       // → v 126 (deci-volts)
+  s.esc[0].busCurrentA = 2.5f;    // → cur 25 (deci-amps)
+  s.esc[0].rpmHz = 100;           // → rpm 3000 (×30)
+  s.esc[0].escTempC = 25.4f;      // → tE 25
+  s.esc[0].motorTempC = 65.5f;    // → tM 66 (lroundf half away from zero)
+  s.esc[0].lastGoodMs = 900;      // → age 100 at nowMs 1000
+  s.esc[0].valid = true;
+  // esc[1] left zeroed: never received → age 999999, ok 0.
+  return s;
+}
+
+TEST_CASE("JSON frame: exact bytes of the pre-extraction buildTelemJson format") {
+  char body[400];
+  int n = encodeTelemetryJson(body, sizeof(body), exampleSnapshot(), 7);
+  const std::string expected =
+      "{\"t\":1000,\"seq\":7,\"gear\":2,\"mode\":1,\"fs\":0,\"lost\":1,"
+      "\"eco\":1,\"cut\":0,\"hot\":1,\"teco\":0,\"tcut\":0,\"outL\":1500,\"outR\":1735,"
+      "\"e0\":{\"ok\":1,\"age\":100,\"rpm\":3000,\"cur\":25,\"v\":126,\"tE\":25,\"tM\":66},"
+      "\"e1\":{\"ok\":0,\"age\":999999,\"rpm\":0,\"cur\":0,\"v\":0,\"tE\":0,\"tM\":0}}";
+  CHECK(std::string(body) == expected);
+  CHECK(n == (int)expected.size());
+}
+
+TEST_CASE("JSON frame: overflow clamps the returned length to the buffer") {
+  char body[64];  // far too small for a full frame
+  int n = encodeTelemetryJson(body, sizeof(body), exampleSnapshot(), 7);
+  CHECK(n == (int)sizeof(body) - 1);           // clamped, never past the buffer
+  CHECK(std::strlen(body) == sizeof(body) - 1);  // snprintf NUL-terminated it
+}
+
+TEST_CASE("CSV line: exact bytes of the pre-extraction debugPrint format") {
+  char line[200];
+  encodeDebugCsv(line, sizeof(line), exampleSnapshot());
+  CHECK(std::string(line) ==
+        "1500,1600,1200,1000,8192,4096,1500,1735,2,0,1,"
+        "126,25,100,25,66,1,0,0,0,0,0,0");
+}


### PR DESCRIPTION
Closes #132

## Summary

Phase D (#116) — observers now read one immutable per-cycle `SystemSnapshot` instead of scraping globals (state-ownership sin #3, ARCHITECTURE-TARGET §5). This is the prerequisite for the `infrastructure/network/` slice: `buildTelemJson`'s global-scraping was exactly what blocked a clean network-adapter cut. `[C-Builder]`

- **`src/application/SystemSnapshot.h`** — first `application/` file (the #150 `check_ino` marker stays dormant — it keys on `FirmwareApp.h` only). Carries: `nowMs`, RC servo-µs input view + failsafe/lost, raw joystick pair, `outL/outR`, gear + override mode, the five safety flags, per-ESC `EscTelem` copies. Deliberately does NOT include `types.h` (which pulls `Arduino.h`) so the stub-free pure suites can compile it — gear travels as a plain `int`.
- **`src/telemetry/JsonEncoder.h/.cpp`** — `buildTelemJson()`'s exact snprintf moved VERBATIM; takes `const SystemSnapshot&` + the caller-owned sequence number (`wifiSeq` stays `[WIFI]`-owned). Same clamp semantics.
- **`src/telemetry/CsvEncoder.h/.cpp`** — `debugPrint()`'s exact CSV format moved VERBATIM, now via the shared TelemetryScaling helpers — killing the inline `lroundf` duplication (identical math: `scaleToDeciInteger` IS `lroundf(x*10)`); the #121 second half.
- **`.ino`** — `buildSystemSnapshot(nowMs)` observes everything in one place; `buildTelemJson`/`debugPrint` keep their names, signatures and call sites as shims. The snapshot is built **at the original observation points** (`buildTelemJson` reads `millis()` exactly where it used to) for exact timing parity — the once-per-cycle build moves into `FirmwareApp` at step 11, where the cycle owner exists.
- **Deferred with reasoning (documented on #132):** alert presentation consuming the snapshot — today's `[ALERT]` is policy that owns `lowVoltLatched`, not a read-only observer; it lands with the `alerts/` extraction (AlertPolicy/PatternPlayer), which this PR unblocks.
- **New pure suite** `tests/telemetry/test_observer_encoders.cpp` locks the EXACT JSON and CSV bytes (previously untested surface) + the JSON overflow clamp.

## Behavior preservation

Zero observable change — covenant PR. Both format strings, the scaling math, the age computation (999999 sentinel), the clamp, and the observation timing are line-for-line the code they replace. The emitted bytes are now unit-locked.

## Test plan

- Host suite: **26/26 binaries green** (25 existing with zero expectation changes + the new encoder suite)
- `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` clean — flash 117580 (+224: the snapshot copy at the observation points; emitted bytes identical), RAM 9836 unchanged
- `python scripts/check_architecture.py` — OK (first `application/` file; telemetry→`application/SystemSnapshot.h` is the checker's designed observer exception)
- cpplint pre-checked on all five new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
