### PR TITLE
V7.35: config/ layer — every [CONFIG] constant to src/config/ (#185, step-11 pre-slice)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ polls via `telemetrySourceUpdate()` on Serial1 (D0/D1):
 ## Architecture Summary
 
 Sketch: `sketches/rc_test/rc_test.ino` (GL10 FOC + telemetry + Wi-Fi + alarms + battery/thermal safety) + `types.h` + `web_page.h`. The version
-string is defined ONCE — `FIRMWARE_VERSION` at the top of `[CONFIG]` (#124).
+string is defined ONCE — `FIRMWARE_VERSION` in `src/config/BuildInfo.h` (#124, #185).
 No doc carries a live copy; dated records (DECISION-LOG,
 FIRMWARE-UPLOAD-LOG) cite versions historically.
 
@@ -300,7 +300,7 @@ and the Arduino-side filter was double-smoothing the stream (operator felt
 ```text
 PROJECT-PLAN.md                          — Full technical specification
 OPERATOR-GUIDE.md                        — User guide for Jason (RC) and Malaki (joystick)
-sketches/rc_test/rc_test.ino             — Main Arduino sketch (version: FIRMWARE_VERSION in [CONFIG]; GL10 FOC + telemetry + Wi-Fi + alarms + safety)
+sketches/rc_test/rc_test.ino             — Main Arduino sketch (version: FIRMWARE_VERSION in src/config/BuildInfo.h; GL10 FOC + telemetry + Wi-Fi + alarms + safety)
 sketches/rc_test/types.h                 — Shared structs (JoystickState, ...; EscTelem re-exported from ports/TelemetrySource.h)
 sketches/rc_test/src/domain/battery/     — Extracted domain (#117): BatteryTypes.h + VoltagePlausibility.h/.cpp + BatteryLadder.h/.cpp (pure logic, host-testable)
 sketches/rc_test/src/domain/thermal/     — Extracted domain (#117): ThermalTypes.h + ThermalHysteresis.h/.cpp + ThermalDerating.h/.cpp (pure logic, host-testable)
@@ -310,6 +310,7 @@ sketches/rc_test/src/domain/safety/      — Extracted domain (#117): SafetyType
 sketches/rc_test/src/application/        — SystemSnapshot.h (#132): immutable per-cycle observation consumed const& by the observer encoders
 sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (×10 wire encode, header-only; register decode moved to infrastructure/xc/, #178) + JsonEncoder (dashboard JSON frame) + CsvEncoder (debug CSV line) — both read only the SystemSnapshot (#132)
 sketches/rc_test/src/alerts/             — Alert policy + players (#183): AlertTypes.h + AlertPolicy (priority ladder, low-V latch, inactivity) + PatternPlayer (one-shot + repeating) — pure logic; the piezo stays behind ports/AlertOutputPort.h
+sketches/rc_test/src/config/             — ALL tunables per domain (#185): BuildInfo.h (FIRMWARE_VERSION SSOT) + Pins.h + Input/Drive/Battery/Thermal/Alert/Telemetry/Wifi/SafetyConfig.h — values are law, included by the .ino
 sketches/rc_test/src/ports/              — Hardware contracts as link-time seams (#130): EscOutputPort.h + JoystickPort.h + AlertOutputPort.h + RcInputPort.h (RcFrame) + TelemetrySource.h (EscTelem) + DashboardServicePort.h + TelemetryFrameSource.h (reverse seam: app encodes, network ships bytes)
 sketches/rc_test/src/infrastructure/     — The ONLY layer with hardware includes (#130): arduino/PwmEscAdapter.cpp (owns the Servos) + arduino/AdcJoystickAdapter.cpp (ADC settle sequence) + arduino/PiezoAdapter.cpp + radiolink/SbusReceiverAdapter.cpp (owns sbusUart + the S.BUS parser) + xc/XbusTelemetryAdapter.h/.cpp (X.BUS 0x10 poller + register decode) + network/ (WifiService + DashboardServer + SseStream — the #69/#54/#77 serving machine + its tunables, #181)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
@@ -352,7 +353,7 @@ monitor.py                               — Simple serial monitor
 
 - All code in `rc_test.ino` is organized in `[MODULE]` sections — search `[NAME]` to jump
 - Structs go in `types.h` (solves Arduino auto-prototype limitation)
-- All tunable constants go in the `[CONFIG]` section — no magic numbers in code
+- All tunable constants live in `src/config/` per-domain headers (#185; the `[CONFIG]` section is now their include point) — no magic numbers in code
 - When the sketch exceeds ~500 lines, split into `.h/.cpp` pairs (not multiple `.ino` files)
 
 ### Testing (#47 — details in docs/TESTING.md)
@@ -387,8 +388,8 @@ monitor.py                               — Simple serial monitor
 - Comment each `[MODULE]` section header with a brief description
 - Commit messages: `V{major}.{minor}: {imperative verb} {what changed}`
 - **README describes behavior, never tunable numbers** (#124): current values
-  live in `[CONFIG]`. PROJECT-PLAN and OPERATOR-GUIDE are technical
-  references — numbers are allowed there but must match `[CONFIG]` (drift is
+  live in `src/config/`. PROJECT-PLAN and OPERATOR-GUIDE are technical
+  references — numbers are allowed there but must match `src/config/` (drift is
   a doc bug)
 
 ### ESC / motor configuration changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,7 @@ sketches/rc_test/src/domain/safety/      — Extracted domain (#117): SafetyType
 sketches/rc_test/src/application/        — SystemSnapshot.h (#132): immutable per-cycle observation consumed const& by the observer encoders
 sketches/rc_test/src/telemetry/          — Extracted observer layer (#117): TelemetryScaling.h (×10 wire encode, header-only; register decode moved to infrastructure/xc/, #178) + JsonEncoder (dashboard JSON frame) + CsvEncoder (debug CSV line) — both read only the SystemSnapshot (#132)
 sketches/rc_test/src/alerts/             — Alert policy + players (#183): AlertTypes.h + AlertPolicy (priority ladder, low-V latch, inactivity) + PatternPlayer (one-shot + repeating) — pure logic; the piezo stays behind ports/AlertOutputPort.h
-sketches/rc_test/src/config/             — ALL tunables per domain (#185): BuildInfo.h (FIRMWARE_VERSION SSOT) + Pins.h + Input/Drive/Battery/Thermal/Alert/Telemetry/Wifi/SafetyConfig.h — values are law, included by the .ino
+sketches/rc_test/src/config/             — Tunables per domain (#185): BuildInfo.h (FIRMWARE_VERSION SSOT) + Pins.h + Input/Drive/Battery/Thermal/Alert/Telemetry/Wifi/SafetyConfig.h — values are law, included by the .ino (adapter-owned tunables stay single-homed in infrastructure/)
 sketches/rc_test/src/ports/              — Hardware contracts as link-time seams (#130): EscOutputPort.h + JoystickPort.h + AlertOutputPort.h + RcInputPort.h (RcFrame) + TelemetrySource.h (EscTelem) + DashboardServicePort.h + TelemetryFrameSource.h (reverse seam: app encodes, network ships bytes)
 sketches/rc_test/src/infrastructure/     — The ONLY layer with hardware includes (#130): arduino/PwmEscAdapter.cpp (owns the Servos) + arduino/AdcJoystickAdapter.cpp (ADC settle sequence) + arduino/PiezoAdapter.cpp + radiolink/SbusReceiverAdapter.cpp (owns sbusUart + the S.BUS parser) + xc/XbusTelemetryAdapter.h/.cpp (X.BUS 0x10 poller + register decode) + network/ (WifiService + DashboardServer + SseStream — the #69/#54/#77 serving machine + its tunables, #181)
 sketches/rc_test/arduino_secrets.h.example — Wi-Fi credential template (#125); copy to arduino_secrets.h (gitignored)
@@ -353,7 +353,7 @@ monitor.py                               — Simple serial monitor
 
 - All code in `rc_test.ino` is organized in `[MODULE]` sections — search `[NAME]` to jump
 - Structs go in `types.h` (solves Arduino auto-prototype limitation)
-- All tunable constants live in `src/config/` per-domain headers (#185; the `[CONFIG]` section is now their include point) — no magic numbers in code
+- All tunable constants live in `src/config/` per-domain headers (#185; the `[CONFIG]` section is now their include point) — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `infrastructure/xc/`, Wi-Fi serving tunables in `infrastructure/network/`)
 - When the sketch exceeds ~500 lines, split into `.h/.cpp` pairs (not multiple `.ino` files)
 
 ### Testing (#47 — details in docs/TESTING.md)

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,30 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-13 — Step-11 pre-slice: config/ layer extraction (#185)
+
+- Every `[CONFIG]` constant moved VERBATIM (values byte-identical) to
+  `src/config/` per the target's grouping: BuildInfo.h (FIRMWARE_VERSION —
+  the #124 SSOT gate is home-agnostic, now fires on this file), Pins.h
+  (application pins; documented include-order contract — it uses the
+  core's A0/A1 macros and must follow <Arduino.h>, config/ may not include
+  hardware headers), InputConfig, DriveConfig (incl. CALIBRATION_MODE +
+  the PIVOT_THROTTLE_TAPER static_assert), BatteryConfig, ThermalConfig,
+  AlertConfig (patterns + tunables), TelemetryConfig (PRINT_INTERVAL),
+  WifiConfig (AP channel), SafetyConfig (WDT_TIMEOUT_MS).
+- Deliberately NOT moved: the mutable state interleaved in [CONFIG]
+  (gearScale/currentGear, safety latches, thermal flags — state is not
+  configuration; goes with FirmwareApp), the outCapToX/reverseCap
+  delegates + Gear↔GearLevel static_assert (read globals + domain), and
+  constant NAMES (SVC/OVR_*/JOY_* stay verbatim — dozens of test files
+  reference them; renames are the #118 sweep's call).
+- Single-homed adapter tunables stay put (X.BUS poll constants in xc/
+  since #178; Wi-Fi serving tunables in network/ since #181).
+- Verified: 27 host binaries green, ZERO test edits; compile
+  BYTE-IDENTICAL (flash 117948, RAM 9848 — compile-time constants);
+  fitness OK. [CONFIG] in the .ino is now the config include point +
+  the state/delegate block.
+
 ## 2026-07-13 — Step-11 pre-slice: alerts/ layer extraction (#183)
 
 - `[BEEPER]`/`[ALERT]` policy and sequencing moved VERBATIM to

--- a/docs/architecture/BENCH-VERIFICATION-DEFERRED.md
+++ b/docs/architecture/BENCH-VERIFICATION-DEFERRED.md
@@ -15,7 +15,7 @@ in one session, then log the flash in `docs/FIRMWARE-UPLOAD-LOG.md` as usual.
 - [ ] Stick→track response identical to V7.34 baseline in all 3 gears, forward/reverse/pivot (feel + serial CSV compare)
 - [ ] RC-loss failsafe: ease to neutral, then no pulses; ESCs beep; recovery on signal return
 - [ ] Battery ladder on bench supply: Eco-lock ~10.8 V (15 s), alarm 10.5 V, cutoff 10.0 V latched
-- [ ] Thermal stages (heat gun / simulated): trill ≥80 °C, Eco ≥90 °C, cut ≥95 °C, auto-recovery + restored flourish
+- [ ] Thermal stages (heat gun / simulated): trill ≥80 °C, Eco ≥90 °C, cut ≥95 °C, auto-recovery + restored flourish; confirm 95 °C sits just BELOW the GL10's own (unpublished) internal thermal limit so our warned cut fires first (src/config/ThermalConfig.h note)
 - [ ] Wi-Fi dashboard: connects, SSE at ~5 Hz, page load doesn't perturb control (watchdog silent)
 - [ ] Horn, Wi-Fi-ready beep, inactivity alarm patterns unchanged
 - [ ] Loop rate still ~20 kHz idle (serial banner / measurement)

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -41,6 +41,10 @@ drive exactly as before.
   boundary, the telemetry port owns the `EscTelem` type it delivers while
   the sketch keeps owning the array, and the network layer only ever
   handles encoded bytes (the reverse `TelemetryFrameSource` seam)
+- **Config is a layer** — every tunable lives in `src/config/` per-domain
+  headers (BuildInfo carries the version single source of truth, Pins
+  carries the application pin map); the `[CONFIG]` section of the sketch
+  is now their include point, and values are law
 - **Alerts are a layer** — the beep vocabulary lives in `src/alerts/`:
   `AlertPolicy` (the priority ladder, the low-voltage latch with its own
   plausibility form, inactivity tracking) + `PatternPlayer` (one-shot and

--- a/sketches/rc_test/rc_test.ino
+++ b/sketches/rc_test/rc_test.ino
@@ -93,201 +93,23 @@
 
 
 // ═══════════════════════════════════════════════════════════════
-// [CONFIG] — All tunable constants
+// [CONFIG] — tunable constants, now grouped in src/config/ (#185)
 // ═══════════════════════════════════════════════════════════════
-
-// Firmware version — SINGLE SOURCE OF TRUTH (#124). The debug banner prints
-// it; docs and FIRMWARE-UPLOAD-LOG reference it. Bump here, nowhere else.
-const char FIRMWARE_VERSION[] = "V7.35";
-
-// Pins
-const uint8_t PIN_JOY_Y  = A0;  // Throttle
-const uint8_t PIN_JOY_X  = A1;  // Steering
-const uint8_t PIN_ESC_L  = 9;   // Left ESC PWM (50 Hz, 1000-2000 us)
-const uint8_t PIN_ESC_R  = 10;  // Right ESC PWM
-const uint8_t PIN_BEEPER = 8;   // D8 — active piezo (digital HIGH = beep)
-
-// S.BUS channel mapping (0-indexed). Confirmed by live capture while
-// the operator moved each control independently on the RC6GS V3:
-// trigger → ch 1, wheel → ch 0.
-const uint8_t SBUS_CH_THR   = 1;  // trigger → throttle (forward/back)
-const uint8_t SBUS_CH_STEER = 0;  // wheel   → steering (left/right)
-const uint8_t SBUS_CH_GEAR  = 3;  // CH4 = gear selector (3-pos switch)
-const uint8_t SBUS_CH_OVR   = 4;  // CH5 = override switch (3-pos switch)
-const uint8_t SBUS_CH_HORN  = 6;  // CH7 = SWD button → horn (beep at +100%)
-
-// S.BUS value range (raw 172-1811, center ~992)
-const int SBUS_MIN = 172;
-const int SBUS_MAX = 1811;
-const int HORN_ON_RAW = 1400;  // SWD raw above this = horn ON (toward +100% ~1811)
-const uint16_t BEEP_WIFI_READY[]   = {180, 140, 180};  // Wi-Fi-ready "beep beep": on, off, on (ms)
-const int      BEEP_WIFI_READY_LEN = 3;                // phases in BEEP_WIFI_READY[]
-
-// [ALERT] repeating alarm patterns (ms, starting with ON; played as a loop).
-// Distinct on purpose so each is identifiable by ear — see OPERATOR-GUIDE.md.
-const uint16_t ALERT_INACT[]   = {500, 1500};                   // one long beep / 2 s  (RC off)
-const int      ALERT_INACT_LEN = 2;
-const uint16_t ALERT_LOWV[]    = {120, 120, 120, 120, 120, 600};  // three fast chirps / ~1.2 s (low batt)
-const int      ALERT_LOWV_LEN  = 6;
-// Motor/ESC over-temp patterns (#111) — chosen to be unmistakable by ear vs the
-// four above (2 short once / 1 long / 3 short fast / continuous horn):
-const uint16_t ALERT_THERM_WARN[]   = {100, 100};                      // fast nonstop TRILL (>= 80 C)
-const int      ALERT_THERM_WARN_LEN = 2;
-const uint16_t ALERT_THERM_CUT[]    = {500, 150, 500, 150, 500, 1000};  // three LONG beeps (>= 95 C cut)
-const int      ALERT_THERM_CUT_LEN  = 6;
-const uint16_t BEEP_THERM_RESTORED[]   = {120, 100, 120, 100, 120, 100, 120, 1500};  // 4 quick flourish, one-shot (< 75 C)
-const int      BEEP_THERM_RESTORED_LEN = 8;
-
-// [ALERT] tunables
-const uint32_t INACT_RC_OFF_MS  = 60000UL;  // RC off this long → inactivity beep ("unplug me")
-const float    LOWV_THRESH_V    = 10.5f;   // worst-of-two pack EMA below this → low-batt alarm (heads-up beep before the 10.0 V cutoff)
-const float    LOWV_PLAUS_MIN_V = 6.0f;    // pack reading below this = not present / bad → ignore
-const float    LOWV_PLAUS_MAX_V = 13.0f;   // pack reading above this = bad read → ignore
-const uint32_t LOWV_DEBOUNCE_MS = 3000UL;  // must stay below thresh this long before latching
-const uint32_t ALERT_STARTUP_MS = 60000UL;  // suppress low-V alarm until telemetry/EMA settles
-
-// [SAFETY] battery motor-cutoff (#65) — a HARD stop below the audible low-V alarm.
-// Worst-of-two pack EMA < CUTOFF_THRESH_V, validity-gated + debounced + latched →
-// motors cut AND the D8 alarm chirps immediately (no startup grace; the validity
-// gate alone guards the ~1 s telemetry warm-up). 10.0 V on a 3S pack = 3.33 V/cell
-// average — conservative, above the ~3.0 V/cell damage line even with some cell
-// imbalance. Latches until power-cycle. All three timings are tunable here.
-const float    CUTOFF_THRESH_V    = 10.0f;   // worst pack EMA below this → cut motors
-const uint32_t CUTOFF_DEBOUNCE_MS = 1500UL;  // sustained below thresh before cutting (ignore load sag; do NOT set 0)
-const uint32_t CUTOFF_HOLD_MS     = 500UL;   // command neutral this long before cutting PWM (let GL10 wind down)
-// Boot gate (#65): the cutoff latch lives in RAM, so a watchdog/brownout reset
-// would clear it. To stop a low pack from driving in that window, the output is
-// held OFF after boot until a valid battery reading confirms it's ABOVE the
-// cutoff. If telemetry never reports (dead X.BUS), fail OPEN after this timeout
-// so a telemetry fault can't permanently disable driving.
-const uint32_t BATTERY_CONFIRM_MS = 3000UL;  // no valid battery within this → allow drive anyway (telemetry-optional)
-
-// [SAFETY] low-battery Eco lockout (#65) — a STAGE BEFORE the hard cutoff. When
-// the worst pack sags low for an extended period, force Eco gear regardless of
-// the RC gear switch so a nearly-drained pack isn't hit with Boost/Normal load.
-// Latches until power-cycle. 10.8 V ≈ 30% on a 3S pack — the LiPo "knee", so the
-// top ~70% keeps full Boost/Normal and Eco only eases the final steep stretch.
-// (Ladder: 10.8 V → Eco lock (15 s) · 10.5 V → beep · 10.0 V → hard cutoff.)
-const float    ECO_LOCK_THRESH_V    = 10.8f;    // worst pack EMA below this → force Eco
-const uint32_t ECO_LOCK_DEBOUNCE_MS = 15000UL;  // sustained below thresh before locking Eco
-
-// [SAFETY] motor / ESC over-temperature protection (#111) — staged, NON-LATCHING
-// with hysteresis. Heat is the OPPOSITE of a drained LiPo: once it cools, driving
-// must resume automatically, so each stage releases on its own (lower) threshold
-// rather than latching to power-cycle like the battery ladder. Source = HOTTEST
-// of all 4 sensors (ESC + motor temp on BOTH ESCs), already EMA-smoothed
-// (TELEMETRY_EMA_ALPHA_TEMPERATURE) + a short trip debounce so a single spike / dropped frame can't
-// flip a stage. A telemetry dropout (no fresh valid reading) HOLDS the last state
-// — it never triggers a cut.
-//   Warning beep  >= 80 C  (release < 78 C) : trill, motors keep running
-//   Eco lock      >= 90 C  (release < 80 C) : force Eco gear
-//   Hard cutoff   >= 95 C  (release < 75 C) : ease PWM to neutral, keep beeping
-// NOTE: 95 C is PROVISIONAL — confirm on the bench that it sits just BELOW the
-// GL10's own internal thermal limit (param 17 = temp-controlled fan; the GL10's
-// internal throttle/cutoff number is unpublished) so our warned graceful cut
-// fires before the ESC's silent one.
-const float    TEMP_WARN_ON_C    = 80.0f;
-const float    TEMP_WARN_OFF_C   = 78.0f;
-const float    TEMP_ECO_ON_C     = 90.0f;
-const float    TEMP_ECO_OFF_C    = 80.0f;
-const float    TEMP_CUT_ON_C     = 95.0f;
-const float    TEMP_CUT_OFF_C    = 75.0f;
-const uint32_t TEMP_DEBOUNCE_MS  = 1000UL;   // sustained past a TRIP threshold before the stage flips on
-const float    TEMP_PLAUS_MIN_C  = -20.0f;   // reading below this = bad / unplugged sensor → ignore
-const float    TEMP_PLAUS_MAX_C  = 200.0f;   // reading above this = bad read → ignore
-
-// Servo PWM range (matches GL10's standard 50 Hz, 1-2 ms input spec)
-const int SVC   = 1500;  // Center (neutral)
-const int SVMIN = 1000;  // Full reverse
-const int SVMAX = 2000;  // Full forward
-
-// ADC
-const int ADC_CENTER = 8192;  // 14-bit midpoint
-
-// Deadbands
-const int RC_DEADBAND  = 50;   // RC mapped pulse (us)
-const int JOY_DEADBAND = 480;  // Joystick ADC (~5.9% of travel)
-
-// Override switch thresholds (mapped to PWM-equivalent)
-const int OVR_LO = 1400;  // Below → RC only
-const int OVR_HI = 1600;  // Above → 50/50 blend (RC + joystick)
-
-// Expo curve blend weights — output = LINEAR*|x| + CUBIC*|x|^3.
-// Throttle keeps the smoother (more cubic) curve so launch feel is gentle.
-// Steering uses a more linear curve so partial joystick deflection
-// produces real turn authority — operator feedback was that the joystick
-// pivot felt underpowered before reaching full lock.
-const float EXPO_THROTTLE_LINEAR = 0.4f;
-const float EXPO_THROTTLE_CUBIC  = 0.6f;
-const float EXPO_STEER_LINEAR    = 0.7f;
-const float EXPO_STEER_CUBIC     = 0.3f;
-
-// Joystick steering polarity: -1.0f to flip left/right (set after the
-// operator-side cable was rewired and right-stick produced a left turn).
-const float JOY_STEER_DIR = -1.0f;
-
-// Joystick throttle gain (#90) — the Genie stick under-ranges: full physical
-// deflection only reaches ~0.75 xSpeed, so the rider couldn't hit the per-gear
-// caps below. Lift it so full travel can reach the cap. Joystick-only; RC
-// unaffected. Tunable.
-const float JOY_THROTTLE_GAIN = 1.40f;
-
-// ── Throttle output caps ──────────────────────────────────────────────────
-// All caps below are MAX TRACK-OUTPUT fractions (0..1). A straight-line track
-// output = xSpeed * gearScale, so each cap is converted to the xSpeed domain
-// via outCapToX() at point of use — one helper, no scattered conversions.
-
-// Per-gear joystick FORWARD cap (#90) — the joystick rider's max forward track
-// output per gear (RC keeps the gear's full authority). Throttle axis only;
-// steering / pivot unaffected.
-const float JOY_CAP_ECO    = 0.65f;  // Eco
-const float JOY_CAP_NORMAL = 0.75f;  // Normal
-const float JOY_CAP_BOOST  = 0.90f;  // Boost
-
-// REVERSE caps (#87/#113) — per gear, flat across BOTH inputs (RC + joystick).
-// Reverse is held below forward authority; Boost is allowed a little more reverse
-// than Eco/Normal. Applied through reverseCap() (defined with the other gear-cap
-// helpers below) so there is ONE source of truth, not a scattered conditional.
-// These are TRUE percentages only because the GL10s were recalibrated to the full
-// 1000/1500/2000 us range on 2026-07-03. Previously they were calibrated while the
-// firmware capped reverse at 65%, so they mislearned 65% as 100% reverse — which
-// made a 65%-commanded reverse drive ~100%. Do NOT lower the firmware reverse cap
-// and recalibrate at the same time, or that mislearning returns.
-const float REVERSE_CAP_STD   = 0.55f;  // Eco + Normal
-const float REVERSE_CAP_BOOST = 0.65f;  // Boost
-
-// Power range — full PWM authority (1000-2000 us = ±500 us from SVC)
-const float SOFT_RANGE = 500.0f;  // Max servo offset from center (us)
-
-// ── ESC THROTTLE-CALIBRATION MODE (#113) ───────────────────────────────────
-// TEMPORARY. When true, the throttle stick passes STRAIGHT THROUGH to the full
-// ±100% PWM range (1000 / 1500 / 2000 us) on BOTH tracks — ALL caps, gear scaling
-// and steering are bypassed — so the GL10s can learn the Arduino's TRUE endpoints
-// (Option A, docs/GL10-OPERATION.md §5). Needed because the ESCs were previously
-// calibrated while the firmware capped reverse at 65%, so they mislearned 65% as
-// their 100% reverse endpoint (that is why 65%-commanded reverse drove ~100%).
-// After BOTH ESCs are recalibrated, set this back to false and reflash the normal
-// firmware (where REVERSE_CAP etc. become TRUE percentages again).
-// SAFETY: motors reach full power in this mode — tracks clear / wheels up.
-const bool CALIBRATION_MODE = false;
-
-// Gear scaling — RC CH4 selects the AVERAGE-speed cap. 3-position switch:
-//   LOW  → 65% average-speed cap  (training / tight spaces)
-//   MID  → 80% average-speed cap  (normal driving — the everyday gear)
-//   HIGH → 100% (the rail)        (full throttle authority)
-// The cap limits the AVERAGE track speed, not each wheel: in a turn the outer
-// track may use the headroom up to the ESC limit so the turn holds its speed
-// (see curvatureDrive). Boost has no headroom (already at the rail).
-// Failsafe: when S.BUS is invalid, gearScale stays at LOW for safety.
-const float GEAR_LOW_SCALE  = 0.65f;  // Eco   (+10pp 2026-06-21 for usefulness; keeps ~35% turn headroom)
-const float GEAR_MID_SCALE  = 0.80f;  // Normal (+10pp 2026-06-21 — the everyday gear; keeps ~20% turn headroom)
-const float GEAR_HIGH_SCALE = 1.00f;  // Boost  (no turn headroom — at the rail)
-
-// Eco gets extra PIVOT authority so the operator can still maneuver in tight
-// spaces (pivot input cap; forward stays at GEAR_LOW_SCALE 65%). Effective pivot
-// wheel speed = pivot cap × gear scale: 0.725 × 0.65 = 0.47 (vs 0.60 × 0.65).
-// (Reverse is capped per gear via reverseCap(): 55% Eco/Normal, 65% Boost.)
-const float PIVOT_SPEED_CAP_LOW = 0.725f;
+// Values unchanged on move; one header per domain, per the target:
+// BuildInfo (version SSOT #124) · Pins · InputConfig · DriveConfig ·
+// BatteryConfig · ThermalConfig · AlertConfig · TelemetryConfig ·
+// WifiConfig · SafetyConfig (watchdog). Pins.h uses the core's A0/A1
+// macros and relies on <Arduino.h> being included first (it is, above).
+#include "src/config/BuildInfo.h"
+#include "src/config/Pins.h"
+#include "src/config/InputConfig.h"
+#include "src/config/DriveConfig.h"
+#include "src/config/BatteryConfig.h"
+#include "src/config/ThermalConfig.h"
+#include "src/config/AlertConfig.h"
+#include "src/config/TelemetryConfig.h"
+#include "src/config/WifiConfig.h"
+#include "src/config/SafetyConfig.h"
 
 // Gear state — declared here so curvatureDrive() and rcCommand() can read
 // it for the Eco-only conditional caps above. updateGear() in [GEAR]
@@ -331,69 +153,6 @@ inline float reverseCap() {
   return reverseCapForGear((GearLevel)currentGear, REVERSE_CAP_STD,
                            REVERSE_CAP_BOOST);
 }
-
-// Curvature drive — pivot/curvature blend band.
-// |xSpeed| <= START: pure pivot (counter-rotate at PIVOT_SPEED_CAP)
-// |xSpeed| >= END:   pure curvature (outer holds the average, inner slows)
-// Between: smoothstep blend so the operator doesn't feel a mode jump. The band
-// is WIDE (0.05–0.55) so the pivot↔forward/reverse hand-off is gradual — a
-// narrow band made the transition snap near 15–20% throttle (#72).
-const float PIVOT_BLEND_START = 0.05f;
-const float PIVOT_BLEND_END   = 0.55f;
-const float PIVOT_SPEED_CAP   = 0.60f;  // pivot rotation cap (~60% wheel power)
-
-// Pivot-branch throttle taper (#114). Throttle used to enter BOTH tracks of the
-// pivot branch at full gain, so 10–20% throttle while steering shifted both
-// tracks forward together — an instant surge (mirrored in reverse). Taper the
-// pivot branch's throttle term by steering: while turning, the outer track
-// keeps most of its pivot speed (it still gains (1−taper)·throttle) and the
-// inner keeps a slight counter-rotation that eases through zero as throttle
-// rises; forward speed then builds as the blend hands over to the curvature
-// branch. The taper deliberately follows the RAW steering stick, not
-// cappedRotation: past the pivot cap extra deflection adds no rotation, but it
-// still reads as "hold the pivot", so full lock holds hardest (2026-07-03,
-// field-validated — see docs/DECISION-LOG.md). 0.0 = old behavior, 1.0 =
-// throttle fully suppressed at full steer. Straight-line (z = 0), pure pivot
-// (x = 0), and at-speed turns (|xSpeed| >= PIVOT_BLEND_END → pure curvature)
-// are mathematically unchanged. Field-tune WITHIN [0, 1] — enforced below
-// because above 1.0 the term flips sign (forward stick would command reverse).
-constexpr float PIVOT_THROTTLE_TAPER = 0.70f;
-static_assert(PIVOT_THROTTLE_TAPER >= 0.0f && PIVOT_THROTTLE_TAPER <= 1.0f,
-              "PIVOT_THROTTLE_TAPER outside [0,1] inverts pivot-branch throttle");
-
-// Outer-track turn cap (#96). The #72 outer-track headroom lets the outer wheel
-// borrow up to the ESC rail to hold speed through a turn — but when the INNER
-// track is stopped (full steer) that headroom is wasted (the outer doesn't need
-// ~99% to swing the nose). curvatureDrive fades the outer-track ceiling from the
-// rail (straight, both tracks moving) down to TURN_TRACK_CAP (full steer, inner
-// stopped), driven by |zRotation| — open-loop, smooth, no hard switch.
-const float TURN_TRACK_CAP    = 0.70f;  // outer-track cap at full steer (field-tune)
-
-// RC input gains — neutral baseline (1.0 = no scaling). Stick travel
-// maps directly to curvatureDrive, which already handles inner-track
-// slowdown and pivot/curvature blend. Earlier non-unity values were
-// band-aids compensating for the flipped-ESC steering bug; with the
-// root cause fixed, the gains return to neutral.
-const float RC_THROTTLE_GAIN = 1.00f;
-const float RC_STEERING_GAIN = 1.00f;
-
-// Debug
-const uint32_t PRINT_INTERVAL = 100000UL;  // 10 Hz CSV output
-
-// Wi-Fi telemetry-dashboard identity (monitoring only — never affects
-// control). The serving tunables (SSE cadence/frame cap, page chunk, modem
-// timeout) moved to src/infrastructure/network/WifiService.h with the
-// serving machine (#181, values unchanged); credentials stay in
-// arduino_secrets.h under [WIFI].
-const uint8_t  WIFI_AP_CHANNEL       = 11;   // 2.4 GHz AP channel — off the crowded 1/6 (issue #54)
-
-// Safety watchdog (#69). The MCU resets if loop() fails to service the control
-// path (read inputs + write outputs) within WDT_TIMEOUT_MS — a reset stops PWM,
-// so the ESCs go to neutral/failsafe instead of holding the last throttle. This
-// bounds ANY loop stall (Wi-Fi serving or otherwise) to at most this long.
-// Starting value; tune on the bench. Must stay above the worst-case single loop
-// pass (with incremental page serving, a pass is far under this).
-const uint32_t WDT_TIMEOUT_MS        = 250;
 
 
 // ═══════════════════════════════════════════════════════════════

--- a/sketches/rc_test/src/config/AlertConfig.h
+++ b/sketches/rc_test/src/config/AlertConfig.h
@@ -1,0 +1,30 @@
+// config — beep/alarm patterns + audible-alert tunables (#185, #51/#68).
+#pragma once
+
+#include <stdint.h>
+
+const uint16_t BEEP_WIFI_READY[]   = {180, 140, 180};  // Wi-Fi-ready "beep beep": on, off, on (ms)
+const int      BEEP_WIFI_READY_LEN = 3;                // phases in BEEP_WIFI_READY[]
+
+// [ALERT] repeating alarm patterns (ms, starting with ON; played as a loop).
+// Distinct on purpose so each is identifiable by ear — see OPERATOR-GUIDE.md.
+const uint16_t ALERT_INACT[]   = {500, 1500};                   // one long beep / 2 s  (RC off)
+const int      ALERT_INACT_LEN = 2;
+const uint16_t ALERT_LOWV[]    = {120, 120, 120, 120, 120, 600};  // three fast chirps / ~1.2 s (low batt)
+const int      ALERT_LOWV_LEN  = 6;
+// Motor/ESC over-temp patterns (#111) — chosen to be unmistakable by ear vs the
+// four above (2 short once / 1 long / 3 short fast / continuous horn):
+const uint16_t ALERT_THERM_WARN[]   = {100, 100};                      // fast nonstop TRILL (>= 80 C)
+const int      ALERT_THERM_WARN_LEN = 2;
+const uint16_t ALERT_THERM_CUT[]    = {500, 150, 500, 150, 500, 1000};  // three LONG beeps (>= 95 C cut)
+const int      ALERT_THERM_CUT_LEN  = 6;
+const uint16_t BEEP_THERM_RESTORED[]   = {120, 100, 120, 100, 120, 100, 120, 1500};  // 4 quick flourish, one-shot (< 75 C)
+const int      BEEP_THERM_RESTORED_LEN = 8;
+
+// [ALERT] tunables
+const uint32_t INACT_RC_OFF_MS  = 60000UL;  // RC off this long → inactivity beep ("unplug me")
+const float    LOWV_THRESH_V    = 10.5f;   // worst-of-two pack EMA below this → low-batt alarm (heads-up beep before the 10.0 V cutoff)
+const float    LOWV_PLAUS_MIN_V = 6.0f;    // pack reading below this = not present / bad → ignore
+const float    LOWV_PLAUS_MAX_V = 13.0f;   // pack reading above this = bad read → ignore
+const uint32_t LOWV_DEBOUNCE_MS = 3000UL;  // must stay below thresh this long before latching
+const uint32_t ALERT_STARTUP_MS = 60000UL;  // suppress low-V alarm until telemetry/EMA settles

--- a/sketches/rc_test/src/config/BatteryConfig.h
+++ b/sketches/rc_test/src/config/BatteryConfig.h
@@ -1,0 +1,29 @@
+// config — the low-battery motor-protection ladder tunables (#185, #65).
+#pragma once
+
+#include <stdint.h>
+
+// [SAFETY] battery motor-cutoff (#65) — a HARD stop below the audible low-V alarm.
+// Worst-of-two pack EMA < CUTOFF_THRESH_V, validity-gated + debounced + latched →
+// motors cut AND the D8 alarm chirps immediately (no startup grace; the validity
+// gate alone guards the ~1 s telemetry warm-up). 10.0 V on a 3S pack = 3.33 V/cell
+// average — conservative, above the ~3.0 V/cell damage line even with some cell
+// imbalance. Latches until power-cycle. All three timings are tunable here.
+const float    CUTOFF_THRESH_V    = 10.0f;   // worst pack EMA below this → cut motors
+const uint32_t CUTOFF_DEBOUNCE_MS = 1500UL;  // sustained below thresh before cutting (ignore load sag; do NOT set 0)
+const uint32_t CUTOFF_HOLD_MS     = 500UL;   // command neutral this long before cutting PWM (let GL10 wind down)
+// Boot gate (#65): the cutoff latch lives in RAM, so a watchdog/brownout reset
+// would clear it. To stop a low pack from driving in that window, the output is
+// held OFF after boot until a valid battery reading confirms it's ABOVE the
+// cutoff. If telemetry never reports (dead X.BUS), fail OPEN after this timeout
+// so a telemetry fault can't permanently disable driving.
+const uint32_t BATTERY_CONFIRM_MS = 3000UL;  // no valid battery within this → allow drive anyway (telemetry-optional)
+
+// [SAFETY] low-battery Eco lockout (#65) — a STAGE BEFORE the hard cutoff. When
+// the worst pack sags low for an extended period, force Eco gear regardless of
+// the RC gear switch so a nearly-drained pack isn't hit with Boost/Normal load.
+// Latches until power-cycle. 10.8 V ≈ 30% on a 3S pack — the LiPo "knee", so the
+// top ~70% keeps full Boost/Normal and Eco only eases the final steep stretch.
+// (Ladder: 10.8 V → Eco lock (15 s) · 10.5 V → beep · 10.0 V → hard cutoff.)
+const float    ECO_LOCK_THRESH_V    = 10.8f;    // worst pack EMA below this → force Eco
+const uint32_t ECO_LOCK_DEBOUNCE_MS = 15000UL;  // sustained below thresh before locking Eco

--- a/sketches/rc_test/src/config/BuildInfo.h
+++ b/sketches/rc_test/src/config/BuildInfo.h
@@ -1,0 +1,6 @@
+// config — firmware identity (#185).
+#pragma once
+
+// Firmware version — SINGLE SOURCE OF TRUTH (#124). The debug banner prints
+// it; docs and FIRMWARE-UPLOAD-LOG reference it. Bump here, nowhere else.
+const char FIRMWARE_VERSION[] = "V7.35";

--- a/sketches/rc_test/src/config/DriveConfig.h
+++ b/sketches/rc_test/src/config/DriveConfig.h
@@ -1,0 +1,111 @@
+// config — drive/output tunables: servo authority, per-gear caps, pivot
+// blend, calibration mode (#185).
+#pragma once
+
+// Servo PWM range (matches GL10's standard 50 Hz, 1-2 ms input spec)
+const int SVC   = 1500;  // Center (neutral)
+const int SVMIN = 1000;  // Full reverse
+const int SVMAX = 2000;  // Full forward
+
+// ── Throttle output caps ──────────────────────────────────────────────────
+// All caps below are MAX TRACK-OUTPUT fractions (0..1). A straight-line track
+// output = xSpeed * gearScale, so each cap is converted to the xSpeed domain
+// via outCapToX() at point of use — one helper, no scattered conversions.
+
+// Per-gear joystick FORWARD cap (#90) — the joystick rider's max forward track
+// output per gear (RC keeps the gear's full authority). Throttle axis only;
+// steering / pivot unaffected.
+const float JOY_CAP_ECO    = 0.65f;  // Eco
+const float JOY_CAP_NORMAL = 0.75f;  // Normal
+const float JOY_CAP_BOOST  = 0.90f;  // Boost
+
+// REVERSE caps (#87/#113) — per gear, flat across BOTH inputs (RC + joystick).
+// Reverse is held below forward authority; Boost is allowed a little more reverse
+// than Eco/Normal. Applied through reverseCap() (defined with the other gear-cap
+// helpers in the sketch) so there is ONE source of truth, not a scattered
+// conditional. These are TRUE percentages only because the GL10s were
+// recalibrated to the full 1000/1500/2000 us range on 2026-07-03. Previously
+// they were calibrated while the firmware capped reverse at 65%, so they
+// mislearned 65% as 100% reverse — which made a 65%-commanded reverse drive
+// ~100%. Do NOT lower the firmware reverse cap and recalibrate at the same
+// time, or that mislearning returns.
+const float REVERSE_CAP_STD   = 0.55f;  // Eco + Normal
+const float REVERSE_CAP_BOOST = 0.65f;  // Boost
+
+// Power range — full PWM authority (1000-2000 us = ±500 us from SVC)
+const float SOFT_RANGE = 500.0f;  // Max servo offset from center (us)
+
+// ── ESC THROTTLE-CALIBRATION MODE (#113) ───────────────────────────────────
+// TEMPORARY. When true, the throttle stick passes STRAIGHT THROUGH to the full
+// ±100% PWM range (1000 / 1500 / 2000 us) on BOTH tracks — ALL caps, gear scaling
+// and steering are bypassed — so the GL10s can learn the Arduino's TRUE endpoints
+// (Option A, docs/GL10-OPERATION.md §5). Needed because the ESCs were previously
+// calibrated while the firmware capped reverse at 65%, so they mislearned 65% as
+// their 100% reverse endpoint (that is why 65%-commanded reverse drove ~100%).
+// After BOTH ESCs are recalibrated, set this back to false and reflash the normal
+// firmware (where REVERSE_CAP etc. become TRUE percentages again).
+// SAFETY: motors reach full power in this mode — tracks clear / wheels up.
+const bool CALIBRATION_MODE = false;
+
+// Gear scaling — RC CH4 selects the AVERAGE-speed cap. 3-position switch:
+//   LOW  → 65% average-speed cap  (training / tight spaces)
+//   MID  → 80% average-speed cap  (normal driving — the everyday gear)
+//   HIGH → 100% (the rail)        (full throttle authority)
+// The cap limits the AVERAGE track speed, not each wheel: in a turn the outer
+// track may use the headroom up to the ESC limit so the turn holds its speed
+// (see curvatureDrive). Boost has no headroom (already at the rail).
+// Failsafe: when S.BUS is invalid, gearScale stays at LOW for safety.
+const float GEAR_LOW_SCALE  = 0.65f;  // Eco   (+10pp 2026-06-21 for usefulness; keeps ~35% turn headroom)
+const float GEAR_MID_SCALE  = 0.80f;  // Normal (+10pp 2026-06-21 — the everyday gear; keeps ~20% turn headroom)
+const float GEAR_HIGH_SCALE = 1.00f;  // Boost  (no turn headroom — at the rail)
+
+// Eco gets extra PIVOT authority so the operator can still maneuver in tight
+// spaces (pivot input cap; forward stays at GEAR_LOW_SCALE 65%). Effective pivot
+// wheel speed = pivot cap × gear scale: 0.725 × 0.65 = 0.47 (vs 0.60 × 0.65).
+// (Reverse is capped per gear via reverseCap(): 55% Eco/Normal, 65% Boost.)
+const float PIVOT_SPEED_CAP_LOW = 0.725f;
+
+// Curvature drive — pivot/curvature blend band.
+// |xSpeed| <= START: pure pivot (counter-rotate at PIVOT_SPEED_CAP)
+// |xSpeed| >= END:   pure curvature (outer holds the average, inner slows)
+// Between: smoothstep blend so the operator doesn't feel a mode jump. The band
+// is WIDE (0.05–0.55) so the pivot↔forward/reverse hand-off is gradual — a
+// narrow band made the transition snap near 15–20% throttle (#72).
+const float PIVOT_BLEND_START = 0.05f;
+const float PIVOT_BLEND_END   = 0.55f;
+const float PIVOT_SPEED_CAP   = 0.60f;  // pivot rotation cap (~60% wheel power)
+
+// Pivot-branch throttle taper (#114). Throttle used to enter BOTH tracks of the
+// pivot branch at full gain, so 10–20% throttle while steering shifted both
+// tracks forward together — an instant surge (mirrored in reverse). Taper the
+// pivot branch's throttle term by steering: while turning, the outer track
+// keeps most of its pivot speed (it still gains (1−taper)·throttle) and the
+// inner keeps a slight counter-rotation that eases through zero as throttle
+// rises; forward speed then builds as the blend hands over to the curvature
+// branch. The taper deliberately follows the RAW steering stick, not
+// cappedRotation: past the pivot cap extra deflection adds no rotation, but it
+// still reads as "hold the pivot", so full lock holds hardest (2026-07-03,
+// field-validated — see docs/DECISION-LOG.md). 0.0 = old behavior, 1.0 =
+// throttle fully suppressed at full steer. Straight-line (z = 0), pure pivot
+// (x = 0), and at-speed turns (|xSpeed| >= PIVOT_BLEND_END → pure curvature)
+// are mathematically unchanged. Field-tune WITHIN [0, 1] — enforced below
+// because above 1.0 the term flips sign (forward stick would command reverse).
+constexpr float PIVOT_THROTTLE_TAPER = 0.70f;
+static_assert(PIVOT_THROTTLE_TAPER >= 0.0f && PIVOT_THROTTLE_TAPER <= 1.0f,
+              "PIVOT_THROTTLE_TAPER outside [0,1] inverts pivot-branch throttle");
+
+// Outer-track turn cap (#96). The #72 outer-track headroom lets the outer wheel
+// borrow up to the ESC rail to hold speed through a turn — but when the INNER
+// track is stopped (full steer) that headroom is wasted (the outer doesn't need
+// ~99% to swing the nose). curvatureDrive fades the outer-track ceiling from the
+// rail (straight, both tracks moving) down to TURN_TRACK_CAP (full steer, inner
+// stopped), driven by |zRotation| — open-loop, smooth, no hard switch.
+const float TURN_TRACK_CAP    = 0.70f;  // outer-track cap at full steer (field-tune)
+
+// RC input gains — neutral baseline (1.0 = no scaling). Stick travel
+// maps directly to curvatureDrive, which already handles inner-track
+// slowdown and pivot/curvature blend. Earlier non-unity values were
+// band-aids compensating for the flipped-ESC steering bug; with the
+// root cause fixed, the gains return to neutral.
+const float RC_THROTTLE_GAIN = 1.00f;
+const float RC_STEERING_GAIN = 1.00f;

--- a/sketches/rc_test/src/config/InputConfig.h
+++ b/sketches/rc_test/src/config/InputConfig.h
@@ -1,0 +1,50 @@
+// config — operator-input tunables: RC channel map, ADC, deadbands,
+// override thresholds, expo weights, joystick gains (#185).
+#pragma once
+
+#include <stdint.h>
+
+// S.BUS channel mapping (0-indexed). Confirmed by live capture while
+// the operator moved each control independently on the RC6GS V3:
+// trigger → ch 1, wheel → ch 0.
+const uint8_t SBUS_CH_THR   = 1;  // trigger → throttle (forward/back)
+const uint8_t SBUS_CH_STEER = 0;  // wheel   → steering (left/right)
+const uint8_t SBUS_CH_GEAR  = 3;  // CH4 = gear selector (3-pos switch)
+const uint8_t SBUS_CH_OVR   = 4;  // CH5 = override switch (3-pos switch)
+const uint8_t SBUS_CH_HORN  = 6;  // CH7 = SWD button → horn (beep at +100%)
+
+// S.BUS value range (raw 172-1811, center ~992)
+const int SBUS_MIN = 172;
+const int SBUS_MAX = 1811;
+const int HORN_ON_RAW = 1400;  // SWD raw above this = horn ON (toward +100% ~1811)
+
+// ADC
+const int ADC_CENTER = 8192;  // 14-bit midpoint
+
+// Deadbands
+const int RC_DEADBAND  = 50;   // RC mapped pulse (us)
+const int JOY_DEADBAND = 480;  // Joystick ADC (~5.9% of travel)
+
+// Override switch thresholds (mapped to PWM-equivalent)
+const int OVR_LO = 1400;  // Below → RC only
+const int OVR_HI = 1600;  // Above → 50/50 blend (RC + joystick)
+
+// Expo curve blend weights — output = LINEAR*|x| + CUBIC*|x|^3.
+// Throttle keeps the smoother (more cubic) curve so launch feel is gentle.
+// Steering uses a more linear curve so partial joystick deflection
+// produces real turn authority — operator feedback was that the joystick
+// pivot felt underpowered before reaching full lock.
+const float EXPO_THROTTLE_LINEAR = 0.4f;
+const float EXPO_THROTTLE_CUBIC  = 0.6f;
+const float EXPO_STEER_LINEAR    = 0.7f;
+const float EXPO_STEER_CUBIC     = 0.3f;
+
+// Joystick steering polarity: -1.0f to flip left/right (set after the
+// operator-side cable was rewired and right-stick produced a left turn).
+const float JOY_STEER_DIR = -1.0f;
+
+// Joystick throttle gain (#90) — the Genie stick under-ranges: full physical
+// deflection only reaches ~0.75 xSpeed, so the rider couldn't hit the per-gear
+// caps below. Lift it so full travel can reach the cap. Joystick-only; RC
+// unaffected. Tunable.
+const float JOY_THROTTLE_GAIN = 1.40f;

--- a/sketches/rc_test/src/config/Pins.h
+++ b/sketches/rc_test/src/config/Pins.h
@@ -1,0 +1,17 @@
+// config — every application-owned pin assignment in one file (#185).
+// The S.BUS pins live with infrastructure/radiolink/SbusReceiverAdapter.cpp
+// (#176) — wiring detail of that adapter; docs/WIRING-GUIDE-V8.md is the
+// canonical hardware reference.
+//
+// INCLUDE-ORDER CONTRACT: A0/A1 are the core's analog-pin macros; config/
+// may not include hardware headers, so this file must be included AFTER
+// <Arduino.h> (the sketch/composition root always does).
+#pragma once
+
+#include <stdint.h>
+
+const uint8_t PIN_JOY_Y  = A0;  // Throttle
+const uint8_t PIN_JOY_X  = A1;  // Steering
+const uint8_t PIN_ESC_L  = 9;   // Left ESC PWM (50 Hz, 1000-2000 us)
+const uint8_t PIN_ESC_R  = 10;  // Right ESC PWM
+const uint8_t PIN_BEEPER = 8;   // D8 — active piezo (digital HIGH = beep)

--- a/sketches/rc_test/src/config/SafetyConfig.h
+++ b/sketches/rc_test/src/config/SafetyConfig.h
@@ -1,0 +1,12 @@
+// config — the loop watchdog bound (#185, #69).
+#pragma once
+
+#include <stdint.h>
+
+// Safety watchdog (#69). The MCU resets if loop() fails to service the control
+// path (read inputs + write outputs) within WDT_TIMEOUT_MS — a reset stops PWM,
+// so the ESCs go to neutral/failsafe instead of holding the last throttle. This
+// bounds ANY loop stall (Wi-Fi serving or otherwise) to at most this long.
+// Starting value; tune on the bench. Must stay above the worst-case single loop
+// pass (with incremental page serving, a pass is far under this).
+const uint32_t WDT_TIMEOUT_MS        = 250;

--- a/sketches/rc_test/src/config/TelemetryConfig.h
+++ b/sketches/rc_test/src/config/TelemetryConfig.h
@@ -1,0 +1,10 @@
+// config — observer cadences (#185). The X.BUS poll constants live with
+// infrastructure/xc/XbusTelemetryAdapter.h (#178) and the Wi-Fi serving
+// tunables with infrastructure/network/WifiService.h (#181) — each single-
+// homed with its machine.
+#pragma once
+
+#include <stdint.h>
+
+// Debug
+const uint32_t PRINT_INTERVAL = 100000UL;  // 10 Hz CSV output

--- a/sketches/rc_test/src/config/ThermalConfig.h
+++ b/sketches/rc_test/src/config/ThermalConfig.h
@@ -1,0 +1,29 @@
+// config — motor/ESC over-temperature staging tunables (#185, #111).
+#pragma once
+
+#include <stdint.h>
+
+// [SAFETY] motor / ESC over-temperature protection (#111) — staged, NON-LATCHING
+// with hysteresis. Heat is the OPPOSITE of a drained LiPo: once it cools, driving
+// must resume automatically, so each stage releases on its own (lower) threshold
+// rather than latching to power-cycle like the battery ladder. Source = HOTTEST
+// of all 4 sensors (ESC + motor temp on BOTH ESCs), already EMA-smoothed
+// (TELEMETRY_EMA_ALPHA_TEMPERATURE) + a short trip debounce so a single spike / dropped frame can't
+// flip a stage. A telemetry dropout (no fresh valid reading) HOLDS the last state
+// — it never triggers a cut.
+//   Warning beep  >= 80 C  (release < 78 C) : trill, motors keep running
+//   Eco lock      >= 90 C  (release < 80 C) : force Eco gear
+//   Hard cutoff   >= 95 C  (release < 75 C) : ease PWM to neutral, keep beeping
+// NOTE: 95 C is PROVISIONAL — confirm on the bench that it sits just BELOW the
+// GL10's own internal thermal limit (param 17 = temp-controlled fan; the GL10's
+// internal throttle/cutoff number is unpublished) so our warned graceful cut
+// fires before the ESC's silent one.
+const float    TEMP_WARN_ON_C    = 80.0f;
+const float    TEMP_WARN_OFF_C   = 78.0f;
+const float    TEMP_ECO_ON_C     = 90.0f;
+const float    TEMP_ECO_OFF_C    = 80.0f;
+const float    TEMP_CUT_ON_C     = 95.0f;
+const float    TEMP_CUT_OFF_C    = 75.0f;
+const uint32_t TEMP_DEBOUNCE_MS  = 1000UL;   // sustained past a TRIP threshold before the stage flips on
+const float    TEMP_PLAUS_MIN_C  = -20.0f;   // reading below this = bad / unplugged sensor → ignore
+const float    TEMP_PLAUS_MAX_C  = 200.0f;   // reading above this = bad read → ignore

--- a/sketches/rc_test/src/config/WifiConfig.h
+++ b/sketches/rc_test/src/config/WifiConfig.h
@@ -1,0 +1,8 @@
+// config — Wi-Fi identity (#185). Monitoring only — never affects control.
+// Credentials stay in arduino_secrets.h (gitignored, #125), sketch-side;
+// the serving tunables live with infrastructure/network/WifiService.h.
+#pragma once
+
+#include <stdint.h>
+
+const uint8_t  WIFI_AP_CHANNEL       = 11;   // 2.4 GHz AP channel — off the crowded 1/6 (issue #54)


### PR DESCRIPTION
Closes #185

## Summary

Step-11 pre-slice 2 (#116 Phase D finale: alerts/ ✓ → config/ (this) → FirmwareApp). Every `[CONFIG]` constant moves VERBATIM to `src/config/` per ARCHITECTURE-TARGET §2. `[C-Builder]`

- **Ten headers, one per domain:** `BuildInfo.h` (FIRMWARE_VERSION — the #124 SSOT gate requires exactly one defining file and is home-agnostic, verified; now fires on this header), `Pins.h` (application pins with a documented include-order contract: it uses the core's `A0`/`A1` macros and must follow `<Arduino.h>`, since `config/` may not include hardware headers — the sketch always does), `InputConfig.h`, `DriveConfig.h` (incl. `CALIBRATION_MODE` with its full safety comment and the `PIVOT_THROTTLE_TAPER` static_assert), `BatteryConfig.h`, `ThermalConfig.h`, `AlertConfig.h` (patterns + tunables), `TelemetryConfig.h`, `WifiConfig.h`, `SafetyConfig.h` (watchdog).
- **Deliberately NOT moved:** the mutable state interleaved in `[CONFIG]` (gearScale/currentGear, safety latches, thermal flags — state is not configuration; lands with FirmwareApp), the `outCapToX`/`reverseCap` delegates + the Gear↔GearLevel static_assert (they read globals and domain functions), and **constant NAMES** (`SVC`, `OVR_*`, `JOY_*` stay verbatim — dozens of test files reference them as expectation inputs; naming.md prohibits mass-renaming untouched consumers, and renames belong to the #118 sweep).
- **Single-homed adapter tunables stay put** (X.BUS poll constants with `xc/` since #178; Wi-Fi serving tunables with `network/` since #181) — noted in `TelemetryConfig.h`/`WifiConfig.h`.
- The `.ino` `[CONFIG]` section is now the ten config includes + the state/delegate block with a pointer comment.
- **Docs same-PR:** CLAUDE.md (version-SSOT sentence, the "all tunables" coding rule, README-numbers rule, file map), DECISION-LOG entry, wiki `architecture-remediation` bullet.

## Behavior preservation

Zero observable change — covenant PR, and this one is **provably** so: the binary is BYTE-IDENTICAL (flash 117948 / RAM 9848, exactly the pre-extraction figures) because every move is a compile-time constant changing translation-unit position only.

## Test plan

- Host suite: **27/27 binaries green with ZERO test edits** (`wsl -e make -C tests run`) — every constant resolves through the `.ino` includes exactly as before
- `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/rc_test` — **byte-identical** (117948/9848)
- `python scripts/check_architecture.py` — OK (first `config/` files; the #124 SSOT check now detects `BuildInfo.h` as the single definition)
- cpplint pre-checked on all ten headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance and architecture documentation to identify the centralized configuration layer.
  * Documented the firmware version as the single source of truth.
  * Added a decision log entry covering the configuration reorganization and verification results.

* **Refactor**
  * Centralized firmware, input, drive, safety, telemetry, Wi‑Fi, battery, thermal, alert, and pin settings.
  * Preserved existing tuning values and runtime behavior while making configuration easier to locate and maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->