### PR TITLE
Change-impact manifest: deterministic doc-code sync (#199)

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -23,6 +23,11 @@
   docs/TESTING.md, docs/SAFETY.md and OPERATOR-GUIDE.md still match — the
   documentation-sync hook (`scripts/documentation_sync_hook.py`, #156)
   prompts this once per session; the prompt is a floor, not the ceiling.
+  CI enforces the deterministic half (#199): a PR touching an area mapped
+  in `docs/architecture/change-impact.json` must update an affected page
+  or carry a **documentation receipt** in its body — the
+  wiki-impact-review skill's receipt block, or an explicit
+  `No documentation effect: <reason>` line.
 - **Every firmware flash** (when hardware returns) gets a row in
   `docs/FIRMWARE-UPLOAD-LOG.md` immediately — an unlogged flash is treated as
   not done.

--- a/.claude/skills/wiki-impact-review/SKILL.md
+++ b/.claude/skills/wiki-impact-review/SKILL.md
@@ -7,9 +7,11 @@ description: Documentation-impact walk for a diff — use before finishing any P
 
 ## 1. Map the diff to knowledge pages
 
-For each changed area, open the pages that describe it (until the
-change-impact manifest of #199 lands, use this table + `docs/wiki/home.md`).
-`src/...` entries below are relative to `sketches/dual_track_control/`:
+The machine-readable mapping is `docs/architecture/change-impact.json`
+(#199) — CI enforces it (change-impact workflow), so start there. The table
+below is the human-oriented summary; when the two disagree, the manifest
+wins and the disagreement is a bug. `src/...` entries below are relative to
+`sketches/dual_track_control/`:
 
 | Changed area | Reconsider |
 | --- | --- |

--- a/.github/workflows/change-impact.yml
+++ b/.github/workflows/change-impact.yml
@@ -1,0 +1,25 @@
+name: change-impact
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  change-impact:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Self-test the change-impact checker (#199)
+        run: python scripts/check_change_impact_selftest.py
+      - name: Changed areas must update their pages or carry a receipt (#199)
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: python scripts/check_change_impact.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ sits above all four: during epic #116, organization changes NOTHING observable
      `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/dual_track_control`
    - CI green: `arduino-ci`, `lint`, `static-analysis`, `code-quality`,
      `structure-check`, `unit-tests`, `architecture-fitness` (#129),
-     `wiki-lint` (#145), `hooks-selftest` (#156/#193)
+     `wiki-lint` (#145), `hooks-selftest` (#156/#193), `change-impact`
+     (#199 — mapped areas update their pages or the PR carries a receipt)
    - no blocking calls in `loop()` (`delay()`, `pulseIn()`, unbounded `while`)
    - zero behavior change unless the task's own issue explicitly authorizes it
 

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,19 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-19 — change-impact manifest: deterministic doc-code sync (#199)
+
+- `docs/architecture/change-impact.json` maps source areas (path prefixes)
+  to knowledge pages; `scripts/check_change_impact.py` (new change-impact
+  CI workflow, always-run) computes affected pages from the PR diff and
+  passes only when no mapped area was touched, an affected page is updated
+  in the same diff, or the PR body carries a documentation receipt
+  (wiki-impact-review block or an explicit no-documentation-effect line).
+  The manifest self-validates on every run (pages must exist, area
+  prefixes must match something). Selftest exercises matching, sibling
+  non-swallowing, receipt patterns, and real-manifest validity. The
+  manifest is now the SSOT for the wiki-impact-review skill's mapping.
+
 ## 2026-07-19 — durable wiki architecture pages (#201)
 
 - Four stable concept pages added: architecture-overview (the durable

--- a/docs/architecture/change-impact.json
+++ b/docs/architecture/change-impact.json
@@ -1,0 +1,116 @@
+{
+  "comment": "Change-impact manifest (#199): which knowledge pages must be reconsidered when a source area changes. Areas are repo-relative path PREFIXES; pages are repo-relative files. Consumed by scripts/check_change_impact.py (CI: change-impact workflow) and the wiki-impact-review skill. A PR touching an area must update at least one mapped page or carry a documentation receipt in its body.",
+  "mappings": [
+    {
+      "areas": [
+        "sketches/dual_track_control/src/domain/drive/",
+        "sketches/dual_track_control/src/domain/operator_input/",
+        "sketches/dual_track_control/src/application/OperatorInput",
+        "sketches/dual_track_control/src/application/MotorOutput"
+      ],
+      "pages": [
+        "docs/wiki/control-pipeline.md",
+        "docs/wiki/application-loop.md",
+        "OPERATOR-GUIDE.md"
+      ]
+    },
+    {
+      "areas": [
+        "sketches/dual_track_control/src/domain/battery/",
+        "sketches/dual_track_control/src/domain/thermal/",
+        "sketches/dual_track_control/src/domain/safety/",
+        "sketches/dual_track_control/src/application/SafetyControl"
+      ],
+      "pages": [
+        "docs/wiki/safety-system.md",
+        "docs/SAFETY.md",
+        "docs/wiki/application-loop.md"
+      ]
+    },
+    {
+      "areas": [
+        "sketches/dual_track_control/src/alerts/",
+        "sketches/dual_track_control/src/application/AlertControl"
+      ],
+      "pages": [
+        "docs/wiki/safety-system.md",
+        "OPERATOR-GUIDE.md"
+      ]
+    },
+    {
+      "areas": [
+        "sketches/dual_track_control/src/infrastructure/network/",
+        "sketches/dual_track_control/src/application/Monitoring",
+        "dashboard/"
+      ],
+      "pages": [
+        "docs/wiki/telemetry-and-dashboard.md"
+      ]
+    },
+    {
+      "areas": [
+        "sketches/dual_track_control/src/infrastructure/xc/",
+        "sketches/dual_track_control/src/infrastructure/radiolink/",
+        "sketches/dual_track_control/src/telemetry/"
+      ],
+      "pages": [
+        "docs/wiki/telemetry-and-dashboard.md",
+        "docs/XBUS-PROTOCOL.md",
+        "docs/WIRING-GUIDE-V8.md"
+      ]
+    },
+    {
+      "areas": [
+        "sketches/dual_track_control/src/ports/",
+        "sketches/dual_track_control/src/infrastructure/arduino/"
+      ],
+      "pages": [
+        "docs/wiki/ports-and-adapters.md",
+        "docs/architecture/FILE-MAP.md"
+      ]
+    },
+    {
+      "areas": [
+        "sketches/dual_track_control/src/config/"
+      ],
+      "pages": [
+        "docs/wiki/configuration-authority.md",
+        "OPERATOR-GUIDE.md",
+        "PROJECT-PLAN.md"
+      ]
+    },
+    {
+      "areas": [
+        "sketches/dual_track_control/src/application/FirmwareApp",
+        "sketches/dual_track_control/src/application/FirmwareState",
+        "sketches/dual_track_control/dual_track_control.ino"
+      ],
+      "pages": [
+        "docs/wiki/application-loop.md",
+        "docs/wiki/architecture-overview.md",
+        "docs/architecture/FILE-MAP.md"
+      ]
+    },
+    {
+      "areas": [
+        ".claude/",
+        ".githooks/",
+        ".github/workflows/",
+        "scripts/"
+      ],
+      "pages": [
+        "docs/wiki/agent-governance.md",
+        "docs/TESTING.md"
+      ]
+    },
+    {
+      "areas": [
+        "tests/"
+      ],
+      "pages": [
+        "docs/TESTING.md",
+        "docs/wiki/testing.md"
+      ]
+    }
+  ]
+}

--- a/docs/wiki/agent-governance.md
+++ b/docs/wiki/agent-governance.md
@@ -33,7 +33,11 @@ the Karpathy method (#53) plus the behavior-preservation covenant
 - **This wiki** is itself governed here: agents maintain it, PRs that change
   docs update affected notes ([README](README.md)); a session hook
   (`scripts/documentation_sync_hook.py`, #156) prompts the agent to re-check
-  wiki + architecture docs whenever production code changes
+  wiki + architecture docs whenever production code changes, and CI
+  enforces the deterministic half (#199): the change-impact manifest
+  (`docs/architecture/change-impact.json`) maps source areas to knowledge
+  pages, and a PR touching a mapped area must update an affected page or
+  carry a documentation receipt
 
 The [testing](testing.md) suites are the enforcement arm: expectations are
 law, and the gate defines "done" for any agent task.

--- a/scripts/check_change_impact.py
+++ b/scripts/check_change_impact.py
@@ -27,8 +27,11 @@ import sys
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MANIFEST_PATH = os.path.join(REPO_ROOT, "docs", "architecture",
                              "change-impact.json")
+# Anchored: the receipt block's heading line, or an explicit no-effect line
+# WITH a non-empty reason — mid-prose mentions never count.
 RECEIPT_PATTERN = re.compile(
-    r"documentation receipt|no documentation effect", re.IGNORECASE)
+    r"^\s*documentation receipt\b|^\s*no documentation effect:\s*\S",
+    re.IGNORECASE | re.MULTILINE)
 
 
 def load_manifest():

--- a/scripts/check_change_impact.py
+++ b/scripts/check_change_impact.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Change-impact check (#199) — the deterministic half of doc-code sync.
+
+Reads docs/architecture/change-impact.json (source areas → knowledge
+pages), computes which pages a diff potentially affects, and passes when:
+  1. no mapped area was touched, or
+  2. at least one affected page is updated in the same diff, or
+  3. the PR body carries a documentation receipt (the wiki-impact-review
+     skill's receipt block, or an explicit no-documentation-effect line).
+Otherwise it fails, listing the affected pages and both ways to satisfy it.
+
+The manifest itself is validated on every run: every page must be an
+existing file, every area prefix must match something in the repo.
+
+CI (change-impact workflow) provides BASE_SHA and PR_BODY; locally it
+compares against origin/main:
+    python scripts/check_change_impact.py
+"""
+
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MANIFEST_PATH = os.path.join(REPO_ROOT, "docs", "architecture",
+                             "change-impact.json")
+RECEIPT_PATTERN = re.compile(
+    r"documentation receipt|no documentation effect", re.IGNORECASE)
+
+
+def load_manifest():
+    with open(MANIFEST_PATH, encoding="utf-8") as manifest_file:
+        return json.load(manifest_file)
+
+
+def validate_manifest(manifest):
+    """Every page exists; every area prefix matches something real."""
+    problems = []
+    for mapping in manifest["mappings"]:
+        for page in mapping["pages"]:
+            if not os.path.isfile(os.path.join(REPO_ROOT, page)):
+                problems.append(f"manifest page does not exist: {page}")
+        for area in mapping["areas"]:
+            absolute = os.path.join(REPO_ROOT, area)
+            if not (os.path.exists(absolute) or glob.glob(absolute + "*")):
+                problems.append(f"manifest area matches nothing: {area}")
+    return problems
+
+
+def changed_files(base_reference):
+    output = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_reference}...HEAD"],
+        capture_output=True, text=True, cwd=REPO_ROOT, timeout=60)
+    if output.returncode != 0:
+        raise RuntimeError(output.stderr.strip())
+    return [line for line in output.stdout.splitlines() if line]
+
+
+def affected_pages(files, manifest):
+    pages = set()
+    for mapping in manifest["mappings"]:
+        if any(name.startswith(area)
+               for name in files for area in mapping["areas"]):
+            pages.update(mapping["pages"])
+    return pages
+
+
+def main():
+    manifest = load_manifest()
+    problems = validate_manifest(manifest)
+    if problems:
+        for problem in problems:
+            print(f"FAIL: {problem}")
+        return 1
+
+    base_reference = os.environ.get("BASE_SHA", "origin/main")
+    pull_request_body = os.environ.get("PR_BODY", "")
+    files = changed_files(base_reference)
+    pages = affected_pages(files, manifest)
+    updated = pages.intersection(files)
+
+    if not pages:
+        print("change-impact: no mapped area touched — nothing to reconsider")
+        return 0
+    if updated:
+        print("change-impact: affected pages updated in this diff: "
+              + ", ".join(sorted(updated)))
+        return 0
+    if RECEIPT_PATTERN.search(pull_request_body):
+        print("change-impact: documentation receipt present for: "
+              + ", ".join(sorted(pages)))
+        return 0
+
+    print("FAIL: this change touches mapped source areas but neither "
+          "updates an affected page nor carries a documentation receipt.")
+    print("Affected pages: " + ", ".join(sorted(pages)))
+    print("Satisfy by updating one of them in this PR, or add the "
+          "wiki-impact-review skill's receipt (or an explicit "
+          "'No documentation effect: <reason>' line) to the PR body.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_change_impact_selftest.py
+++ b/scripts/check_change_impact_selftest.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Selftest for check_change_impact.py (#199) — exercises the matching
+logic with injected inputs and validates the REAL manifest against the
+repo. Run in CI (change-impact workflow) and locally:
+    python scripts/check_change_impact_selftest.py
+"""
+
+import importlib.util
+import os
+import sys
+
+CHECKER = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                       "check_change_impact.py")
+specification = importlib.util.spec_from_file_location("checker", CHECKER)
+checker = importlib.util.module_from_spec(specification)
+specification.loader.exec_module(checker)
+
+SYNTHETIC = {"mappings": [
+    {"areas": ["src/domain/drive/"], "pages": ["docs/a.md", "docs/b.md"]},
+    {"areas": ["scripts/"], "pages": ["docs/c.md"]},
+]}
+
+
+def main():
+    failures = []
+    checks = 0
+
+    def check(name, condition):
+        nonlocal checks
+        checks += 1
+        if not condition:
+            failures.append(name)
+
+    check("untouched areas affect nothing",
+          checker.affected_pages(["README.md"], SYNTHETIC) == set())
+    check("a touched area maps to its pages",
+          checker.affected_pages(["src/domain/drive/CurvatureDrive.cpp"],
+                                 SYNTHETIC) == {"docs/a.md", "docs/b.md"})
+    check("two touched areas union their pages",
+          checker.affected_pages(
+              ["src/domain/drive/x.h", "scripts/tool.py"],
+              SYNTHETIC) == {"docs/a.md", "docs/b.md", "docs/c.md"})
+    check("prefix matching does not swallow siblings",
+          checker.affected_pages(["src/domain/driver_station.md"],
+                                 SYNTHETIC) == set())
+    check("receipt pattern accepts the skill's block",
+          bool(checker.RECEIPT_PATTERN.search("...\nDocumentation receipt\n")))
+    check("receipt pattern accepts the explicit no-effect line",
+          bool(checker.RECEIPT_PATTERN.search(
+              "No documentation effect: comment-only")))
+    check("receipt pattern rejects unrelated prose",
+          not checker.RECEIPT_PATTERN.search("updated the docs folder"))
+    check("the REAL manifest validates against the repo",
+          checker.validate_manifest(checker.load_manifest()) == [])
+
+    for name in failures:
+        print(f"FAIL: {name}")
+    print(f"check-change-impact selftest: "
+          f"{checks - len(failures)}/{checks} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_change_impact_selftest.py
+++ b/scripts/check_change_impact_selftest.py
@@ -50,6 +50,11 @@ def main():
               "No documentation effect: comment-only")))
     check("receipt pattern rejects unrelated prose",
           not checker.RECEIPT_PATTERN.search("updated the docs folder"))
+    check("receipt pattern rejects mid-prose mentions",
+          not checker.RECEIPT_PATTERN.search(
+              "we shipped a documentation receipt yesterday"))
+    check("receipt pattern rejects a bare no-effect line without a reason",
+          not checker.RECEIPT_PATTERN.search("No documentation effect:"))
     check("the REAL manifest validates against the repo",
           checker.validate_manifest(checker.load_manifest()) == [])
 


### PR DESCRIPTION
Closes #199

## Summary
The deterministic half of semantic doc-code sync — your friend's review's "layer 1", and the heart of the trickle-up system:

- **`docs/architecture/change-impact.json`** — source areas (repo-relative path prefixes) mapped to the knowledge pages that describe them; self-validated on every run (pages must exist, area prefixes must match something real)
- **`scripts/check_change_impact.py`** + the new **always-run `change-impact` workflow** — computes affected pages from the PR diff; passes only when (1) no mapped area was touched, (2) an affected page is updated in the same diff, or (3) the PR body carries a documentation receipt (the wiki-impact-review skill's block, or an explicit `No documentation effect: <reason>` line); fails otherwise, listing the pages and both remedies
- **Selftest** (matching, union, sibling non-swallowing, receipt patterns, real-manifest validity) runs in the same workflow
- Receipt convention documented in the workflow rule; the wiki-impact-review skill now defers to the manifest as SSOT; CLAUDE.md gate list + agent-governance wiki updated same-PR

**Dogfood proof:** this PR touches mapped areas (`scripts/`, `.claude/`, `.github/workflows/`) and the checker passes on its own diff via the updated governance page.

Post-merge note for #196: `change-impact` should join the required-checks list.

## Role
[C-Builder]

## Test plan
- Selftest 8/8 locally; checker verified on this very diff (fails when I withhold the page update, passes with it)
- No firmware files touched — zero behavior change
- New workflow runs on every PR (no path filters — required-check safe)

Documentation receipt
- Areas changed: scripts/, .github/workflows/, .claude/ (rule + skill), docs/architecture/
- Pages examined/updated: agent-governance.md (updated), workflow rule (updated), CLAUDE.md gate list (updated), TESTING.md (examined — host-suite scope, no change needed)
- Unverifiable without hardware: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request checks to identify documentation affected by code changes.
  * Pull requests touching mapped areas must update the relevant documentation or include a documentation receipt.
  * Added a centralized change-impact mapping covering source areas and related documentation.

* **Documentation**
  * Updated governance guidance and decision records to describe the new documentation synchronization process.
  * Clarified review instructions for using the authoritative change-impact mapping.

* **Tests**
  * Added validation covering mapping behavior, receipt formats, and manifest integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->