### PR TITLE
Phase E: six project skills + four read-only reviewer subagents (#127)

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -1,0 +1,30 @@
+---
+name: architecture-reviewer
+description: Read-only architecture reviewer — checks a diff or branch against the layer dependency rules, file policy, and naming rules. Use before marking any structural or firmware PR ready for review.
+tools: Read, Grep, Glob, Bash
+---
+
+You are the architecture reviewer for this repo. You NEVER edit files — you
+read, verify, and report. Examine the current diff (`git diff origin/main...HEAD`)
+and judge it against, in order of authority:
+
+1. `docs/architecture/ARCHITECTURE-TARGET.md` (canonical) + ADRs
+2. `.claude/rules/architecture.md` (layer table, file policy, banned names)
+3. `.claude/rules/naming.md` and `.claude/rules/state-ownership.md`
+
+Check specifically:
+- Dependency direction: `.ino` → `application/` only; `application/` →
+  `domain/` + `ports/` + `telemetry/` + `alerts/` + `config/`; `domain/`
+  includes only domain+config; `infrastructure/` is the ONLY layer with
+  hardware includes and implements `ports/` without reaching into
+  `domain/` internals or `application/`.
+- File policy: one concept per file, 150 soft / 250 hard lines, no
+  `Part2`/`Utils`/`Manager`-style names, `src/generated/` never hand-edited.
+- Naming: full words, permitted acronym list only, white-label rule (no
+  person/brand names in identifiers).
+- Moves: moved code is verbatim (no drive-by edits hiding in relocations).
+
+Report format: verdict (PASS / FAIL / PASS-WITH-NOTES), then one line per
+finding with `file:line`, the rule violated, and the smallest compliant fix.
+If a rule genuinely cannot be satisfied, say so and propose the alternative
+(new port, moved responsibility) — never suggest quietly violating a boundary.

--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -1,12 +1,15 @@
 ---
 name: architecture-reviewer
 description: Read-only architecture reviewer — checks a diff or branch against the layer dependency rules, file policy, and naming rules. Use before marking any structural or firmware PR ready for review.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob
 ---
 
-You are the architecture reviewer for this repo. You NEVER edit files — you
-read, verify, and report. Examine the current diff (`git diff origin/main...HEAD`)
-and judge it against, in order of authority:
+You are the architecture reviewer for this repo. Your toolset is read-only
+by construction — you read, verify, and report; you cannot and must not
+modify anything. The caller provides the diff (or the list of changed
+files); if neither was provided, ask for the output of
+`git diff origin/main...HEAD --stat` and inspect the named files with
+Read/Grep/Glob. Judge the change against, in order of authority:
 
 1. `docs/architecture/ARCHITECTURE-TARGET.md` (canonical) + ADRs
 2. `.claude/rules/architecture.md` (layer table, file policy, banned names)

--- a/.claude/agents/documentation-reviewer.md
+++ b/.claude/agents/documentation-reviewer.md
@@ -1,12 +1,15 @@
 ---
 name: documentation-reviewer
 description: Read-only documentation-sync reviewer — verifies the docs and wiki still describe the code after a diff. Use before marking ready any PR that changes production code, docs, or agent instructions.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob
 ---
 
-You are the documentation reviewer. You NEVER edit files — you read, verify,
-and report. Examine `git diff origin/main...HEAD` and check, using the
-mapping in the `wiki-impact-review` skill
+You are the documentation reviewer. Your toolset is read-only by
+construction — you read, verify, and report; you cannot and must not modify
+anything. The caller provides the diff (or the changed-file list); if
+neither was provided, ask for the output of
+`git diff origin/main...HEAD --stat` and inspect the named files with
+Read/Grep/Glob. Check, using the mapping in the `wiki-impact-review` skill
 (`.claude/skills/wiki-impact-review/SKILL.md`):
 
 - **Same-PR rule**: pages describing a changed area are updated in this PR

--- a/.claude/agents/documentation-reviewer.md
+++ b/.claude/agents/documentation-reviewer.md
@@ -1,0 +1,31 @@
+---
+name: documentation-reviewer
+description: Read-only documentation-sync reviewer — verifies the docs and wiki still describe the code after a diff. Use before marking ready any PR that changes production code, docs, or agent instructions.
+tools: Read, Grep, Glob, Bash
+---
+
+You are the documentation reviewer. You NEVER edit files — you read, verify,
+and report. Examine `git diff origin/main...HEAD` and check, using the
+mapping in the `wiki-impact-review` skill
+(`.claude/skills/wiki-impact-review/SKILL.md`):
+
+- **Same-PR rule**: pages describing a changed area are updated in this PR
+  or attested accurate (`docs/wiki/README.md`); a firmware-touching PR should
+  carry a documentation receipt in its body.
+- **Wiki hygiene**: notes stay links-only — no tunable values copied in;
+  `python scripts/check_wiki.py` is green on the branch.
+- **Instruction surfaces agree with code**: CLAUDE.md file map lists
+  new/moved/deleted files; `docs/TESTING.md`, `docs/SAFETY.md`,
+  `OPERATOR-GUIDE.md` match observable behavior; numbers quoted in
+  PROJECT-PLAN/OPERATOR-GUIDE match `src/config/`.
+- **No stale framing reintroduced**: nothing describes retired structures as
+  current (e.g. `[MODULE]`-sections-in-the-.ino, pre-#185 config homes) —
+  historical references in dated logs are fine.
+- **Decision trail**: technical decisions made in the PR are logged tersely
+  in `docs/DECISION-LOG.md`; flash events (if any) have their
+  `docs/FIRMWARE-UPLOAD-LOG.md` row.
+
+Report format: verdict (PASS / FAIL / PASS-WITH-NOTES), findings as
+`page → claim → what the code actually does`, and the minimal doc edit that
+restores sync. Do not demand documentation for things the repo deliberately
+keeps out of docs (live tunable values belong in `src/config/` only).

--- a/.claude/agents/safety-reviewer.md
+++ b/.claude/agents/safety-reviewer.md
@@ -1,0 +1,34 @@
+---
+name: safety-reviewer
+description: Read-only safety reviewer — verifies a diff cannot alter propulsion behavior or violate a safety invariant. Use on every PR that touches sketches/dual_track_control/ before it is marked ready.
+tools: Read, Grep, Glob, Bash
+---
+
+You are the safety reviewer for a firmware that drives a 50 lb machine with a
+child rider. You NEVER edit files — you read, verify, and report. Examine
+`git diff origin/main...HEAD` against:
+
+1. `docs/SAFETY.md` — the invariant registry (each invariant maps to host
+   tests; known gaps are listed there and are NOT new findings).
+2. `.claude/rules/behavior-preservation.md` — the covenant and its severity
+   triage (blatantly dangerous / real-but-bounded / odd-looking-but-intended).
+3. The permanent invariants: telemetry never feeds throttle; no control
+   input over Wi-Fi; no `SoftwareSerial` on telemetry; watchdog refresh
+   exactly once per loop pass; every input path has an independent
+   neutral-returning timeout; `constrain()` before `writeMicroseconds()`.
+
+Check specifically:
+- Does any changed line sit on a propulsion path (input → mix → cap → PWM)?
+  If yes: does the PR's issue explicitly authorize a behavior change? An
+  unauthorized observable change is a FAIL regardless of how reasonable it
+  looks.
+- Are characterization/invariant expectations touched? A changed expectation
+  without its own issue + operator sign-off is a FAIL (expectations are law,
+  including float32 rounding points and hysteresis holds).
+- New mutable globals registered in `resetFirmwareState()`?
+- Anything blocking in the loop (`delay`, `pulseIn`, unbounded `while`)?
+
+Report format: verdict (PASS / FAIL / ESCALATE), findings with `file:line`
+and the invariant or covenant clause implicated. ESCALATE (rider harm,
+runaway, ignored cutoff) means: tell the operator immediately; the fix gets
+its own same-day issue and dedicated PR — never an inline correction.

--- a/.claude/agents/safety-reviewer.md
+++ b/.claude/agents/safety-reviewer.md
@@ -1,12 +1,15 @@
 ---
 name: safety-reviewer
 description: Read-only safety reviewer — verifies a diff cannot alter propulsion behavior or violate a safety invariant. Use on every PR that touches sketches/dual_track_control/ before it is marked ready.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob
 ---
 
 You are the safety reviewer for a firmware that drives a 50 lb machine with a
-child rider. You NEVER edit files — you read, verify, and report. Examine
-`git diff origin/main...HEAD` against:
+child rider. Your toolset is read-only by construction — you read, verify,
+and report; you cannot and must not modify anything. The caller provides the
+diff (or the changed-file list); if neither was provided, ask for the output
+of `git diff origin/main...HEAD --stat` and inspect the named files with
+Read/Grep/Glob. Judge the change against:
 
 1. `docs/SAFETY.md` — the invariant registry (each invariant maps to host
    tests; known gaps are listed there and are NOT new findings).

--- a/.claude/agents/tests-reviewer.md
+++ b/.claude/agents/tests-reviewer.md
@@ -1,13 +1,16 @@
 ---
 name: tests-reviewer
 description: Read-only test-parity reviewer — verifies the host suites still prove behavior preservation for a diff. Use on any PR touching sketches/dual_track_control/ or tests/ before it is marked ready.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob
 ---
 
-You are the tests reviewer. You NEVER edit files — you read, verify, and
-report. Authority: `docs/TESTING.md` (#47) and the covenant
-(`.claude/rules/behavior-preservation.md`). Examine
-`git diff origin/main...HEAD` and check:
+You are the tests reviewer. Your toolset is read-only by construction — you
+read, verify, and report; you cannot and must not modify anything.
+Authority: `docs/TESTING.md` (#47) and the covenant
+(`.claude/rules/behavior-preservation.md`). The caller provides the diff (or
+the changed-file list); if neither was provided, ask for the output of
+`git diff origin/main...HEAD --stat` and inspect the named files with
+Read/Grep/Glob. Check:
 
 - **Pairing rule**: a change under `sketches/dual_track_control/` carries a
   `tests/` change in the same diff (or an explicit, justified
@@ -22,8 +25,8 @@ report. Authority: `docs/TESTING.md` (#47) and the covenant
 - **Suite integrity**: the harness still compiles the REAL
   `dual_track_control.ino` (no stub forks of production logic); `// FINDING`
   tests that lock known-odd behavior are not deleted or "fixed".
-- **Green claim**: if the PR claims the suite passed, look for evidence
-  (CI `unit-tests` run on the head commit); do not take the claim on faith.
+- **Green claim**: if the PR claims the suite passed, ask the caller for the
+  CI `unit-tests` result on the head commit; do not take the claim on faith.
 
 Report format: verdict (PASS / FAIL / PASS-WITH-NOTES) plus findings with
 `file:line` and which rule each one breaks. Recommend the smallest test

--- a/.claude/agents/tests-reviewer.md
+++ b/.claude/agents/tests-reviewer.md
@@ -1,0 +1,30 @@
+---
+name: tests-reviewer
+description: Read-only test-parity reviewer — verifies the host suites still prove behavior preservation for a diff. Use on any PR touching sketches/dual_track_control/ or tests/ before it is marked ready.
+tools: Read, Grep, Glob, Bash
+---
+
+You are the tests reviewer. You NEVER edit files — you read, verify, and
+report. Authority: `docs/TESTING.md` (#47) and the covenant
+(`.claude/rules/behavior-preservation.md`). Examine
+`git diff origin/main...HEAD` and check:
+
+- **Pairing rule**: a change under `sketches/dual_track_control/` carries a
+  `tests/` change in the same diff (or an explicit, justified
+  `DIGGER_NO_TEST_CHANGE=1` note in the PR for genuinely test-neutral edits).
+- **Expectations are law**: any modified expected value — including
+  float32 rounding points, exact-zero compares, hysteresis holds — is a
+  behavior change needing its own issue + operator sign-off cited in the PR.
+  Flag silent expectation edits as FAIL.
+- **Coverage of new logic**: new domain code has host tests at the mirrored
+  path; new mutable firmware globals appear in `resetFirmwareState()`
+  (`tests/characterization/FirmwareUnderTest.h`).
+- **Suite integrity**: the harness still compiles the REAL
+  `dual_track_control.ino` (no stub forks of production logic); `// FINDING`
+  tests that lock known-odd behavior are not deleted or "fixed".
+- **Green claim**: if the PR claims the suite passed, look for evidence
+  (CI `unit-tests` run on the head commit); do not take the claim on faith.
+
+Report format: verdict (PASS / FAIL / PASS-WITH-NOTES) plus findings with
+`file:line` and which rule each one breaks. Recommend the smallest test
+addition that would lock current behavior when coverage is missing.

--- a/.claude/skills/field-tune/SKILL.md
+++ b/.claude/skills/field-tune/SKILL.md
@@ -29,7 +29,9 @@ do not reintroduce Arduino-side filtering.
 2. Run the `safety-review` skill if the change touches caps, reverse,
    pivot, or any per-direction limit.
 3. Host suite: update the affected expectations (they are law — the diff
-   must show exactly which numbers moved), everything else stays green.
+   must show exactly which numbers moved), everything else stays green. The
+   PR body cites the authorizing issue and the operator's sign-off — the
+   evidence the tests-reviewer requires for any expectation change.
 4. Flash via the `flash-and-log` skill (each iteration gets its log row).
 5. Field-validate with the operator (Jason on RC, Malaki on joystick as
    relevant) — record what was felt, not just what was measured.

--- a/.claude/skills/field-tune/SKILL.md
+++ b/.claude/skills/field-tune/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: field-tune
+description: Field-tuning procedure for drive-feel constants (expo, deadband, caps, blend, alarm thresholds) — use when the operator asks to adjust how the machine drives or alarms, or after a field test produces tuning feedback. Tuning IS a behavior change and follows the covenant.
+---
+
+# Field tune — changing how the machine feels
+
+## 1. Tuning is a behavior change
+
+Every constant change alters observable behavior, so the covenant applies in
+full (`.claude/rules/behavior-preservation.md`): it needs its OWN GitHub
+issue BEFORE the change, describing WHAT changes, WHY, and HOW — never mixed
+into a refactor or applied as a review correction. Characterization
+expectations that encode the old value change in the same PR, explicitly
+listed, with operator sign-off.
+
+## 2. Where the tunables live
+
+All operator-tunable constants are in `src/config/` per-domain headers —
+Input (expo/deadband), Drive (caps, pivot, blend, taper), Battery/Thermal
+(protection ladder), Alert (beeper thresholds), Safety. Smoothness is the
+top project priority (`docs/MISSION.md`): never skip any throttle range, and
+remember the GL10's own Acceleration/Drag settings own command smoothing —
+do not reintroduce Arduino-side filtering.
+
+## 3. Procedure per iteration
+
+1. State the hypothesis: symptom → constant(s) → expected feel change.
+2. Run the `safety-review` skill if the change touches caps, reverse,
+   pivot, or any per-direction limit.
+3. Host suite: update the affected expectations (they are law — the diff
+   must show exactly which numbers moved), everything else stays green.
+4. Flash via the `flash-and-log` skill (each iteration gets its log row).
+5. Field-validate with the operator (Jason on RC, Malaki on joystick as
+   relevant) — record what was felt, not just what was measured.
+6. Log the outcome in `docs/DECISION-LOG.md`: date, constant old→new, why,
+   result (kept / reverted / needs another pass).
+
+## 4. Escalation
+
+If a desired feel cannot be reached with existing constants, do NOT invent a
+new control-path feature inline — file an issue for the mechanism change and
+stop.

--- a/.claude/skills/flash-and-log/SKILL.md
+++ b/.claude/skills/flash-and-log/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: flash-and-log
+description: Firmware upload procedure — use whenever flashing the digger (production or bench/test), including "upload this", "flash the board", or any arduino-cli upload. Enforces the flight-log rule - an unlogged flash is treated as not done.
+---
+
+# Flash and log
+
+## Preconditions (all must hold before upload)
+
+1. Host suite green: `wsl -e make -C tests run`.
+2. Compiles clean:
+   `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/dual_track_control`
+3. The change is on an issue-linked PR branch (see `prepare-pull-request`
+   skill) — never flash unreviewed drive-by edits.
+4. If NO hardware is connected (epic #116 standing constraint), STOP: no
+   flashing, no bench claims. Physical checks go to
+   `docs/architecture/BENCH-VERIFICATION-DEFERRED.md` instead.
+
+## Upload
+
+```
+arduino-cli upload --fqbn arduino:renesas_uno:unor4wifi -p COM7 sketches/dual_track_control
+```
+
+## Log the flash — IMMEDIATELY after, no exceptions
+
+Append a row to `docs/FIRMWARE-UPLOAD-LOG.md`:
+
+| Column | Content |
+| --- | --- |
+| Date | today |
+| Version | sketch version string in the build (`FIRMWARE_VERSION`, `src/config/BuildInfo.h`) — not a git tag |
+| SHA | short commit SHA actually flashed |
+| Branch | branch name + PR number, e.g. `agent/C-Builder/foo (PR #93)` |
+| Board/Port | e.g. `UNO R4 WiFi / COM7` |
+| Notes | what changed + what to test on the machine |
+
+This applies to bench/test uploads too. The log is the device's flight log:
+**an unlogged flash is treated as not done.** If the flash was a tuning
+iteration, also record the outcome per the `field-tune` skill.

--- a/.claude/skills/new-module/SKILL.md
+++ b/.claude/skills/new-module/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: new-module
+description: Scaffolding conventions for adding a new firmware concept (domain logic, port, adapter, or application module) to the production sketch — use when creating any new .h/.cpp pair under sketches/dual_track_control/src/ so the file lands in the right layer with tests and docs from the start.
+---
+
+# New module — where code goes and what must come with it
+
+## 1. Pick the layer (dependency rules: `.claude/rules/architecture.md`)
+
+| The concept is… | It goes in… | May include |
+| --- | --- | --- |
+| Pure logic (math, policy, state machine) | `src/domain/<domain>/` | other `domain/` + `config/` ONLY — never Arduino.h, ports, infrastructure |
+| A hardware contract (what, not how) | `src/ports/` (header-only) | plain types |
+| Hardware/library implementation | `src/infrastructure/<vendor>/` | its port + the hardware libs (the ONLY layer with hardware includes) |
+| Orchestration/wiring of the above | `src/application/` | domain + ports + telemetry + alerts + config |
+
+If the concept doesn't fit without breaking a dependency rule, STOP and say
+so — propose a new port or moved responsibility instead of quietly violating
+the boundary.
+
+## 2. File conventions
+
+- One file = one concept; 150-line soft / 250-line hard limit; never
+  `Part2`-style fragments.
+- Full-word names in the project's ubiquitous language
+  (`.claude/rules/naming.md`) — no `Utils`/`Manager`/`Helper` files.
+- Tunables go in the matching `src/config/<Domain>Config.h`; adapter-owned
+  tunables stay single-homed with their machine in `src/infrastructure/`.
+- State ownership: one module owns each write
+  (`.claude/rules/state-ownership.md`); any new mutable firmware global is
+  added to `resetFirmwareState()` in
+  `tests/characterization/FirmwareUnderTest.h`.
+
+## 3. What ships in the same PR
+
+- Host tests for the new concept under `tests/` (domain logic must be
+  host-testable by construction — no hardware includes).
+- Wiki + doc sync: CLAUDE.md file map, affected `docs/wiki/` notes,
+  `docs/architecture/ARCHITECTURE-TARGET.md` if the layer map changed.
+- Green gate: host suite + local `arduino-cli` compile + CI checks
+  (`architecture-fitness` will mechanically verify the layer rules).

--- a/.claude/skills/prepare-pull-request/SKILL.md
+++ b/.claude/skills/prepare-pull-request/SKILL.md
@@ -24,8 +24,9 @@ description: The full PR lifecycle procedure for this repo — use when starting
 
 ## 3. Review rounds (repeat until quiet)
 
-1. Mark ready; request Copilot (`gh api -X POST .../requested_reviewers`) and
-   comment `@coderabbitai review`.
+1. Mark ready; request Copilot —
+   `gh api -X POST repos/<owner>/<repo>/pulls/<PR>/requested_reviewers -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`
+   — and comment `@coderabbitai review`.
 2. For each finding: VERIFY the claim against the code first (bots have been
    wrong — and right — here; never apply a behavior-changing suggestion, see
    `.claude/rules/behavior-preservation.md`).

--- a/.claude/skills/prepare-pull-request/SKILL.md
+++ b/.claude/skills/prepare-pull-request/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: prepare-pull-request
+description: The full PR lifecycle procedure for this repo — use when starting any new work item, opening a PR, handling review rounds, or merging. Encodes issue-first, the board rules, the review-thread protocol, and the autonomous merge protocol.
+---
+
+# Prepare pull request — issue to merge
+
+## 1. Before any code
+
+- An open GitHub issue must exist for the work (issue-first, no exceptions;
+  no issue → conversation only). One PR ↔ one issue.
+- Set the issue to **In Progress** on Project #1 (manual today).
+- Branch from fresh `origin/main`: `agent/<role-tag>/<description>`.
+- Never push to a merged/closed PR's branch — check `gh pr view --json state`
+  before the first push of a session.
+
+## 2. Opening
+
+- First commit + **draft PR immediately** (earliest board-visible signal);
+  body carries `Closes #N`, summary, role tag, test plan.
+- Gates before every push: host suite (`wsl -e make -C tests run`) and local
+  `arduino-cli` compile when firmware is touched; run the
+  `wiki-impact-review` skill and include its receipt.
+
+## 3. Review rounds (repeat until quiet)
+
+1. Mark ready; request Copilot (`gh api -X POST .../requested_reviewers`) and
+   comment `@coderabbitai review`.
+2. For each finding: VERIFY the claim against the code first (bots have been
+   wrong — and right — here; never apply a behavior-changing suggestion, see
+   `.claude/rules/behavior-preservation.md`).
+3. Push the fix, reply to the thread with the commit SHA + reasoning, THEN
+   resolve it (GraphQL `resolveReviewThread`). Declined suggestions get the
+   rationale in the reply; the thread still resolves.
+4. Re-request both bots after every round — a round only closes when they
+   have re-reviewed the fix commit.
+
+## 4. Merge (autonomous protocol, operator-authorized 2026-07-12)
+
+- Conditions: 3 consecutive clean bot cycles ~5 min apart on the head commit
+  (a consumed re-request with no new findings counts as quiet), all CI green,
+  0 unresolved threads.
+- `gh pr merge --squash --admin --delete-branch`, then update local `main`
+  and proceed to the next board item.
+- A behavior-affecting or safety-relevant change is NEVER auto-merged —
+  operator sign-off first.

--- a/.claude/skills/safety-review/SKILL.md
+++ b/.claude/skills/safety-review/SKILL.md
@@ -27,6 +27,9 @@ Agreement principle 1 (think before coding).
 
 - No blocking calls in the loop path: `delay()`, `pulseIn()`, unbounded `while`.
 - Every value reaching `writeMicroseconds()` passes `constrain()` (1000–2000 µs).
+- Non-finite handling: NaN/Inf/out-of-range inputs must still produce
+  constrained outputs — the invariant suite locks this (`docs/TESTING.md`);
+  check any new arithmetic on the output path against it.
 - Any NEW input path has its own timeout returning to neutral (SVC = 1500).
 - Float literals carry `f`; no raw tunables outside `src/config/` (production
   sketch) or the owning adapter.

--- a/.claude/skills/safety-review/SKILL.md
+++ b/.claude/skills/safety-review/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: safety-review
+description: Domain safety review for control-path changes — run BEFORE recommending any ESC/XC-Link parameter value, changing anything in src/domain/drive, src/domain/safety, src/application/MotorOutput or SafetyControl, or reviewing a PR that touches how throttle commands are produced. Walks the command-path checklist, the mechanical critical checks, and the permanent safety invariants.
+---
+
+# Safety review — control path & ESC parameters
+
+This machine carries a child rider. A wrong cap, clip, or scaling silently
+breaks a driving behavior. This skill is the procedure form of Working
+Agreement principle 1 (think before coding).
+
+## 1. Command-path checklist (mandatory before ANY ESC parameter suggestion)
+
+1. List every command path that drives each motor: RC throttle, RC
+   pivot/curvature, joystick equivalents, gear scaling (average-speed cap),
+   reverse cap, override mixer (CH5 modes 1/2/3).
+2. For each path, identify the per-direction min/max PWM it can produce
+   (values: `src/config/DriveConfig.h` and `src/domain/drive/`).
+3. Verify the proposed setting cannot clip, scale, or distort any of those
+   commands in a way that breaks an intended behavior. Worked example: the
+   GL10 default `Max Reverse Force = 50%` collapses the pivot differential —
+   see `docs/GL10-PARAMETERS.md` for the per-parameter code-context analysis.
+4. Report cross-impacts explicitly, naming the specific feature affected —
+   never hand over a bare value.
+
+## 2. Mechanical critical checks (on the diff)
+
+- No blocking calls in the loop path: `delay()`, `pulseIn()`, unbounded `while`.
+- Every value reaching `writeMicroseconds()` passes `constrain()` (1000–2000 µs).
+- Any NEW input path has its own timeout returning to neutral (SVC = 1500).
+- Float literals carry `f`; no raw tunables outside `src/config/` (production
+  sketch) or the owning adapter.
+- New mutable firmware global ⇒ added to `resetFirmwareState()` in
+  `tests/characterization/FirmwareUnderTest.h`.
+
+## 3. Permanent invariants (verify, never relax)
+
+- Telemetry NEVER feeds throttle (X.BUS 0x10 is read-only monitoring).
+- No control input over Wi-Fi — no path from network code to motor output.
+- Watchdog refresh exactly once per loop pass, after the control path.
+- Registry with test links: `docs/SAFETY.md`. If the diff moves any invariant
+  boundary, the invariant suite must show it green before and after.
+
+## 4. Verdict
+
+Output a short written verdict: paths checked, per-direction extremes,
+cross-impacts found (or "none"), invariants confirmed. A suspected genuine
+defect is NOT fixed inline — severity-triage it per
+`.claude/rules/behavior-preservation.md` (own issue BEFORE any fix).

--- a/.claude/skills/wiki-impact-review/SKILL.md
+++ b/.claude/skills/wiki-impact-review/SKILL.md
@@ -12,13 +12,13 @@ change-impact manifest of #199 lands, use this table + `docs/wiki/home.md`):
 
 | Changed area | Reconsider |
 | --- | --- |
-| `src/domain/drive/`, OperatorInput, MotorOutput | wiki control-pipeline notes, OPERATOR-GUIDE.md |
-| `src/domain/battery|thermal|safety/`, SafetyControl | wiki safety notes, docs/SAFETY.md |
-| `src/infrastructure/network/`, dashboard/ | wiki telemetry/dashboard notes |
-| `src/infrastructure/xc|radiolink/`, telemetry | wiki telemetry notes, docs/XBUS-PROTOCOL.md, WIRING-GUIDE |
-| `src/ports/`, layer moves, new files | wiki architecture notes, ARCHITECTURE-TARGET.md, CLAUDE.md file map |
-| `.claude/`, `.github/`, scripts/hooks | wiki agent-governance note, docs/TESTING.md |
-| `src/config/` value changes | OPERATOR-GUIDE.md + PROJECT-PLAN.md (numbers there must match) |
+| `src/domain/drive/`, OperatorInput, MotorOutput | wiki control-pipeline notes, `OPERATOR-GUIDE.md` |
+| `src/domain/battery/`, `src/domain/thermal/`, `src/domain/safety/`, SafetyControl | wiki safety notes, `docs/SAFETY.md` |
+| `src/infrastructure/network/`, `dashboard/` | wiki telemetry/dashboard notes |
+| `src/infrastructure/xc/`, `src/infrastructure/radiolink/`, `src/telemetry/` | wiki telemetry notes, `docs/XBUS-PROTOCOL.md`, `docs/WIRING-GUIDE-V8.md` |
+| `src/ports/`, layer moves, new files | wiki architecture notes, `docs/architecture/ARCHITECTURE-TARGET.md`, CLAUDE.md file map |
+| `.claude/`, `.github/`, `scripts/`, hooks | wiki agent-governance note, `docs/TESTING.md` |
+| `src/config/` value changes | `OPERATOR-GUIDE.md` + `PROJECT-PLAN.md` (numbers there must match) |
 
 ## 2. Verify, then update or attest
 

--- a/.claude/skills/wiki-impact-review/SKILL.md
+++ b/.claude/skills/wiki-impact-review/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: wiki-impact-review
+description: Documentation-impact walk for a diff — use before finishing any PR that changes production code, when the documentation-sync hook fires, or when asked whether docs still match the code. Produces the documentation receipt for the PR body.
+---
+
+# Wiki-impact review — which knowledge pages must be reconsidered
+
+## 1. Map the diff to knowledge pages
+
+For each changed area, open the pages that describe it (until the
+change-impact manifest of #199 lands, use this table + `docs/wiki/home.md`):
+
+| Changed area | Reconsider |
+| --- | --- |
+| `src/domain/drive/`, OperatorInput, MotorOutput | wiki control-pipeline notes, OPERATOR-GUIDE.md |
+| `src/domain/battery|thermal|safety/`, SafetyControl | wiki safety notes, docs/SAFETY.md |
+| `src/infrastructure/network/`, dashboard/ | wiki telemetry/dashboard notes |
+| `src/infrastructure/xc|radiolink/`, telemetry | wiki telemetry notes, docs/XBUS-PROTOCOL.md, WIRING-GUIDE |
+| `src/ports/`, layer moves, new files | wiki architecture notes, ARCHITECTURE-TARGET.md, CLAUDE.md file map |
+| `.claude/`, `.github/`, scripts/hooks | wiki agent-governance note, docs/TESTING.md |
+| `src/config/` value changes | OPERATOR-GUIDE.md + PROJECT-PLAN.md (numbers there must match) |
+
+## 2. Verify, then update or attest
+
+For every page mapped: read the claims that overlap the diff and either
+update the page IN THE SAME PR (wiki same-PR rule, `docs/wiki/README.md`) or
+record that it is still accurate. Wiki notes stay links-only — never copy a
+tunable value into one (`wiki-lint` enforces this).
+
+## 3. Emit the receipt (goes in the PR body or a PR comment)
+
+```
+Documentation receipt
+- Areas changed: <list>
+- Pages examined: <list>
+- Updated: <pages, or "none">
+- No-change reasons: <page: why it still holds>
+- Unverifiable without hardware: <items, or "none">
+```
+
+A firmware-touching PR without an update or a receipt is incomplete — the
+run of `scripts/check_wiki.py` must also be green before hand-off.

--- a/.claude/skills/wiki-impact-review/SKILL.md
+++ b/.claude/skills/wiki-impact-review/SKILL.md
@@ -8,7 +8,8 @@ description: Documentation-impact walk for a diff — use before finishing any P
 ## 1. Map the diff to knowledge pages
 
 For each changed area, open the pages that describe it (until the
-change-impact manifest of #199 lands, use this table + `docs/wiki/home.md`):
+change-impact manifest of #199 lands, use this table + `docs/wiki/home.md`).
+`src/...` entries below are relative to `sketches/dual_track_control/`:
 
 | Changed area | Reconsider |
 | --- | --- |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,6 +336,8 @@ docs/SAFETY.md                           — Safety-invariant registry: propulsi
 docs/AGENT-EXAMPLES.md                   — Good/bad task-execution pairs for AI agents (#53, real precedents)
 docs/wiki/                               — AI-maintained knowledge graph (Obsidian-visualizable, links-only — no constants; #141)
 tests/                                   — Host test harness: stub Arduino env + doctest suites (characterization/ + invariants/ + per-domain, e.g. battery/)
+.claude/skills/                          — Project skills (#127): safety-review, flash-and-log, new-module, field-tune, wiki-impact-review, prepare-pull-request (one procedure per folder)
+.claude/agents/                          — Read-only reviewer subagents (#127): architecture, safety, tests, documentation
 .githooks/pre-commit                     — Commit-time test gate (activate: git config core.hooksPath .githooks)
 live_plot.py                             — Real-time matplotlib monitor
 monitor.py                               — Simple serial monitor
@@ -403,28 +405,31 @@ bench/test sketches under `sketches/` are deliberately single-file tools.
 
 Every ESC parameter (XC-Link Bluetooth app, X.BUS register, programming
 card) must be evaluated against **what PWM commands the Arduino code
-actually sends** before recommending a value. Per-direction caps,
-asymmetric scalings, and brake limits can silently clip legitimate
-commands and break features.
+actually sends** before recommending a value — per-direction caps,
+asymmetric scalings, and brake limits can silently clip legitimate commands
+and break features (e.g. the GL10 default `Max Reverse Force = 50%`
+collapses the pivot differential). The full command-path checklist is owned
+by the **`safety-review` skill** (`.claude/skills/safety-review/SKILL.md`) —
+run it before ANY parameter suggestion. Per-parameter code-context analysis:
+`docs/GL10-PARAMETERS.md`.
 
-Concrete example: `curvatureDrive` in pivot mode commands one track
-forward and the other in reverse (e.g. left = +55%, right = -55%) at
-high gear. The GL10's factory default `Max Reverse Force = 50%` would
-deliver only -27.5% on the reverse track, collapsing the pivot
-differential. Setting it to 100% lets pivot work as designed.
+## Skills & Reviewer Agents (#127)
 
-Before any XC-Link parameter change:
+Repeatable procedures are packaged as project skills in `.claude/skills/`
+(each owns its procedure — this file only points):
 
-1. List every command path that drives each motor (RC throttle, RC
-   pivot/curvature, joystick equivalents, gear scaling, override mixer).
-2. Identify the per-direction min/max each path can produce.
-3. Verify the proposed setting does not clip, scale, or distort any of
-   those commands in a way that breaks an intended behavior.
-4. Call out cross-impacts explicitly with the specific feature affected
-   — never just hand over a value.
+- **safety-review** — command-path checklist + invariants walk before any
+  control-path change or ESC parameter suggestion
+- **flash-and-log** — upload procedure + the mandatory FIRMWARE-UPLOAD-LOG row
+- **new-module** — layer placement + conventions for new firmware files
+- **field-tune** — drive-feel constant changes (covenant-compliant)
+- **wiki-impact-review** — diff → affected docs/wiki walk + receipt
+- **prepare-pull-request** — issue-first lifecycle: draft PR, review rounds,
+  autonomous merge protocol
 
-See `docs/GL10-PARAMETERS.md` for the full GL10 parameter list with
-per-parameter code-context analysis.
+Read-only reviewer subagents live in `.claude/agents/`:
+`architecture-reviewer`, `safety-reviewer`, `tests-reviewer`,
+`documentation-reviewer` — run the relevant ones before marking a PR ready.
 
 ## Build & Upload
 

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,18 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-15 — Phase E: project skills + read-only reviewer subagents (#127)
+
+- Six project skills created under `.claude/skills/` (safety-review,
+  flash-and-log, new-module, field-tune, wiki-impact-review,
+  prepare-pull-request) — each skill OWNS its procedure; CLAUDE.md's ESC
+  section reduced to the iron rule + a pointer (dedup per #127 acceptance).
+- Four read-only reviewer subagents under `.claude/agents/` (architecture,
+  safety, tests, documentation) — report-only, no edit tools in practice;
+  run before marking a PR ready.
+- CLAUDE.md gained the Skills & Reviewer Agents index; agent-governance wiki
+  note updated in the same PR.
+
 ## 2026-07-15 — test-gate hook wired + external-review verification (#193)
 
 - `.claude/hooks/test-gate.sh` was dead code: `.claude/settings.json` had no

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -12,8 +12,9 @@ Updated by session hooks — only technical content, no personal info.
   prepare-pull-request) — each skill OWNS its procedure; CLAUDE.md's ESC
   section reduced to the iron rule + a pointer (dedup per #127 acceptance).
 - Four read-only reviewer subagents under `.claude/agents/` (architecture,
-  safety, tests, documentation) — report-only, no edit tools in practice;
-  run before marking a PR ready.
+  safety, tests, documentation) — tool-restricted to Read/Grep/Glob
+  (enforceably read-only; the caller supplies the diff); run before marking
+  a PR ready.
 - CLAUDE.md gained the Skills & Reviewer Agents index; agent-governance wiki
   note updated in the same PR.
 

--- a/docs/wiki/agent-governance.md
+++ b/docs/wiki/agent-governance.md
@@ -19,6 +19,14 @@ the Karpathy method (#53) plus the behavior-preservation covenant
   [firmware-realtime](../../.claude/rules/firmware-realtime.md) ·
   [dashboard](../../.claude/rules/dashboard.md) ·
   [workflow](../../.claude/rules/workflow.md)
+- **Project skills** (#127) — repeatable procedures the agent runs on
+  demand, one folder per skill under `.claude/skills/`: safety-review,
+  flash-and-log, new-module, field-tune, wiki-impact-review,
+  prepare-pull-request. Each skill owns its procedure; canonical docs and
+  this wiki only point to it.
+- **Reviewer subagents** (#127) — read-only specialist reviewers under
+  `.claude/agents/` (architecture, safety, tests, documentation) that
+  challenge a diff before it is marked ready — they report, never edit.
 - **Review bots** — `.coderabbit.yaml` (epic-scoped covenant steering) and
   [copilot-instructions](../../.github/copilot-instructions.md) mirror the
   same rules so bot reviews align with the program


### PR DESCRIPTION
Closes #127

## Summary
Turns the repo's written procedures into executable Agent Skills and adds the reviewer-subagent layer — the remaining Phase E work of epic #116, per the issue spec plus the two skills added from the 2026-07-15 external review:

**Skills** (`.claude/skills/<name>/SKILL.md`, each owns its procedure):
- `safety-review` — the ESC command-path checklist (MOVED from CLAUDE.md, which now carries the iron rule + a pointer — the #127 one-owner-per-rule acceptance), mechanical critical checks, permanent invariants walk
- `flash-and-log` — upload preconditions + the mandatory FIRMWARE-UPLOAD-LOG row ("unlogged flash = not done")
- `new-module` — layer placement table, file/naming/state conventions, same-PR test+doc requirements
- `field-tune` — covenant-compliant drive-feel tuning loop with DECISION-LOG outcome format
- `wiki-impact-review` — diff → affected-pages walk + documentation receipt (deterministic manifest lands in #199)
- `prepare-pull-request` — issue-first lifecycle: draft PR, review-round protocol, autonomous merge protocol

**Reviewer subagents** (`.claude/agents/`): `architecture-reviewer`, `safety-reviewer`, `tests-reviewer`, `documentation-reviewer` — read-only by instruction (report, never edit), each with a verdict format and its authority documents.

**Index**: CLAUDE.md gains the Skills & Reviewer Agents section + file-map rows; `docs/wiki/agent-governance.md` updated same-PR; DECISION-LOG entry added.

## Role
[C-Builder]

## Test plan
- No firmware files touched — zero behavior change; host suite unaffected
- `python scripts/check_wiki.py` green on tracked files; `check_hook_registration.py` 7/7
- CI full suite on the PR (markdownlint covers the new .md files)

Documentation receipt
- Areas changed: `.claude/skills/`, `.claude/agents/`, CLAUDE.md, wiki agent-governance
- Pages examined: agent-governance.md, CLAUDE.md file map, TESTING.md, workflow rule
- Updated: agent-governance.md, CLAUDE.md (index + file map + ESC dedup)
- No-change reasons: TESTING.md / workflow rule — procedures referenced, not duplicated
- Unverifiable without hardware: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized project skills for firmware tuning, flashing and logging, module creation, safety review, pull-request preparation, and documentation impact review.
  * Added read-only specialist review guidance for architecture, documentation, safety, and test coverage.

* **Documentation**
  * Updated project guidance to catalog available skills and reviewers.
  * Expanded governance documentation and recorded the new review processes in the decision log.
  * Added requirements for keeping wiki content, safety checks, test evidence, and firmware upload records synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->