### PR TITLE
Authority matrix: one page states which artifact wins (#198)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,8 @@ lineage): `docs/DECISION-LOG.md`.
 ## Coding Rules
 
 Path-scoped rules in `.claude/rules/` and the architecture spec WIN over any
-summary. Quick reference:
+summary; which artifact is authoritative for what is stated once in
+`docs/wiki/authority-matrix.md` (#198). Quick reference:
 
 - **Architecture**: production sketch only — layers per the table above;
   one file = one concept (150/250); structs shared with the `.ino` in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,8 @@ lineage): `docs/DECISION-LOG.md`.
 
 Path-scoped rules in `.claude/rules/` and the architecture spec WIN over any
 summary; which artifact is authoritative for what is stated once in
-`docs/wiki/authority-matrix.md` (#198). Quick reference:
+[docs/wiki/authority-matrix.md](docs/wiki/authority-matrix.md) (#198).
+Quick reference:
 
 - **Architecture**: production sketch only — layers per the table above;
   one file = one concept (150/250); structs shared with the `.ino` in

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,16 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-19 — authority matrix: one page states which artifact wins (#198)
+
+- `docs/wiki/authority-matrix.md` states the source-of-truth hierarchy once
+  (behavior=code+tests, tunables=config layer, structure=architecture
+  spec+ADRs, safety=SAFETY.md+invariant tests, operation=OPERATOR-GUIDE,
+  rationale=DECISION-LOG, navigation=wiki, agent conduct=CLAUDE.md+rules+
+  skills). Wiki README's stale "canonical docs (CLAUDE.md, SAFETY.md)"
+  tunables claim repointed (tunables' authority is the config layer);
+  CLAUDE.md Coding Rules intro links the matrix.
+
 ## 2026-07-19 — review/merge protocol amended after 52-round retrospective (#211)
 
 - Operator decisions after PR #210 reached 34 review rounds: (1) self-review

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -18,9 +18,11 @@ interconnected notes; humans read and visualize them** (issue #141).
 ## Rules for this folder (anti-drift)
 
 - **Navigation layer, not a second copy.** Notes describe stable concepts and
-  link to the canonical source. Tunable values — constants, thresholds, pin
-  numbers, versions — live ONLY in the canonical docs (`CLAUDE.md`,
-  `docs/SAFETY.md`, …); a wiki note that restates one is a bug. Stable
+  link to the canonical source — which artifact is canonical for what is
+  stated once in [authority-matrix](authority-matrix.md). Tunable values —
+  constants, thresholds, pin numbers, versions — live ONLY in their
+  authority (the config layer for tunables); a wiki note that restates one
+  is a bug. Stable
   identity is fine: component model names and ordinary descriptive
   quantities ("three-position switch") make notes readable and only change
   when the thing itself changes.

--- a/docs/wiki/authority-matrix.md
+++ b/docs/wiki/authority-matrix.md
@@ -9,7 +9,7 @@ that row wins — and the disagreement itself is a doc bug to file.
 | --- | --- | --- |
 | What does the firmware DO? | The code, proven by the host suites — test expectations are behavior law | [dual_track_control](../../sketches/dual_track_control/dual_track_control.ino) + [testing](testing.md) |
 | What are the current tunable values? | The config layer — no doc carries a live copy | `sketches/dual_track_control/src/config/` (inventory: [FILE-MAP](../architecture/FILE-MAP.md)) |
-| What structure must code follow? | The architecture spec + accepted ADRs (rules files summarize; the spec wins) | [ARCHITECTURE-TARGET](../architecture/ARCHITECTURE-TARGET.md) + [adr/](../architecture/adr/0001-domain-oriented-firmware-architecture.md) |
+| What structure must code follow? | The architecture spec + accepted ADRs (rules files summarize; the spec wins) | [ARCHITECTURE-TARGET](../architecture/ARCHITECTURE-TARGET.md) + [ADR-0001](../architecture/adr/0001-domain-oriented-firmware-architecture.md) |
 | What must NEVER change without sign-off? | The safety-invariant registry, each invariant tied to an executable test | [SAFETY](../SAFETY.md) + [safety-system](safety-system.md) |
 | How is the machine operated? | The operator guide (numbers there must match the config layer — drift is a doc bug) | [OPERATOR-GUIDE](../../OPERATOR-GUIDE.md) |
 | Why is it this way? | The dated decision log — history is immutable, entries are never retro-edited | [DECISION-LOG](../DECISION-LOG.md) |
@@ -19,7 +19,7 @@ that row wins — and the disagreement itself is a doc bug to file.
 Two standing corollaries:
 
 - **A changed test expectation is a behavior change**, not a refactor — it
-  needs its own issue and operator sign-off before any code
+  needs its own issue and operator sign-off before any code is written
   ([agent-governance](agent-governance.md)).
 - **Docs describe behavior, never live numbers.** Anything quoting a
   tunable outside the config layer is either a dated historical record

--- a/docs/wiki/authority-matrix.md
+++ b/docs/wiki/authority-matrix.md
@@ -1,0 +1,26 @@
+# Authority matrix — which artifact wins for what
+
+"Canonical" gets used loosely across this repo. This page states the
+hierarchy once; every other document points here instead of restating it.
+When two sources disagree, the one higher in its row's column wins, and the
+disagreement is a bug to file.
+
+| Question | The authority | Where |
+| --- | --- | --- |
+| What does the firmware DO? | The code, proven by the host suites — test expectations are behavior law | [dual_track_control](../../sketches/dual_track_control/dual_track_control.ino) + [testing](testing.md) |
+| What are the current tunable values? | The config layer — no doc carries a live copy | `sketches/dual_track_control/src/config/` |
+| What structure must code follow? | The architecture spec + accepted ADRs (rules files summarize; the spec wins) | [ARCHITECTURE-TARGET](../architecture/ARCHITECTURE-TARGET.md) + [adr/](../architecture/adr/0001-domain-oriented-firmware-architecture.md) |
+| What must NEVER change without sign-off? | The safety-invariant registry, each invariant tied to an executable test | [SAFETY](../SAFETY.md) + [safety-system](safety-system.md) |
+| How is the machine operated? | The operator guide (numbers there must match the config layer — drift is a doc bug) | [OPERATOR-GUIDE](../../OPERATOR-GUIDE.md) |
+| Why is it this way? | The dated decision log — history is immutable, entries are never retro-edited | [DECISION-LOG](../DECISION-LOG.md) |
+| Where do I start reading? | This wiki — navigation and synthesis only, never a second copy | [home](home.md) |
+| How do agents work here? | Project memory + path-scoped rules + skills, in that order of generality | [CLAUDE.md](../../CLAUDE.md) + [agent-governance](agent-governance.md) |
+
+Two standing corollaries:
+
+- **A changed test expectation is a behavior change**, not a refactor — it
+  needs its own issue and operator sign-off before any code
+  ([agent-governance](agent-governance.md)).
+- **Docs describe behavior, never live numbers.** Anything quoting a
+  tunable outside the config layer is either a dated historical record
+  (allowed) or drift (a bug).

--- a/docs/wiki/authority-matrix.md
+++ b/docs/wiki/authority-matrix.md
@@ -2,13 +2,13 @@
 
 "Canonical" gets used loosely across this repo. This page states the
 hierarchy once; every other document points here instead of restating it.
-When two sources disagree, the one higher in its row's column wins, and the
-disagreement is a bug to file.
+When two sources disagree about a row's question, the artifact named in
+that row wins — and the disagreement itself is a doc bug to file.
 
 | Question | The authority | Where |
 | --- | --- | --- |
 | What does the firmware DO? | The code, proven by the host suites — test expectations are behavior law | [dual_track_control](../../sketches/dual_track_control/dual_track_control.ino) + [testing](testing.md) |
-| What are the current tunable values? | The config layer — no doc carries a live copy | `sketches/dual_track_control/src/config/` |
+| What are the current tunable values? | The config layer — no doc carries a live copy | `sketches/dual_track_control/src/config/` (inventory: [FILE-MAP](../architecture/FILE-MAP.md)) |
 | What structure must code follow? | The architecture spec + accepted ADRs (rules files summarize; the spec wins) | [ARCHITECTURE-TARGET](../architecture/ARCHITECTURE-TARGET.md) + [adr/](../architecture/adr/0001-domain-oriented-firmware-architecture.md) |
 | What must NEVER change without sign-off? | The safety-invariant registry, each invariant tied to an executable test | [SAFETY](../SAFETY.md) + [safety-system](safety-system.md) |
 | How is the machine operated? | The operator guide (numbers there must match the config layer — drift is a doc bug) | [OPERATOR-GUIDE](../../OPERATOR-GUIDE.md) |

--- a/docs/wiki/home.md
+++ b/docs/wiki/home.md
@@ -6,6 +6,8 @@ telemetry dashboard. Project memory: [CLAUDE.md](../../CLAUDE.md) · full
 spec: [PROJECT-PLAN.md](../../PROJECT-PLAN.md) · design philosophy:
 [MISSION](../MISSION.md) (smoothness above all).
 
+Which artifact wins for what: [authority-matrix](authority-matrix.md).
+
 ## Domains
 
 - [Hardware](hardware.md) — board, ESCs, motors, batteries, wiring


### PR DESCRIPTION
Closes #198

## Summary
`docs/wiki/authority-matrix.md` — the source-of-truth hierarchy stated once, as a links-only wiki note: behavior = code + host suites (expectations are law), tunables = the config layer, structure = ARCHITECTURE-TARGET + ADRs, safety = SAFETY.md + invariant tests, operation = OPERATOR-GUIDE, rationale = DECISION-LOG (immutable dated history), navigation = wiki, agent conduct = CLAUDE.md + rules + skills. Plus two standing corollaries (expectation changes are behavior changes; docs describe behavior, never live numbers).

Other docs now point at it instead of restating: the wiki README's stale "canonical docs (`CLAUDE.md`, `docs/SAFETY.md`)" tunables claim is repointed (that claim predated #185 — tunables' authority is the config layer), home.md links it, CLAUDE.md's Coding Rules intro links it.

## Role
[A-Content]

## Test plan
- Docs-only, zero firmware change; wiki lint green on tracked files (link integrity, reachability from home, no tunable values in the note)
- Self-review sweep done pre-request: no other live doc makes a canonical-hierarchy claim

Documentation receipt
- Areas changed: docs/wiki/ (new note + home + README), CLAUDE.md, DECISION-LOG
- Pages examined: agent-governance (no hierarchy claim), TESTING/SAFETY (already consistent with the matrix rows)
- Unverifiable without hardware: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)