### PR TITLE
Fix stale pre-refactor architecture wording in agent surfaces (#194)

### DIFF
--- a/.claude/rules/firmware-realtime.md
+++ b/.claude/rules/firmware-realtime.md
@@ -12,8 +12,8 @@ paths:
 - **Float literals carry `f`** (`1.0f`, not `1.0`) — `double` is
   software-emulated on the RA4M1.
 - **All tunables live in `src/config/`** per-domain headers (#185), included
-  by `src/application/FirmwareState.h` (the former `[CONFIG]` block, #189).
-  No magic numbers at point of use. (Adapter-owned tunables stay single-homed with their machines in
+  by `src/application/FirmwareApp.h` (#189). No magic numbers at point of
+  use. (Adapter-owned tunables stay single-homed with their machines in
   `src/infrastructure/` — X.BUS poll constants, Wi-Fi serving tunables.)
 - **Per-channel failsafe**: any new input path gets an independent timeout
   that returns to neutral (SVC = 1500).

--- a/.claude/rules/firmware-realtime.md
+++ b/.claude/rules/firmware-realtime.md
@@ -11,9 +11,9 @@ paths:
   `writeMicroseconds()` outside 1000–2000 µs.
 - **Float literals carry `f`** (`1.0f`, not `1.0`) — `double` is
   software-emulated on the RA4M1.
-- **All tunables live in `src/config/`** per-domain headers (#185); the
-  `[CONFIG]` section is only their include point. No magic numbers at point
-  of use. (Adapter-owned tunables stay single-homed with their machines in
+- **All tunables live in `src/config/`** per-domain headers (#185), included
+  by `src/application/FirmwareState.h` (the former `[CONFIG]` block, #189).
+  No magic numbers at point of use. (Adapter-owned tunables stay single-homed with their machines in
   `src/infrastructure/` — X.BUS poll constants, Wi-Fi serving tunables.)
 - **Per-channel failsafe**: any new input path gets an independent timeout
   that returns to neutral (SVC = 1500).

--- a/.claude/rules/firmware-realtime.md
+++ b/.claude/rules/firmware-realtime.md
@@ -14,7 +14,7 @@ paths:
 - **All tunables live in `src/config/`** per-domain headers (#185); the
   `[CONFIG]` section is only their include point. No magic numbers at point
   of use. (Adapter-owned tunables stay single-homed with their machines in
-  `infrastructure/` — X.BUS poll constants, Wi-Fi serving tunables.)
+  `src/infrastructure/` — X.BUS poll constants, Wi-Fi serving tunables.)
 - **Per-channel failsafe**: any new input path gets an independent timeout
   that returns to neutral (SVC = 1500).
 - **Watchdog refresh stays exactly once per loop pass**, after the control

--- a/.claude/rules/firmware-realtime.md
+++ b/.claude/rules/firmware-realtime.md
@@ -14,8 +14,10 @@ paths:
 - **All tunables live in `src/config/`** per-domain headers (#185), included
   by `src/application/FirmwareApp.h` (#189) — this applies to the production
   sketch `sketches/dual_track_control/`; single-file bench/test sketches keep
-  their few constants local and named. No magic numbers at point of use. (Adapter-owned tunables stay single-homed with their machines in
-  `src/infrastructure/` — X.BUS poll constants, Wi-Fi serving tunables.)
+  their few constants local and named. No magic numbers at point of use.
+  (Adapter-owned tunables stay single-homed with their machines — X.BUS poll
+  constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in
+  `src/infrastructure/network/`.)
 - **Per-channel failsafe**: any new input path gets an independent timeout
   that returns to neutral (SVC = 1500).
 - **Watchdog refresh stays exactly once per loop pass**, after the control

--- a/.claude/rules/firmware-realtime.md
+++ b/.claude/rules/firmware-realtime.md
@@ -12,8 +12,9 @@ paths:
 - **Float literals carry `f`** (`1.0f`, not `1.0`) — `double` is
   software-emulated on the RA4M1.
 - **All tunables live in `src/config/`** per-domain headers (#185), included
-  by `src/application/FirmwareApp.h` (#189). No magic numbers at point of
-  use. (Adapter-owned tunables stay single-homed with their machines in
+  by `src/application/FirmwareApp.h` (#189) — this applies to the production
+  sketch `sketches/dual_track_control/`; single-file bench/test sketches keep
+  their few constants local and named. No magic numbers at point of use. (Adapter-owned tunables stay single-homed with their machines in
   `src/infrastructure/` — X.BUS poll constants, Wi-Fi serving tunables.)
 - **Per-channel failsafe**: any new input path gets an independent timeout
   that returns to neutral (SVC = 1500).

--- a/.claude/rules/firmware-realtime.md
+++ b/.claude/rules/firmware-realtime.md
@@ -11,8 +11,10 @@ paths:
   `writeMicroseconds()` outside 1000–2000 µs.
 - **Float literals carry `f`** (`1.0f`, not `1.0`) — `double` is
   software-emulated on the RA4M1.
-- **All tunables live in config** (today `[CONFIG]`, target `src/config/`).
-  No magic numbers at point of use.
+- **All tunables live in `src/config/`** per-domain headers (#185); the
+  `[CONFIG]` section is only their include point. No magic numbers at point
+  of use. (Adapter-owned tunables stay single-homed with their machines in
+  `infrastructure/` — X.BUS poll constants, Wi-Fi serving tunables.)
 - **Per-channel failsafe**: any new input path gets an independent timeout
   that returns to neutral (SVC = 1500).
 - **Watchdog refresh stays exactly once per loop pass**, after the control

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,13 +47,13 @@ Safety-critical: code errors can cause a 50lb machine with a child riding it to 
 - **Missing constrain() on servo output**: Every value written to `writeMicroseconds()` MUST be constrained to 1000-2000.
 - **Integer overflow**: Watch for arithmetic that could overflow 32-bit `int` (e.g. multiplying two large values like `micros()` differences, sensor readings). Flag multiplication without explicit casts. Extra care if code is ever ported to 8/16-bit AVR platforms.
 - **Float without f suffix**: Flag `1.0` (promotes to `double`). The Cortex-M4 FPU handles single-precision `float` in hardware, but `double` has no hardware support on the RA4M1 — double-precision operations fall back to software emulation and are significantly slower. Always use `1.0f` to keep arithmetic in the hardware FPU.
-- **Magic numbers**: Flag raw numeric constants outside `src/config/` per-domain headers (or the owning adapter for single-homed infrastructure tunables — X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`). All tunables must be named constants.
+- **Magic numbers**: In the production sketch (`sketches/dual_track_control/`), flag raw numeric constants outside `src/config/` per-domain headers (or the owning adapter for single-homed infrastructure tunables — X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`). All tunables must be named constants; single-file bench/test sketches keep theirs local.
 - **Missing failsafe**: Any new RC input path must have a timeout/failsafe that returns to neutral (SVC = 1500) when signal is lost.
 - **Global state mutation**: Flag functions that modify global state without clear documentation. Prefer passing state explicitly.
 
 ## Code Quality Checks (Flag as suggestions)
 - **Cyclomatic complexity**: Flag functions with more than 3 levels of nesting or more than 10 branches.
-- **Single Responsibility**: One file = one concept (150-line soft / 250-line hard limit, `.claude/rules/architecture.md`); layers under `src/` respect the dependency direction (`.ino` → `application/` only; `application/` → `domain/` + `ports/` + `telemetry/` + `alerts/` + `config/`; `infrastructure/` implements `ports/` — full table in `.claude/rules/architecture.md`). Flag functions that mix input reading with output writing.
+- **Single Responsibility**: One file = one concept (150-line soft / 250-line hard limit, `.claude/rules/architecture.md`). In the production sketch (`sketches/dual_track_control/` — bench/test sketches are single-file tools), layers under `src/` respect the dependency direction (`.ino` → `application/` only; `application/` → `domain/` + `ports/` + `telemetry/` + `alerts/` + `config/`; `infrastructure/` implements `ports/` — full table in `.claude/rules/architecture.md`). Flag functions that mix input reading with output writing.
 - **Inefficient patterns**: Flag nested loops, repeated calculations that could be cached, or string operations in the hot loop.
 - **Consistent naming**: Constants = UPPER_SNAKE_CASE, structs = PascalCase, functions = camelCase, pins = PIN_NAME.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,13 +47,13 @@ Safety-critical: code errors can cause a 50lb machine with a child riding it to 
 - **Missing constrain() on servo output**: Every value written to `writeMicroseconds()` MUST be constrained to 1000-2000.
 - **Integer overflow**: Watch for arithmetic that could overflow 32-bit `int` (e.g. multiplying two large values like `micros()` differences, sensor readings). Flag multiplication without explicit casts. Extra care if code is ever ported to 8/16-bit AVR platforms.
 - **Float without f suffix**: Flag `1.0` (promotes to `double`). The Cortex-M4 FPU handles single-precision `float` in hardware, but `double` has no hardware support on the RA4M1 — double-precision operations fall back to software emulation and are significantly slower. Always use `1.0f` to keep arithmetic in the hardware FPU.
-- **Magic numbers**: Flag raw numeric constants outside the [CONFIG] section. All tunables must be named constants.
+- **Magic numbers**: Flag raw numeric constants outside `src/config/` per-domain headers (or the owning adapter for single-homed infrastructure tunables — X.BUS poll constants in `infrastructure/xc/`, Wi-Fi serving tunables in `infrastructure/network/`). All tunables must be named constants.
 - **Missing failsafe**: Any new RC input path must have a timeout/failsafe that returns to neutral (SVC = 1500) when signal is lost.
 - **Global state mutation**: Flag functions that modify global state without clear documentation. Prefer passing state explicitly.
 
 ## Code Quality Checks (Flag as suggestions)
 - **Cyclomatic complexity**: Flag functions with more than 3 levels of nesting or more than 10 branches.
-- **Single Responsibility**: Each [MODULE] section should do one thing. Flag functions that mix input reading with output writing.
+- **Single Responsibility**: One file = one concept (150-line soft / 250-line hard limit, `.claude/rules/architecture.md`); layers under `src/` respect the dependency direction (`.ino` → `application/` → `domain/`+`ports/`; `infrastructure/` implements `ports/`). Flag functions that mix input reading with output writing.
 - **Inefficient patterns**: Flag nested loops, repeated calculations that could be cached, or string operations in the hot loop.
 - **Consistent naming**: Constants = UPPER_SNAKE_CASE, structs = PascalCase, functions = camelCase, pins = PIN_NAME.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,7 +53,7 @@ Safety-critical: code errors can cause a 50lb machine with a child riding it to 
 
 ## Code Quality Checks (Flag as suggestions)
 - **Cyclomatic complexity**: Flag functions with more than 3 levels of nesting or more than 10 branches.
-- **Single Responsibility**: One file = one concept (150-line soft / 250-line hard limit, `.claude/rules/architecture.md`); layers under `src/` respect the dependency direction (`.ino` → `application/` → `domain/`+`ports/`; `infrastructure/` implements `ports/`). Flag functions that mix input reading with output writing.
+- **Single Responsibility**: One file = one concept (150-line soft / 250-line hard limit, `.claude/rules/architecture.md`); layers under `src/` respect the dependency direction (`.ino` → `application/` only; `application/` → `domain/` + `ports/` + `telemetry/` + `alerts/` + `config/`; `infrastructure/` implements `ports/` — full table in `.claude/rules/architecture.md`). Flag functions that mix input reading with output writing.
 - **Inefficient patterns**: Flag nested loops, repeated calculations that could be cached, or string operations in the hot loop.
 - **Consistent naming**: Constants = UPPER_SNAKE_CASE, structs = PascalCase, functions = camelCase, pins = PIN_NAME.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,7 +47,7 @@ Safety-critical: code errors can cause a 50lb machine with a child riding it to 
 - **Missing constrain() on servo output**: Every value written to `writeMicroseconds()` MUST be constrained to 1000-2000.
 - **Integer overflow**: Watch for arithmetic that could overflow 32-bit `int` (e.g. multiplying two large values like `micros()` differences, sensor readings). Flag multiplication without explicit casts. Extra care if code is ever ported to 8/16-bit AVR platforms.
 - **Float without f suffix**: Flag `1.0` (promotes to `double`). The Cortex-M4 FPU handles single-precision `float` in hardware, but `double` has no hardware support on the RA4M1 — double-precision operations fall back to software emulation and are significantly slower. Always use `1.0f` to keep arithmetic in the hardware FPU.
-- **Magic numbers**: Flag raw numeric constants outside `src/config/` per-domain headers (or the owning adapter for single-homed infrastructure tunables — X.BUS poll constants in `infrastructure/xc/`, Wi-Fi serving tunables in `infrastructure/network/`). All tunables must be named constants.
+- **Magic numbers**: Flag raw numeric constants outside `src/config/` per-domain headers (or the owning adapter for single-homed infrastructure tunables — X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`). All tunables must be named constants.
 - **Missing failsafe**: Any new RC input path must have a timeout/failsafe that returns to neutral (SVC = 1500) when signal is lost.
 - **Global state mutation**: Flag functions that modify global state without clear documentation. Prefer passing state explicitly.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,7 +357,7 @@ monitor.py                               — Simple serial monitor
 
 - The `.ino` is a composition root ONLY (#189): it includes `src/application/FirmwareApp.h` and delegates `setup()`/`loop()`. Firmware code lives under `src/` in layers — `application/` → `domain/` + `ports/` + `telemetry/` + `alerts/` + `config/`; `infrastructure/` implements `ports/` (dependency rules: `.claude/rules/architecture.md`). The former `[MODULE]` banners moved into `src/application/` files — search `[NAME]` still jumps there
 - Structs shared with the `.ino` go in `types.h` (solves the Arduino auto-prototype limitation); domain-owned types live with their domain (e.g. `DriveTypes.h`, `SafetyTypes.h`)
-- All tunable constants live in `src/config/` per-domain headers (#185; the `[CONFIG]` section is now their include point) — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `infrastructure/xc/`, Wi-Fi serving tunables in `infrastructure/network/`)
+- All tunable constants live in `src/config/` per-domain headers (#185; the `[CONFIG]` section is now their include point) — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`)
 - File policy: one file = one concept, 150-line soft / 250-line hard limit (`.claude/rules/architecture.md`) — split by responsibility, never into `Part2`-style fragments
 
 ### Testing (#47 — details in docs/TESTING.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,7 +359,7 @@ These bullets describe the production sketch `sketches/dual_track_control/`;
 bench/test sketches under `sketches/` are deliberately single-file tools.
 
 - The `.ino` is a composition root ONLY (#189): it includes `src/application/FirmwareApp.h` and delegates `setup()`/`loop()`. Firmware code lives under `src/` in layers — `application/` → `domain/` + `ports/` + `telemetry/` + `alerts/` + `config/`; `infrastructure/` implements `ports/` (dependency rules: `.claude/rules/architecture.md`). The former `[MODULE]` banners moved into `src/application/` files — search `[NAME]` still jumps there
-- Structs shared with the `.ino` go in `types.h` (solves the Arduino auto-prototype limitation); domain-owned types live with their domain (e.g. `DriveTypes.h`, `SafetyTypes.h`)
+- Shared structs sit in `types.h` — the interim shared-types bridge, slated to dissolve (it also sidesteps the Arduino auto-prototype limitation); domain-owned types live with their domain (e.g. `DriveTypes.h`, `SafetyTypes.h`)
 - All tunable constants live in `src/config/` per-domain headers (#185), included by `src/application/FirmwareApp.h`; the firmware's mutable cross-module state lives in `src/application/FirmwareState.h` (#189) — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`)
 - File policy: one file = one concept, 150-line soft / 250-line hard limit (`.claude/rules/architecture.md`) — split by responsibility, never into `Part2`-style fragments
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,10 +355,10 @@ monitor.py                               — Simple serial monitor
 
 ### Architecture
 
-- All code in `dual_track_control.ino` is organized in `[MODULE]` sections — search `[NAME]` to jump
-- Structs go in `types.h` (solves Arduino auto-prototype limitation)
+- The `.ino` is a composition root ONLY (#189): it includes `src/application/FirmwareApp.h` and delegates `setup()`/`loop()`. Firmware code lives under `src/` in layers — `application/` → `domain/` + `ports/` + `telemetry/` + `alerts/` + `config/`; `infrastructure/` implements `ports/` (dependency rules: `.claude/rules/architecture.md`). The former `[MODULE]` banners moved into `src/application/` files — search `[NAME]` still jumps there
+- Structs shared with the `.ino` go in `types.h` (solves the Arduino auto-prototype limitation); domain-owned types live with their domain (e.g. `DriveTypes.h`, `SafetyTypes.h`)
 - All tunable constants live in `src/config/` per-domain headers (#185; the `[CONFIG]` section is now their include point) — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `infrastructure/xc/`, Wi-Fi serving tunables in `infrastructure/network/`)
-- When the sketch exceeds ~500 lines, split into `.h/.cpp` pairs (not multiple `.ino` files)
+- File policy: one file = one concept, 150-line soft / 250-line hard limit (`.claude/rules/architecture.md`) — split by responsibility, never into `Part2`-style fragments
 
 ### Testing (#47 — details in docs/TESTING.md)
 
@@ -389,7 +389,7 @@ monitor.py                               — Simple serial monitor
 
 - Use `float` with `f` suffix for FPU (`1.0f` not `1.0`) — `double` is software-emulated
 - Use `constrain()` at all servo output boundaries
-- Comment each `[MODULE]` section header with a brief description
+- Comment each `[MODULE]` section banner (now living in `src/application/` files) with a brief description
 - Commit messages: `V{major}.{minor}: {imperative verb} {what changed}`
 - **README describes behavior, never tunable numbers** (#124): current values
   live in `src/config/`. PROJECT-PLAN and OPERATOR-GUIDE are technical

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,7 +357,7 @@ monitor.py                               — Simple serial monitor
 
 - The `.ino` is a composition root ONLY (#189): it includes `src/application/FirmwareApp.h` and delegates `setup()`/`loop()`. Firmware code lives under `src/` in layers — `application/` → `domain/` + `ports/` + `telemetry/` + `alerts/` + `config/`; `infrastructure/` implements `ports/` (dependency rules: `.claude/rules/architecture.md`). The former `[MODULE]` banners moved into `src/application/` files — search `[NAME]` still jumps there
 - Structs shared with the `.ino` go in `types.h` (solves the Arduino auto-prototype limitation); domain-owned types live with their domain (e.g. `DriveTypes.h`, `SafetyTypes.h`)
-- All tunable constants live in `src/config/` per-domain headers (#185; the `[CONFIG]` section is now their include point) — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`)
+- All tunable constants live in `src/config/` per-domain headers (#185), included by `src/application/FirmwareState.h` — the former `[CONFIG]` block, moved there in #189 — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`)
 - File policy: one file = one concept, 150-line soft / 250-line hard limit (`.claude/rules/architecture.md`) — split by responsibility, never into `Part2`-style fragments
 
 ### Testing (#47 — details in docs/TESTING.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,6 +355,9 @@ monitor.py                               — Simple serial monitor
 
 ### Architecture
 
+These bullets describe the production sketch `sketches/dual_track_control/`;
+bench/test sketches under `sketches/` are deliberately single-file tools.
+
 - The `.ino` is a composition root ONLY (#189): it includes `src/application/FirmwareApp.h` and delegates `setup()`/`loop()`. Firmware code lives under `src/` in layers — `application/` → `domain/` + `ports/` + `telemetry/` + `alerts/` + `config/`; `infrastructure/` implements `ports/` (dependency rules: `.claude/rules/architecture.md`). The former `[MODULE]` banners moved into `src/application/` files — search `[NAME]` still jumps there
 - Structs shared with the `.ino` go in `types.h` (solves the Arduino auto-prototype limitation); domain-owned types live with their domain (e.g. `DriveTypes.h`, `SafetyTypes.h`)
 - All tunable constants live in `src/config/` per-domain headers (#185), included by `src/application/FirmwareApp.h` (#189; the former `[CONFIG]` block's mutable state lives in `src/application/FirmwareState.h`) — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`)
@@ -389,7 +392,7 @@ monitor.py                               — Simple serial monitor
 
 - Use `float` with `f` suffix for FPU (`1.0f` not `1.0`) — `double` is software-emulated
 - Use `constrain()` at all servo output boundaries
-- Comment each `[MODULE]` section banner (now living in `src/application/` files) with a brief description
+- Comment each `[MODULE]` section banner (a `dual_track_control` convention; the banners live in its `src/application/` files) with a brief description
 - Commit messages: `V{major}.{minor}: {imperative verb} {what changed}`
 - **README describes behavior, never tunable numbers** (#124): current values
   live in `src/config/`. PROJECT-PLAN and OPERATOR-GUIDE are technical

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,7 +357,7 @@ monitor.py                               — Simple serial monitor
 
 - The `.ino` is a composition root ONLY (#189): it includes `src/application/FirmwareApp.h` and delegates `setup()`/`loop()`. Firmware code lives under `src/` in layers — `application/` → `domain/` + `ports/` + `telemetry/` + `alerts/` + `config/`; `infrastructure/` implements `ports/` (dependency rules: `.claude/rules/architecture.md`). The former `[MODULE]` banners moved into `src/application/` files — search `[NAME]` still jumps there
 - Structs shared with the `.ino` go in `types.h` (solves the Arduino auto-prototype limitation); domain-owned types live with their domain (e.g. `DriveTypes.h`, `SafetyTypes.h`)
-- All tunable constants live in `src/config/` per-domain headers (#185), included by `src/application/FirmwareState.h` — the former `[CONFIG]` block, moved there in #189 — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`)
+- All tunable constants live in `src/config/` per-domain headers (#185), included by `src/application/FirmwareApp.h` (#189; the former `[CONFIG]` block's mutable state lives in `FirmwareState.h`) — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`)
 - File policy: one file = one concept, 150-line soft / 250-line hard limit (`.claude/rules/architecture.md`) — split by responsibility, never into `Part2`-style fragments
 
 ### Testing (#47 — details in docs/TESTING.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,7 +357,7 @@ monitor.py                               — Simple serial monitor
 
 - The `.ino` is a composition root ONLY (#189): it includes `src/application/FirmwareApp.h` and delegates `setup()`/`loop()`. Firmware code lives under `src/` in layers — `application/` → `domain/` + `ports/` + `telemetry/` + `alerts/` + `config/`; `infrastructure/` implements `ports/` (dependency rules: `.claude/rules/architecture.md`). The former `[MODULE]` banners moved into `src/application/` files — search `[NAME]` still jumps there
 - Structs shared with the `.ino` go in `types.h` (solves the Arduino auto-prototype limitation); domain-owned types live with their domain (e.g. `DriveTypes.h`, `SafetyTypes.h`)
-- All tunable constants live in `src/config/` per-domain headers (#185), included by `src/application/FirmwareApp.h` (#189; the former `[CONFIG]` block's mutable state lives in `FirmwareState.h`) — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`)
+- All tunable constants live in `src/config/` per-domain headers (#185), included by `src/application/FirmwareApp.h` (#189; the former `[CONFIG]` block's mutable state lives in `src/application/FirmwareState.h`) — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`)
 - File policy: one file = one concept, 150-line soft / 250-line hard limit (`.claude/rules/architecture.md`) — split by responsibility, never into `Part2`-style fragments
 
 ### Testing (#47 — details in docs/TESTING.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,7 +360,7 @@ bench/test sketches under `sketches/` are deliberately single-file tools.
 
 - The `.ino` is a composition root ONLY (#189): it includes `src/application/FirmwareApp.h` and delegates `setup()`/`loop()`. Firmware code lives under `src/` in layers — `application/` → `domain/` + `ports/` + `telemetry/` + `alerts/` + `config/`; `infrastructure/` implements `ports/` (dependency rules: `.claude/rules/architecture.md`). The former `[MODULE]` banners moved into `src/application/` files — search `[NAME]` still jumps there
 - Structs shared with the `.ino` go in `types.h` (solves the Arduino auto-prototype limitation); domain-owned types live with their domain (e.g. `DriveTypes.h`, `SafetyTypes.h`)
-- All tunable constants live in `src/config/` per-domain headers (#185), included by `src/application/FirmwareApp.h` (#189; the former `[CONFIG]` block's mutable state lives in `src/application/FirmwareState.h`) — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`)
+- All tunable constants live in `src/config/` per-domain headers (#185), included by `src/application/FirmwareApp.h`; the firmware's mutable cross-module state lives in `src/application/FirmwareState.h` (#189) — no magic numbers in code. Exception: adapter-owned tunables are single-homed with their machines (X.BUS poll constants in `src/infrastructure/xc/`, Wi-Fi serving tunables in `src/infrastructure/network/`)
 - File policy: one file = one concept, 150-line soft / 250-line hard limit (`.claude/rules/architecture.md`) — split by responsibility, never into `Part2`-style fragments
 
 ### Testing (#47 — details in docs/TESTING.md)
@@ -392,7 +392,7 @@ bench/test sketches under `sketches/` are deliberately single-file tools.
 
 - Use `float` with `f` suffix for FPU (`1.0f` not `1.0`) — `double` is software-emulated
 - Use `constrain()` at all servo output boundaries
-- Comment each `[MODULE]` section banner (a `dual_track_control` convention; the banners live in its `src/application/` files) with a brief description
+- Comment each module section banner — the bracketed `[NAME]` markers that moved into `dual_track_control`'s `src/application/` files (#189) — with a brief description
 - Commit messages: `V{major}.{minor}: {imperative verb} {what changed}`
 - **README describes behavior, never tunable numbers** (#124): current values
   live in `src/config/`. PROJECT-PLAN and OPERATOR-GUIDE are technical


### PR DESCRIPTION
Closes #194

## Summary
Three agent-instruction surfaces still described the pre-Phase-D architecture (external repo review finding, 2026-07-15; all three verified):
- **CLAUDE.md** coding rules: "all code in `[MODULE]` sections of the .ino", "split when the sketch exceeds ~500 lines" → now describe the composition-root architecture (#189), the `src/` layer map, the 150/250 file policy, and the types.h bridge vs domain-owned types
- **.claude/rules/firmware-realtime.md**: "today `[CONFIG]`, target `src/config/`" → `src/config/` IS the present (#185), with the single-homed adapter-tunable exceptions spelled out
- **.github/copilot-instructions.md**: magic-number check now points at `src/config/` + owning adapters; single-responsibility check now states the file policy and layer dependency direction instead of "[MODULE] sections"

Contradictory instructions get applied arbitrarily by agents, and the review bot was judging new-architecture PRs against the retired structure — this makes all surfaces agree with the code.

## Role
[A-Content]

## Test plan
- Docs/instructions only — zero firmware files touched, zero behavior change
- Grepped the three files for MODULE/CONFIG bracket references: every remaining one is historical ("former sections now live in…") or the accurate include-point wording
- Wiki checked (`agent-governance.md`, `architecture-remediation.md`) — already accurate, no drift
- CI: markdownlint + full suite on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified firmware architecture and real-time development guidelines.
  * Documented where tunable settings and shared types should be maintained.
  * Added guidance for production, bench, and test sketches.
  * Expanded code-quality recommendations covering magic numbers, failsafes, global state, file size, dependency direction, and function responsibilities.
  * Updated module documentation and section-banner conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->