### PR TITLE
Register test-gate.sh as PreToolUse hook + CI registration check (#193)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/test-gate.sh\"",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "matcher": "",

--- a/.github/workflows/hooks-selftest.yml
+++ b/.github/workflows/hooks-selftest.yml
@@ -18,3 +18,5 @@ jobs:
           python-version: "3.12"
       - name: Self-test the documentation-sync hook (#156)
         run: python scripts/documentation_sync_hook_selftest.py
+      - name: Check hook registration + test-gate behavior (#193)
+        run: python scripts/check_hook_registration.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ sits above all four: during epic #116, organization changes NOTHING observable
      `code-quality.yml`, `structure-check.yml`, `unit-tests.yml`,
      `architecture-fitness.yml` (#129 — layer/size/naming rules on `src/`
      trees), `wiki-lint.yml` (#145 — docs/wiki graph health),
-     `hooks-selftest.yml` (#156 — documentation-sync hook health)
+     `hooks-selftest.yml` (#156/#193 — documentation-sync hook health +
+     hook registration/test-gate check)
    - no blocking calls in `loop()` (`delay()`, `pulseIn()`, unbounded `while`)
    - zero behavior change unless the task's own issue explicitly authorizes it
 

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,22 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-15 — test-gate hook wired + external-review verification (#193)
+
+- `.claude/hooks/test-gate.sh` was dead code: `.claude/settings.json` had no
+  `PreToolUse` entry, so the #47 agent-proof layer never executed (found by
+  external repo review of `main@ea085d0`; TESTING.md had documented the wiring
+  as if present). Registered as `PreToolUse[Bash]` and CI-guarded: new
+  `scripts/check_hook_registration.py` (in `hooks-selftest.yml`) fails when a
+  script in `.claude/hooks/` is unregistered, and functionally exercises the
+  gate (blocks `--no-verify`/`-n`, blocks inactive `core.hooksPath`) — 7/7.
+- Same review verified via API: `main` branch protection requires 1 approval
+  but ZERO required status checks — all 9 CI workflows advisory (→ #196;
+  already flagged 2026-07-13 as pending operator work). Wiki lint confirmed
+  structural-only (links/orphans/reachability/tunable-drift) — semantic sync
+  tracked in Phase F milestone (#199, #200, #202).
+- Review follow-ups filed as #193–#203; Phase F milestone created.
+
 ## 2026-07-13 — Rename sweep: production sketch + bench abbreviations (#118)
 
 - `sketches/rc_test/` → `sketches/dual_track_control/` — the production

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -134,18 +134,23 @@ Three layers, per issue #47:
 2. **`.claude/hooks/test-gate.sh`** — Claude Code `PreToolUse[Bash]` hook
    that makes layer 1 agent-proof: it refuses `--no-verify` outright and
    blocks commits in a clone where `core.hooksPath` was never activated.
-   Wire it in `.claude/settings.json`:
+   Wired in `.claude/settings.json` (#193):
 
    ```json
    "PreToolUse": [
      {
        "matcher": "Bash",
        "hooks": [
-         { "type": "command", "command": "bash .claude/hooks/test-gate.sh", "timeout": 30000 }
+         { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/test-gate.sh\"", "timeout": 30000 }
        ]
      }
    ]
    ```
+
+   Registration itself is CI-checked: `scripts/check_hook_registration.py`
+   (run by `hooks-selftest.yml`) fails when a script in `.claude/hooks/` is
+   not referenced by any registered hook, and functionally exercises the
+   gate (blocks `--no-verify`/`-n`, blocks inactive `core.hooksPath`).
 
 3. **CI `unit-tests` job** — the layer that cannot be bypassed; required for
    merge.

--- a/scripts/check_hook_registration.py
+++ b/scripts/check_hook_registration.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Hook-registration check (#193) — proves every script in .claude/hooks/ is
+actually wired into .claude/settings.json (a present-but-unregistered hook
+script is dead code), then functionally exercises test-gate.sh: it must block
+agent commits using --no-verify/-n, block commits in a clone where the #47
+pre-commit gate was never activated, and stay out of the way otherwise.
+Run in CI (hooks-selftest.yml) and locally:
+    python scripts/check_hook_registration.py
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SETTINGS = os.path.join(REPO_ROOT, ".claude", "settings.json")
+HOOKS_DIR = os.path.join(REPO_ROOT, ".claude", "hooks")
+TEST_GATE = os.path.join(HOOKS_DIR, "test-gate.sh")
+
+
+def registered_commands():
+    """Every command string registered under any hook event."""
+    with open(SETTINGS, encoding="utf-8") as settings_file:
+        settings = json.load(settings_file)
+    commands = []
+    for event_entries in settings.get("hooks", {}).values():
+        for entry in event_entries:
+            for hook in entry.get("hooks", []):
+                if hook.get("type") == "command":
+                    commands.append(hook.get("command", ""))
+    return commands
+
+
+def gate_exit_code(command, working_dir):
+    """Run test-gate.sh with a PreToolUse-style JSON payload on stdin."""
+    payload = json.dumps({"tool_input": {"command": command}})
+    result = subprocess.run(["sh", TEST_GATE], input=payload,
+                            capture_output=True, text=True, cwd=working_dir)
+    return result.returncode
+
+
+def main():
+    failures = []
+    checks = 0
+
+    def check(name, condition):
+        nonlocal checks
+        checks += 1
+        if not condition:
+            failures.append(name)
+
+    # 1. Registration — script present in .claude/hooks/ implies wired in
+    #    .claude/settings.json (this is the regression #193 fixed).
+    commands = registered_commands()
+    hook_scripts = [name for name in sorted(os.listdir(HOOKS_DIR))
+                    if os.path.isfile(os.path.join(HOOKS_DIR, name))]
+    check("at least one hook script exists", bool(hook_scripts))
+    for script in hook_scripts:
+        check(f"{script} is registered in .claude/settings.json",
+              any(script in command for command in commands))
+
+    # 2. Behavior — exercise the gate in a temp repo where core.hooksPath is
+    #    controlled (exit 2 = blocked, exit 0 = allowed through).
+    if shutil.which("sh") is None or shutil.which("git") is None:
+        print("check-hook-registration: sh/git unavailable — "
+              "functional checks skipped (registration checks still ran)")
+    else:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subprocess.run(["git", "init", "-q", temp_dir], check=True)
+            check("non-commit command passes through",
+                  gate_exit_code("ls -la", temp_dir) == 0)
+            check("git commit --no-verify is blocked",
+                  gate_exit_code("git commit --no-verify -m x", temp_dir) == 2)
+            check("git commit -n is blocked",
+                  gate_exit_code("git commit -n", temp_dir) == 2)
+            check("commit is blocked while core.hooksPath is not .githooks",
+                  gate_exit_code("git commit -m x", temp_dir) == 2)
+            subprocess.run(["git", "-C", temp_dir, "config",
+                            "core.hooksPath", ".githooks"], check=True)
+            check("commit passes once the #47 gate is active",
+                  gate_exit_code("git commit -m x", temp_dir) == 0)
+
+    for name in failures:
+        print(f"FAIL: {name}")
+    print(f"check-hook-registration: {checks - len(failures)}/{checks} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_hook_registration.py
+++ b/scripts/check_hook_registration.py
@@ -42,7 +42,7 @@ def gate_exit_code(command, working_dir):
     # leak into the temp-repo assertions (the gate reads effective config).
     environment["GIT_CONFIG_GLOBAL"] = os.devnull
     environment["GIT_CONFIG_SYSTEM"] = os.devnull
-    result = subprocess.run(["sh", TEST_GATE], input=payload,
+    result = subprocess.run(["bash", TEST_GATE], input=payload,
                             capture_output=True, text=True,
                             cwd=working_dir, env=environment)
     return result.returncode
@@ -66,12 +66,13 @@ def main():
     check("at least one hook script exists", bool(hook_scripts))
     for script in hook_scripts:
         check(f"{script} is registered in .claude/settings.json",
-              any(script in command for command in commands))
+              any(f".claude/hooks/{script}" in command
+                  for command in commands))
 
     # 2. Behavior — exercise the gate in a temp repo where core.hooksPath is
     #    controlled (exit 2 = blocked, exit 0 = allowed through).
-    if shutil.which("sh") is None or shutil.which("git") is None:
-        print("check-hook-registration: sh/git unavailable — "
+    if shutil.which("bash") is None or shutil.which("git") is None:
+        print("check-hook-registration: bash/git unavailable — "
               "functional checks skipped (registration checks still ran)")
     else:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/check_hook_registration.py
+++ b/scripts/check_hook_registration.py
@@ -37,8 +37,14 @@ def registered_commands():
 def gate_exit_code(command, working_dir):
     """Run test-gate.sh with a PreToolUse-style JSON payload on stdin."""
     payload = json.dumps({"tool_input": {"command": command}})
+    environment = dict(os.environ)
+    # Isolate git config: a developer's global/system core.hooksPath must not
+    # leak into the temp-repo assertions (the gate reads effective config).
+    environment["GIT_CONFIG_GLOBAL"] = os.devnull
+    environment["GIT_CONFIG_SYSTEM"] = os.devnull
     result = subprocess.run(["sh", TEST_GATE], input=payload,
-                            capture_output=True, text=True, cwd=working_dir)
+                            capture_output=True, text=True,
+                            cwd=working_dir, env=environment)
     return result.returncode
 
 


### PR DESCRIPTION
Closes #193

## Summary
The #47 agent-proof commit gate (`.claude/hooks/test-gate.sh`) existed but `.claude/settings.json` registered no `PreToolUse` hook — the script never executed (external repo review finding, 2026-07-15; TESTING.md documented the wiring as if present).

- Wire `test-gate.sh` as `PreToolUse[Bash]` in `.claude/settings.json` (exact snippet TESTING.md already specified, with `$CLAUDE_PROJECT_DIR` for robustness)
- New `scripts/check_hook_registration.py` in `hooks-selftest.yml`: fails CI when any script in `.claude/hooks/` is unregistered, and functionally exercises the gate (blocks `--no-verify`/`-n`, blocks commits where `core.hooksPath` isn't `.githooks`, passes benign commands)
- Docs synced same-PR: TESTING.md ("wire it" → "wired", registration-check note), CLAUDE.md gate list, DECISION-LOG entry

## Role
[C-Builder]

## Test plan
- `python scripts/check_hook_registration.py` → 7/7 passed locally (registration + all functional gate cases in a temp repo)
- CI `hooks-selftest.yml` runs both selftests on this PR
- No firmware files touched — zero behavior change; host suite untouched (docs/tooling-only commit path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commit safety checks now run reliably before Bash-based actions.
  * Unsafe commit bypass options are blocked, and commits require the configured hook environment.

* **Tests**
  * Automated checks now verify that safety hooks are registered and behave correctly.
  * Validation covers both blocked and permitted commit scenarios.

* **Documentation**
  * Updated workflow and decision records to document hook registration, safety coverage, and verification practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->