### PR TITLE
Encode amended review/merge protocol in the PR skill (#211)

### DIFF
--- a/.claude/skills/prepare-pull-request/SKILL.md
+++ b/.claude/skills/prepare-pull-request/SKILL.md
@@ -22,26 +22,37 @@ description: The full PR lifecycle procedure for this repo — use when starting
   `arduino-cli` compile when firmware is touched; run the
   `wiki-impact-review` skill and include its receipt.
 
-## 3. Review rounds (repeat until quiet)
+## 3. Self-review FIRST, then review rounds
 
-1. Mark ready; request Copilot —
+1. **Before the first bot request**: run the applicable reviewer agents
+   (`.claude/agents/` — architecture, safety, tests, documentation) on the
+   diff, plus a **stale-reference sweep**: grep for every name, count,
+   path, and claim the diff makes stale elsewhere (docstrings, docs,
+   cross-references) and fix what surfaces. Self-review must match or
+   exceed the bots. Never write derived values (counts, line numbers) in
+   prose — the artifact is the inventory.
+2. Mark ready; request Copilot —
    `gh api -X POST repos/<owner>/<repo>/pulls/<PR>/requested_reviewers -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`
-   — and comment `@coderabbitai review`.
-2. For each finding: VERIFY the claim against the code first (bots have been
-   wrong — and right — here; never apply a behavior-changing suggestion, see
-   `.claude/rules/behavior-preservation.md`).
-3. Push the fix, reply to the thread with the commit SHA + reasoning, THEN
+   — and comment `@coderabbitai review`. Once per fix commit, never on
+   unchanged code.
+3. For each finding: VERIFY the claim against the code first (probe and
+   refute with evidence when wrong; never apply a behavior-changing
+   suggestion, see `.claude/rules/behavior-preservation.md`).
+   **Scope guard (operator 2026-07-19):** a suggestion that EXPANDS the
+   change's scope beyond its issue is declined into a follow-up issue by
+   default — one intent per PR extends to review rounds.
+4. Push the fix, reply to the thread with the commit SHA + reasoning, THEN
    resolve it (GraphQL `resolveReviewThread`). Declined suggestions get the
    rationale in the reply; the thread still resolves.
-4. Re-request both bots after every round — a round only closes when they
-   have re-reviewed the fix commit.
 
-## 4. Merge (autonomous protocol, operator-authorized 2026-07-12)
+## 4. Merge (autonomous protocol, operator-amended 2026-07-19)
 
-- Conditions: 3 consecutive clean bot cycles ~5 min apart on the head commit
-  (a consumed re-request with no new findings counts as quiet), all CI green,
-  0 unresolved threads.
+- Conditions: **ONE clean bot cycle on the final commit** (a consumed
+  re-request with no findings counts as quiet), all CI green,
+  0 unresolved threads. Do not re-invite reviews of unchanged code.
 - `gh pr merge --squash --admin --delete-branch`, then update local `main`
   and proceed to the next board item.
+- No hard round cap, but a repeating finding pattern gets root-caused
+  (retrospective + operator decision), never re-fixed round after round.
 - A behavior-affecting or safety-relevant change is NEVER auto-merged —
   operator sign-off first.

--- a/.claude/skills/prepare-pull-request/SKILL.md
+++ b/.claude/skills/prepare-pull-request/SKILL.md
@@ -48,9 +48,10 @@ description: The full PR lifecycle procedure for this repo — use when starting
 
 ## 4. Merge (autonomous protocol, operator-amended 2026-07-19)
 
-- Conditions: **ONE clean bot cycle on the final commit** (a consumed
-  re-request with no findings counts as quiet), all CI green,
-  0 unresolved threads. Do not re-invite reviews of unchanged code.
+- Conditions: **ONE clean bot cycle on the final commit** — the single
+  request from step 2 returns no new findings (a silently consumed request
+  counts) — plus all CI green and 0 unresolved threads. Do not re-invite
+  reviews of unchanged code.
 - `gh pr merge --squash --admin --delete-branch`, then update local `main`
   and proceed to the next board item.
 - No hard round cap, but a repeating finding pattern gets root-caused

--- a/.claude/skills/prepare-pull-request/SKILL.md
+++ b/.claude/skills/prepare-pull-request/SKILL.md
@@ -33,8 +33,9 @@ description: The full PR lifecycle procedure for this repo — use when starting
    prose — the artifact is the inventory.
 2. Mark ready; request Copilot —
    `gh api -X POST repos/<owner>/<repo>/pulls/<PR>/requested_reviewers -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`
-   — and comment `@coderabbitai review`. Once per fix commit, never on
-   unchanged code.
+   — and comment `@coderabbitai review`. After every fix commit, repeat
+   from step 1 (self-review the fix, then one request); never re-request
+   on unchanged code.
 3. For each finding: VERIFY the claim against the code first (probe and
    refute with evidence when wrong; never apply a behavior-changing
    suggestion, see `.claude/rules/behavior-preservation.md`).

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,22 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-19 — review/merge protocol amended after 52-round retrospective (#211)
+
+- Operator decisions after PR #210 reached 34 review rounds: (1) self-review
+  BEFORE bots — applicable `.claude/agents/` reviewers + a stale-reference
+  sweep (names/counts/paths/claims the diff invalidates elsewhere);
+  (2) merge = ONE clean bot cycle on the final commit + CI green + 0
+  unresolved threads — never re-invite reviews of unchanged code (the old
+  3-cycle rule re-triggered nondeterministic re-reviews and generated
+  rounds); (3) scope guard — reviewer suggestions expanding a change's
+  scope beyond its issue are declined into follow-up issues by default;
+  (4) no derived values (counts/line numbers) in prose; (5) no hard round
+  cap, but repeating finding patterns get root-caused.
+- Retrospective attribution across 5 PRs / ~52 rounds: ~50% missing
+  up-front spec/threat model (#210 parser), ~25% re-request ritual on
+  unchanged code, ~20% derived-value + cross-reference staleness.
+
 ## 2026-07-19 — test-gate rewritten with real command parsing (#206)
 
 - `.claude/hooks/test-gate.sh` (shell globs over the whole JSON payload) →


### PR DESCRIPTION
Closes #211

## Summary
Operator decisions (2026-07-19, after the 52-round retrospective) encoded in `prepare-pull-request`:
- **Self-review first**: applicable `.claude/agents/` reviewers + a stale-reference sweep before any bot request; no derived values in prose
- **Merge = ONE clean bot cycle** on the final commit + CI green + 0 threads; never re-invite reviews of unchanged code
- **Scope guard**: suggestions expanding a change's scope beyond its issue decline into follow-up issues by default
- No hard round cap; repeating finding patterns get root-caused

DECISION-LOG entry records the decisions + round attribution. Memory already amended.

## Role
[A-Content]

## Test plan
- Docs-only; zero firmware change
- Self-review sweep run on this diff: no other live surface states the old 3-cycle protocol (dated DECISION-LOG history excluded by design); wiki agent-governance links-only, unaffected

Documentation receipt
- Areas changed: prepare-pull-request skill, DECISION-LOG
- Pages examined: agent-governance wiki note (links only — accurate), other skills (no protocol references)
- Unverifiable without hardware: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)