### PR TITLE
Wiki lint v2: sources frontmatter + semantic-adjacent checks (#202)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ node_modules/
 
 # Wi-Fi credentials (#125) — copy arduino_secrets.h.example and fill in
 sketches/*/arduino_secrets.h
+
+# Obsidian default-named scratch notes are personal working files (#202)
+Untitled*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ sits above all four: during epic #116, organization changes NOTHING observable
      `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/dual_track_control`
    - CI green: `arduino-ci`, `lint`, `static-analysis`, `code-quality`,
      `structure-check`, `unit-tests`, `architecture-fitness` (#129),
-     `wiki-lint` (#145), `hooks-selftest` (#156/#193), `change-impact`
+     `wiki-lint` (#145/#202), `hooks-selftest` (#156/#193), `change-impact`
      (#199 — mapped areas update their pages or the PR carries a receipt)
    - no blocking calls in `loop()` (`delay()`, `pulseIn()`, unbounded `while`)
    - zero behavior change unless the task's own issue explicitly authorizes it

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,19 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-20 — wiki lint v2: sources frontmatter + semantic-adjacent checks (#202)
+
+- check_wiki.py extended: recursive note discovery (graph keyed by
+  relative path), heading-anchor validation (GitHub slugs), mandatory
+  `sources:` frontmatter on every note except README (declared paths must
+  exist — a vanished source fails the lint so the note gets reconsidered;
+  `sources: none` for pure navigation), duplicate-H1 detection, and a
+  curated deprecated-phrase list (retired sketch name, retired gate
+  filename, completed-phase framing). Selftest demonstrates every failure
+  mode including recursive subdirectory discovery. All real notes gained
+  honest sources frontmatter; manifest validation stays with the #199
+  checker (no duplication).
+
 ## 2026-07-19 — change-impact manifest: deterministic doc-code sync (#199)
 
 - `docs/architecture/change-impact.json` maps source areas (path prefixes)

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -29,7 +29,12 @@ interconnected notes; humans read and visualize them** (issue #141).
 - **Agents own this folder.** A PR that adds, removes, or renames a doc — or
   changes what a subsystem IS — updates the affected wiki notes in the same
   PR. Link fixes are cheap; that is the point of keeping content out.
-- **CI enforces this** (`wiki-lint` workflow, `scripts/check_wiki.py`, #145):
-  broken links, orphan notes, notes unreachable from [home](home.md), and
-  tunable-looking values all fail the build.
+- **Every note declares its sources** (#202): a `---` frontmatter block with
+  a `sources:` list of the repo paths the note navigates to (`sources: none`
+  for pure-navigation pages). Declared paths must exist — a vanished source
+  fails the lint, which is the point: the note must be reconsidered.
+- **CI enforces this** (`wiki-lint` workflow, `scripts/check_wiki.py`,
+  #145/#202): broken links and anchors, orphan notes, notes unreachable
+  from [home](home.md), tunable-looking values, missing or invalid sources
+  frontmatter, duplicate titles, and deprecated phrases all fail the build.
 - Start at [home](home.md).

--- a/docs/wiki/agent-governance.md
+++ b/docs/wiki/agent-governance.md
@@ -1,3 +1,10 @@
+---
+sources:
+  - CLAUDE.md
+  - .claude/rules/
+  - docs/AGENT-EXAMPLES.md
+---
+
 # Agent governance
 
 How AI agents (Claude Code, Copilot, CodeRabbit) are steered in this repo —

--- a/docs/wiki/alerts-and-alarms.md
+++ b/docs/wiki/alerts-and-alarms.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - sketches/dual_track_control/src/alerts/
+  - OPERATOR-GUIDE.md
+---
+
 # Alerts and alarms
 
 Audible signals from a piezo beeper, driven non-blocking with a strict

--- a/docs/wiki/application-loop.md
+++ b/docs/wiki/application-loop.md
@@ -1,3 +1,8 @@
+---
+sources:
+  - sketches/dual_track_control/src/application/FirmwareApp.cpp
+---
+
 # Application loop — one control cycle
 
 What `firmwareLoop()` does each pass, in order. The order IS the safety

--- a/docs/wiki/architecture-overview.md
+++ b/docs/wiki/architecture-overview.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - docs/architecture/ARCHITECTURE-TARGET.md
+  - docs/architecture/FILE-MAP.md
+---
+
 # Architecture overview
 
 The durable map of the firmware as it IS — independent of the migration

--- a/docs/wiki/architecture-remediation.md
+++ b/docs/wiki/architecture-remediation.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - docs/architecture/ARCHITECTURE-TARGET.md
+  - docs/DECISION-LOG.md
+---
+
 # Architecture remediation (epic #116)
 
 Active program: reorganize the single-sketch firmware into a domain-oriented

--- a/docs/wiki/authority-matrix.md
+++ b/docs/wiki/authority-matrix.md
@@ -1,3 +1,7 @@
+---
+sources: none
+---
+
 # Authority matrix — which artifact wins for what
 
 "Canonical" gets used loosely across this repo. This page states the

--- a/docs/wiki/battery-ladder.md
+++ b/docs/wiki/battery-ladder.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - sketches/dual_track_control/src/domain/battery/
+  - docs/SAFETY.md
+---
+
 # Battery ladder
 
 Staged response to falling pack voltage, always keyed to the **worse** of the

--- a/docs/wiki/configuration-authority.md
+++ b/docs/wiki/configuration-authority.md
@@ -1,3 +1,8 @@
+---
+sources:
+  - sketches/dual_track_control/src/config/
+---
+
 # Configuration authority — which values live where
 
 Every number has exactly one home. The full hierarchy of who wins what:

--- a/docs/wiki/control-pipeline.md
+++ b/docs/wiki/control-pipeline.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - sketches/dual_track_control/src/domain/drive/
+  - PROJECT-PLAN.md
+---
+
 # Control pipeline
 
 Stick to track, end to end — all shaping happens on the Arduino, all motor

--- a/docs/wiki/curvature-drive.md
+++ b/docs/wiki/curvature-drive.md
@@ -1,3 +1,8 @@
+---
+sources:
+  - sketches/dual_track_control/src/domain/drive/CurvatureDrive.cpp
+---
+
 # Curvature drive
 
 The tank-mixing algorithm: throttle plus steering in, one speed per track

--- a/docs/wiki/gear-and-reverse-caps.md
+++ b/docs/wiki/gear-and-reverse-caps.md
@@ -1,3 +1,8 @@
+---
+sources:
+  - sketches/dual_track_control/src/domain/drive/GearPolicy.cpp
+---
+
 # Gear and reverse caps
 
 The speed-limiting layer between [curvature drive](curvature-drive.md) and

--- a/docs/wiki/hardware.md
+++ b/docs/wiki/hardware.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - docs/WIRING-GUIDE-V8.md
+  - docs/GL10-PARAMETERS.md
+---
+
 # Hardware
 
 Arduino **UNO R4 WiFi** (RA4M1 + ESP32-S3 Wi-Fi coprocessor) drives two

--- a/docs/wiki/home.md
+++ b/docs/wiki/home.md
@@ -1,3 +1,7 @@
+---
+sources: none
+---
+
 # Home — Excavator Track Controller
 
 Tank-style dual-track controller for a ride-on excavator: Arduino UNO R4

--- a/docs/wiki/output-gate.md
+++ b/docs/wiki/output-gate.md
@@ -1,3 +1,8 @@
+---
+sources:
+  - sketches/dual_track_control/src/domain/safety/OutputGate.cpp
+---
+
 # Output gate
 
 The final authority between the mixer and the servo pins. When any

--- a/docs/wiki/override-modes.md
+++ b/docs/wiki/override-modes.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - sketches/dual_track_control/src/domain/drive/CommandMixer.cpp
+  - OPERATOR-GUIDE.md
+---
+
 # Override modes
 
 Who is driving. A three-position switch on the RC transmitter selects the

--- a/docs/wiki/ports-and-adapters.md
+++ b/docs/wiki/ports-and-adapters.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - sketches/dual_track_control/src/ports/
+  - sketches/dual_track_control/src/infrastructure/
+---
+
 # Ports and adapters — the hardware boundary
 
 How the firmware talks to hardware without the logic ever including a

--- a/docs/wiki/safety-system.md
+++ b/docs/wiki/safety-system.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - docs/SAFETY.md
+  - sketches/dual_track_control/src/domain/safety/
+---
+
 # Safety system
 
 Everything that can slow, stop, or refuse a drive command. The canonical,

--- a/docs/wiki/sbus-input.md
+++ b/docs/wiki/sbus-input.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - sketches/dual_track_control/src/infrastructure/radiolink/SbusReceiverAdapter.cpp
+  - docs/WIRING-GUIDE-V8.md
+---
+
 # S.BUS input
 
 All RC channels arrive on one wire: the receiver's S.BUS output — an

--- a/docs/wiki/telemetry-and-dashboard.md
+++ b/docs/wiki/telemetry-and-dashboard.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - sketches/dual_track_control/src/infrastructure/xc/
+  - dashboard/index.html
+---
+
 # Telemetry and dashboard
 
 Read-only observation path: the ESCs report voltage, current, RPM, and

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - docs/TESTING.md
+  - tests/
+---
+
 # Testing
 
 Host-side suites that compile the **real firmware** (`dual_track_control.ino`) against

--- a/docs/wiki/thermal-derating.md
+++ b/docs/wiki/thermal-derating.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - sketches/dual_track_control/src/domain/thermal/
+  - docs/SAFETY.md
+---
+
 # Thermal derating
 
 Staged response to ESC and motor temperature — **monotone by design**: a

--- a/docs/wiki/wifi-dashboard.md
+++ b/docs/wiki/wifi-dashboard.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - sketches/dual_track_control/src/infrastructure/network/
+  - dashboard/index.html
+---
+
 # Wi-Fi dashboard
 
 The UNO R4 WiFi hosts its own access point and serves a single-page

--- a/docs/wiki/xbus-telemetry.md
+++ b/docs/wiki/xbus-telemetry.md
@@ -1,3 +1,9 @@
+---
+sources:
+  - docs/XBUS-PROTOCOL.md
+  - sketches/dual_track_control/src/infrastructure/xc/XbusTelemetryAdapter.cpp
+---
+
 # X.BUS telemetry
 
 How the firmware reads voltage, current, RPM, and temperatures from both

--- a/scripts/check_wiki.py
+++ b/scripts/check_wiki.py
@@ -1,22 +1,30 @@
-"""Wiki lint (#145) — health checks for the docs/wiki/ knowledge graph.
+"""Wiki lint (#145, v2 #202) — health checks for the docs/wiki/ graph.
 
 The third operation of the Karpathy LLM-wiki pattern (#141): ingest and
 query exist; this is lint. Stdlib-only, identical locally and in CI.
 
 Checks:
-  1. Link integrity — every relative Markdown link in a wiki note resolves.
+  1. Link integrity — every relative Markdown link in a wiki note resolves
+     (recursively: notes may live in subdirectories).
   2. Orphans — every note (except README.md/home.md) has an inbound link
      from another wiki note.
   3. Reachability — every note is reachable from home.md via wiki links.
   4. Tunable drift — wiki notes must not carry tunable-looking values
-     (numbers with units); those live only in canonical docs
+     (numbers with units); those live only in their authority
      (docs/wiki/README.md anti-drift rule).
+  5. Heading anchors — a link's #fragment must match a heading in the
+     target Markdown file.
+  6. Sources frontmatter — every note (except README.md) declares the
+     canonical sources it navigates to, and each declared path exists.
+  7. Duplicate titles — two notes may not share the same H1.
+  8. Deprecated phrases — retired names/framings may not reappear.
 
 Exit code 1 on any failure.
 """
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from collections import deque
 from pathlib import Path
@@ -26,46 +34,153 @@ sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 LINK_PATTERN = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
 EXTERNAL_SCHEMES = ("http://", "https://", "mailto:")
 HUB_NOTES = {"README.md", "home.md"}  # allowed to have no inbound links
+FRONTMATTER_EXEMPT = {"README.md"}
 TUNABLE_PATTERN = re.compile(
     r"\b\d+(?:\.\d+)?\s?(?:V|A|Hz|kHz|MHz|s|ms|us|µs|°C|%)(?!\w)")
+DEPRECATED_PHRASES = {
+    "sketches/rc_test": "renamed to dual_track_control (#118)",
+    "test-gate.sh": "the gate is test-gate.py (#206)",
+    "Phase D target": "Phase D completed (#189) — describe the present",
+}
 
 
-def wiki_links(note: Path) -> list[str]:
-    return [target.split("#")[0]
+def note_links(note: Path) -> list[str]:
+    """Raw relative link targets, fragments preserved."""
+    return [target
             for target in LINK_PATTERN.findall(note.read_text(encoding="utf-8"))
             if target and not target.startswith(EXTERNAL_SCHEMES)
             and not target.startswith("#")]
 
 
+def heading_slugs(markdown_path: Path) -> set[str]:
+    """GitHub-style anchor slugs for every heading in a Markdown file."""
+    slugs: set[str] = set()
+    for line in markdown_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("#"):
+            heading = line.lstrip("#").strip().lower()
+            heading = re.sub(r"[^\w\- ]", "", heading, flags=re.UNICODE)
+            slugs.add(heading.replace(" ", "-"))
+    return slugs
+
+
+def parse_sources(note: Path) -> tuple[list[str] | None, str | None]:
+    """The frontmatter sources list, or (None, why-it-is-malformed)."""
+    lines = note.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None, "no sources frontmatter (--- block with a sources list)"
+    block: list[str] = []
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        block.append(line)
+    else:
+        return None, "unterminated frontmatter block"
+    in_sources = False
+    sources: list[str] = []
+    for line in block:
+        stripped = line.strip()
+        if stripped == "sources: none":
+            return [], None
+        if stripped == "sources:":
+            in_sources = True
+            continue
+        if in_sources and stripped.startswith("- "):
+            sources.append(stripped[2:].strip())
+        elif stripped and not line.startswith(" "):
+            in_sources = False
+    if not sources:
+        return None, "frontmatter has no sources list (or it is empty)"
+    return sources, None
+
+
+def check_note(note: Path, name: str, wiki_root: Path, repo_root: Path,
+               graph: dict[str, set[str]]) -> list[str]:
+    failures: list[str] = []
+    for target in note_links(note):
+        path_part, _, fragment = target.partition("#")
+        resolved = (note.parent / path_part).resolve()
+        try:
+            resolved.relative_to(repo_root.resolve())
+            inside_repo = True
+        except ValueError:
+            inside_repo = False  # escapes the repo — never a valid target
+        if not inside_repo or not resolved.is_file():
+            failures.append(f"{name}: broken link -> {target}")
+            continue
+        if fragment and resolved.suffix == ".md":
+            if fragment.lower() not in heading_slugs(resolved):
+                failures.append(
+                    f"{name}: broken anchor -> {target} "
+                    f"(no such heading in the target)")
+        try:
+            graph[name].add(
+                resolved.relative_to(wiki_root.resolve()).as_posix())
+        except ValueError:
+            pass  # links outside the wiki are canon pointers, not graph edges
+
+    text = note.read_text(encoding="utf-8")
+    for line_number, line in enumerate(text.splitlines(), 1):
+        for match in TUNABLE_PATTERN.findall(line):
+            failures.append(
+                f"{name}:{line_number}: tunable-looking value "
+                f"({match!r}) — constants live in their authority only "
+                f"(docs/wiki/README.md anti-drift rule)")
+        for phrase, why in DEPRECATED_PHRASES.items():
+            if phrase in line:
+                failures.append(
+                    f"{name}:{line_number}: deprecated phrase "
+                    f"({phrase!r}) — {why}")
+
+    if note.name not in FRONTMATTER_EXEMPT:
+        sources, problem = parse_sources(note)
+        if problem:
+            failures.append(f"{name}: {problem}")
+        else:
+            for source in sources or []:
+                absolute = repo_root / source
+                if not (absolute.exists() or list(
+                        absolute.parent.glob(absolute.name + "*"))):
+                    failures.append(
+                        f"{name}: unknown source path in frontmatter "
+                        f"-> {source}")
+    return failures
+
+
+def git_ignored(note: Path, repo_root: Path) -> bool:
+    """True when git ignores the file (personal scratch notes stay local)."""
+    try:
+        return subprocess.run(
+            ["git", "check-ignore", "-q", str(note)],
+            cwd=repo_root, capture_output=True, timeout=10).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False  # no git — lint everything
+
+
 def check_wiki(wiki_root: Path,
                repo_root: Path) -> tuple[list[str], dict[str, set[str]]]:
-    """Return (failures, wiki-internal link graph by note name)."""
+    """Return (failures, wiki-internal link graph by relative path)."""
     failures: list[str] = []
     graph: dict[str, set[str]] = {}
-    notes = sorted(wiki_root.glob("*.md"))
+    notes = sorted(note for note in wiki_root.rglob("*.md")
+                   if not git_ignored(note, repo_root))
     if not notes:
         return [f"{wiki_root}: no wiki notes found"], graph
 
+    titles: dict[str, str] = {}
     for note in notes:
-        graph.setdefault(note.name, set())
-        for target in wiki_links(note):
-            resolved = (note.parent / target).resolve()
-            try:
-                resolved.relative_to(repo_root.resolve())
-                inside_repo = True
-            except ValueError:
-                inside_repo = False  # escapes the repo — never a valid target
-            if not inside_repo or not resolved.is_file():
-                failures.append(f"{note.name}: broken link -> {target}")
-            elif resolved.parent == wiki_root.resolve():
-                graph[note.name].add(resolved.name)
-        for line_number, line in enumerate(
-                note.read_text(encoding="utf-8").splitlines(), 1):
-            for match in TUNABLE_PATTERN.findall(line):
-                failures.append(
-                    f"{note.name}:{line_number}: tunable-looking value "
-                    f"({match!r}) — constants live in canonical docs only "
-                    f"(docs/wiki/README.md anti-drift rule)")
+        name = note.relative_to(wiki_root).as_posix()
+        graph.setdefault(name, set())
+        failures += check_note(note, name, wiki_root, repo_root, graph)
+        for line in note.read_text(encoding="utf-8").splitlines():
+            if line.startswith("# "):
+                title = line[2:].strip()
+                if title in titles:
+                    failures.append(
+                        f"{name}: duplicate title ({title!r}) — already "
+                        f"used by {titles[title]}")
+                else:
+                    titles[title] = name
+                break
     return failures, graph
 
 

--- a/scripts/check_wiki.py
+++ b/scripts/check_wiki.py
@@ -81,6 +81,21 @@ def heading_slugs(markdown_path: Path) -> set[str]:
     return slugs
 
 
+def first_h1(note: Path) -> str | None:
+    """The note's first H1 title, fence-aware (same rules as anchors)."""
+    in_fence = False
+    for line in note.read_text(encoding="utf-8").splitlines():
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        match = HEADING_PATTERN.match(line)
+        if match and len(match.group(1)) == 1:
+            return match.group(2).strip()
+    return None
+
+
 def parse_sources(note: Path) -> tuple[list[str] | None, str | None]:
     """The frontmatter sources list, or (None, why-it-is-malformed)."""
     lines = note.read_text(encoding="utf-8").splitlines()
@@ -155,7 +170,13 @@ def check_note(note: Path, name: str, wiki_root: Path, repo_root: Path,
             failures.append(f"{name}: {problem}")
         else:
             for source in sources or []:
-                if not (repo_root / source).exists():
+                absolute = (repo_root / source).resolve()
+                try:
+                    absolute.relative_to(repo_root.resolve())
+                    inside_repo = True
+                except ValueError:
+                    inside_repo = False  # absolute path or ..-escape
+                if not inside_repo or not absolute.exists():
                     failures.append(
                         f"{name}: unknown source path in frontmatter "
                         f"-> {source}")
@@ -188,16 +209,14 @@ def check_wiki(wiki_root: Path,
         name = note.relative_to(wiki_root).as_posix()
         graph.setdefault(name, set())
         failures += check_note(note, name, wiki_root, repo_root, graph)
-        for line in note.read_text(encoding="utf-8").splitlines():
-            if line.startswith("# "):
-                title = line[2:].strip()
-                if title in titles:
-                    failures.append(
-                        f"{name}: duplicate title ({title!r}) — already "
-                        f"used by {titles[title]}")
-                else:
-                    titles[title] = name
-                break
+        title = first_h1(note)
+        if title is not None:
+            if title in titles:
+                failures.append(
+                    f"{name}: duplicate title ({title!r}) — already "
+                    f"used by {titles[title]}")
+            else:
+                titles[title] = name
     return failures, graph
 
 

--- a/scripts/check_wiki.py
+++ b/scripts/check_wiki.py
@@ -1,7 +1,10 @@
 """Wiki lint (#145, v2 #202) — health checks for the docs/wiki/ graph.
 
 The third operation of the Karpathy LLM-wiki pattern (#141): ingest and
-query exist; this is lint. Stdlib-only, identical locally and in CI.
+query exist; this is lint. Stdlib-only Python; when a `git` executable is
+present, gitignored notes (personal scratch files) are skipped — without
+git, everything on disk is linted (CI checks out tracked files only, so
+its result is unaffected either way).
 
 Checks:
   1. Link integrity — every relative Markdown link in a wiki note resolves

--- a/scripts/check_wiki.py
+++ b/scripts/check_wiki.py
@@ -52,14 +52,32 @@ def note_links(note: Path) -> list[str]:
             and not target.startswith("#")]
 
 
+HEADING_PATTERN = re.compile(r"^ {0,3}(#{1,6})\s+(.*)$")
+
+
 def heading_slugs(markdown_path: Path) -> set[str]:
-    """GitHub-style anchor slugs for every heading in a Markdown file."""
+    """GitHub-style anchor slugs: fence-aware, duplicate-suffixed."""
     slugs: set[str] = set()
+    seen: dict[str, int] = {}
+    in_fence = False
     for line in markdown_path.read_text(encoding="utf-8").splitlines():
-        if line.startswith("#"):
-            heading = line.lstrip("#").strip().lower()
-            heading = re.sub(r"[^\w\- ]", "", heading, flags=re.UNICODE)
-            slugs.add(heading.replace(" ", "-"))
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        match = HEADING_PATTERN.match(line)
+        if not match:
+            continue
+        heading = match.group(2).strip().lower()
+        heading = re.sub(r"[^\w\- ]", "", heading, flags=re.UNICODE)
+        slug = heading.replace(" ", "-")
+        if slug in seen:
+            seen[slug] += 1
+            slugs.add(f"{slug}-{seen[slug]}")
+        else:
+            seen[slug] = 0
+            slugs.add(slug)
     return slugs
 
 
@@ -137,9 +155,7 @@ def check_note(note: Path, name: str, wiki_root: Path, repo_root: Path,
             failures.append(f"{name}: {problem}")
         else:
             for source in sources or []:
-                absolute = repo_root / source
-                if not (absolute.exists() or list(
-                        absolute.parent.glob(absolute.name + "*"))):
+                if not (repo_root / source).exists():
                     failures.append(
                         f"{name}: unknown source path in frontmatter "
                         f"-> {source}")
@@ -149,11 +165,12 @@ def check_note(note: Path, name: str, wiki_root: Path, repo_root: Path,
 def git_ignored(note: Path, repo_root: Path) -> bool:
     """True when git ignores the file (personal scratch notes stay local)."""
     try:
+        relative = note.resolve().relative_to(repo_root.resolve()).as_posix()
         return subprocess.run(
-            ["git", "check-ignore", "-q", str(note)],
+            ["git", "check-ignore", "-q", relative],
             cwd=repo_root, capture_output=True, timeout=10).returncode == 0
-    except (OSError, subprocess.SubprocessError):
-        return False  # no git — lint everything
+    except (ValueError, OSError, subprocess.SubprocessError):
+        return False  # no git (or outside the repo) — lint everything
 
 
 def check_wiki(wiki_root: Path,

--- a/scripts/check_wiki_selftest.py
+++ b/scripts/check_wiki_selftest.py
@@ -28,6 +28,8 @@ EXPECTED_VIOLATIONS = {
     "unknown source path in frontmatter -> docs/GONE.md":
         "declared source that does not exist",
     "broken anchor -> home.md#no-such-heading": "anchor with no matching heading",
+    "broken anchor -> stale.md#in-fence":
+        "a # line inside a code fence is not a heading",
     "duplicate title": "two notes sharing one H1",
     "deprecated phrase ('test-gate.sh')": "retired name reappearing",
     "nested/sub-orphan.md: orphan": "recursive discovery finds subdirectory notes",
@@ -59,7 +61,9 @@ def build_violating_repo(root: Path) -> Path:
     write(wiki / "dup-a.md", FRONTMATTER + "# Same Title\n[home](home.md)\n")
     write(wiki / "dup-b.md", FRONTMATTER + "# Same Title\n[home](home.md)\n")
     write(wiki / "stale.md",
-          FRONTMATTER + "# Stale\nStill mentions test-gate.sh here.\n")
+          FRONTMATTER + "# Stale\nStill mentions test-gate.sh here.\n"
+          "```\n# in fence\n```\n"
+          "[fence anchor](stale.md#in-fence)\n")
     write(wiki / "ghost-sources.md",
           "---\nsources:\n  - docs/GONE.md\n---\n# Ghost\n[home](home.md)\n")
     write(wiki / "readme-only.md", FRONTMATTER + "# Readme only\n[home](home.md)\n")
@@ -75,7 +79,9 @@ def build_clean_repo(root: Path) -> Path:
     repo = root / "repo"
     wiki = repo / "docs" / "wiki"
     write(repo / "docs" / "CANONICAL.md",
-          "# Canonical\n\n## Real Constants\n\nThe real constants live here.\n")
+          "# Canonical\n\n## Real Constants\n\nThe real constants live here.\n"
+          "\n```\n# not a heading (inside a code fence)\n```\n"
+          "\n## Real Constants\n\nDuplicate heading gets a -1 slug.\n")
     write(wiki / "README.md", "[home](home.md)\n")
     write(wiki / "home.md",
           FRONTMATTER + "# Home\n[safety](safety.md)\n[drive](drive.md)\n"
@@ -86,7 +92,8 @@ def build_clean_repo(root: Path) -> Path:
           "[canonical](../CANONICAL.md#real-constants). [drive](drive.md)\n")
     write(wiki / "drive.md",
           "---\nsources:\n  - docs/CANONICAL.md\n---\n"
-          "# Drive\nLoops back to [safety](safety.md).\n")
+          "# Drive\nLoops back to [safety](safety.md). Duplicate-heading "
+          "anchor: [second](../CANONICAL.md#real-constants-1).\n")
     write(wiki / "nested" / "deep.md",
           FRONTMATTER + "# Deep\n[home](../home.md)\n")
     return repo

--- a/scripts/check_wiki_selftest.py
+++ b/scripts/check_wiki_selftest.py
@@ -30,7 +30,9 @@ EXPECTED_VIOLATIONS = {
     "broken anchor -> home.md#no-such-heading": "anchor with no matching heading",
     "broken anchor -> stale.md#in-fence":
         "a # line inside a code fence is not a heading",
-    "duplicate title": "two notes sharing one H1",
+    "duplicate title": "two notes sharing one H1 (one with leading spaces)",
+    "escape-sources.md: unknown source path":
+        "a declared source escaping the repo root",
     "deprecated phrase ('test-gate.sh')": "retired name reappearing",
     "nested/sub-orphan.md: orphan": "recursive discovery finds subdirectory notes",
 }
@@ -55,17 +57,21 @@ def build_violating_repo(root: Path) -> Path:
           "[safety](safety.md)\n"
           "[bad anchor](home.md#no-such-heading)\n"
           "[dup a](dup-a.md)\n[dup b](dup-b.md)\n[stale](stale.md)\n"
-          "[ghost](ghost-sources.md)\n")
+          "[ghost](ghost-sources.md)\n[escape](escape-sources.md)\n")
     write(wiki / "safety.md",
           "Cutoff at 10.5 V and caps at 60% live here.\n")
     write(wiki / "dup-a.md", FRONTMATTER + "# Same Title\n[home](home.md)\n")
-    write(wiki / "dup-b.md", FRONTMATTER + "# Same Title\n[home](home.md)\n")
+    write(wiki / "dup-b.md",
+          FRONTMATTER + "   # Same Title\n[home](home.md)\n")
     write(wiki / "stale.md",
           FRONTMATTER + "# Stale\nStill mentions test-gate.sh here.\n"
           "```\n# in fence\n```\n"
           "[fence anchor](stale.md#in-fence)\n")
     write(wiki / "ghost-sources.md",
           "---\nsources:\n  - docs/GONE.md\n---\n# Ghost\n[home](home.md)\n")
+    write(wiki / "escape-sources.md",
+          "---\nsources:\n  - ../../../outside.md\n---\n"
+          "# Escape\n[home](home.md)\n")
     write(wiki / "readme-only.md", FRONTMATTER + "# Readme only\n[home](home.md)\n")
     write(wiki / "orphan-note.md", FRONTMATTER + "# Orphan\n[home](home.md)\n")
     write(wiki / "island-one.md", FRONTMATTER + "# One\n[two](island-two.md)\n")

--- a/scripts/check_wiki_selftest.py
+++ b/scripts/check_wiki_selftest.py
@@ -1,4 +1,4 @@
-"""Self-test for the wiki lint (#145).
+"""Self-test for the wiki lint (#145, v2 #202).
 
 Builds a throwaway repo skeleton with one deliberate violation per check,
 asserts each fires, then asserts a clean skeleton passes. CI runs this
@@ -13,6 +13,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 from check_wiki import run  # noqa: E402
 
+FRONTMATTER = "---\nsources: none\n---\n"
+
 EXPECTED_VIOLATIONS = {
     "broken link -> missing-note.md": "note links to a file that does not exist",
     "broken link -> ../../../outside.md": "link escaping the repo root",
@@ -22,6 +24,13 @@ EXPECTED_VIOLATIONS = {
     "orphan": "note with no inbound wiki links",
     "island-one.md: not reachable": "linked pair disconnected from home",
     "readme-only.md: not reachable": "note linked only from README, not from home.md",
+    "no sources frontmatter": "note without a frontmatter sources block",
+    "unknown source path in frontmatter -> docs/GONE.md":
+        "declared source that does not exist",
+    "broken anchor -> home.md#no-such-heading": "anchor with no matching heading",
+    "duplicate title": "two notes sharing one H1",
+    "deprecated phrase ('test-gate.sh')": "retired name reappearing",
+    "nested/sub-orphan.md: orphan": "recursive discovery finds subdirectory notes",
 }
 
 
@@ -36,27 +45,50 @@ def build_violating_repo(root: Path) -> Path:
     write(root / "outside.md", "exists on disk, but outside the repo root\n")
     write(wiki / "README.md", "[home](home.md)\n[readme only](readme-only.md)\n")
     write(wiki / "home.md",
+          FRONTMATTER +
+          "# Home\n"
           "[gone](missing-note.md)\n"
           "[escape](../../../outside.md)\n"
           "[directory](../)\n"
-          "[safety](safety.md)\n")
-    write(wiki / "safety.md", "Cutoff at 10.5 V and caps at 60% live here.\n")
-    write(wiki / "readme-only.md", "[home](home.md)\n")
-    write(wiki / "orphan-note.md", "[home](home.md)\n")
-    write(wiki / "island-one.md", "[two](island-two.md)\n")
-    write(wiki / "island-two.md", "[one](island-one.md)\n")
+          "[safety](safety.md)\n"
+          "[bad anchor](home.md#no-such-heading)\n"
+          "[dup a](dup-a.md)\n[dup b](dup-b.md)\n[stale](stale.md)\n"
+          "[ghost](ghost-sources.md)\n")
+    write(wiki / "safety.md",
+          "Cutoff at 10.5 V and caps at 60% live here.\n")
+    write(wiki / "dup-a.md", FRONTMATTER + "# Same Title\n[home](home.md)\n")
+    write(wiki / "dup-b.md", FRONTMATTER + "# Same Title\n[home](home.md)\n")
+    write(wiki / "stale.md",
+          FRONTMATTER + "# Stale\nStill mentions test-gate.sh here.\n")
+    write(wiki / "ghost-sources.md",
+          "---\nsources:\n  - docs/GONE.md\n---\n# Ghost\n[home](home.md)\n")
+    write(wiki / "readme-only.md", FRONTMATTER + "# Readme only\n[home](home.md)\n")
+    write(wiki / "orphan-note.md", FRONTMATTER + "# Orphan\n[home](home.md)\n")
+    write(wiki / "island-one.md", FRONTMATTER + "# One\n[two](island-two.md)\n")
+    write(wiki / "island-two.md", FRONTMATTER + "# Two\n[one](island-one.md)\n")
+    write(wiki / "nested" / "sub-orphan.md",
+          FRONTMATTER + "# Nested orphan\n[home](../home.md)\n")
     return repo
 
 
 def build_clean_repo(root: Path) -> Path:
     repo = root / "repo"
     wiki = repo / "docs" / "wiki"
-    write(repo / "docs" / "CANONICAL.md", "The real constants live here.\n")
+    write(repo / "docs" / "CANONICAL.md",
+          "# Canonical\n\n## Real Constants\n\nThe real constants live here.\n")
     write(wiki / "README.md", "[home](home.md)\n")
-    write(wiki / "home.md", "[safety](safety.md)\n[drive](drive.md)\n")
+    write(wiki / "home.md",
+          FRONTMATTER + "# Home\n[safety](safety.md)\n[drive](drive.md)\n"
+          "[nested](nested/deep.md)\n")
     write(wiki / "safety.md",
-          "Thresholds: see [canonical](../CANONICAL.md). [drive](drive.md)\n")
-    write(wiki / "drive.md", "Loops back to [safety](safety.md).\n")
+          "---\nsources:\n  - docs/CANONICAL.md\n---\n"
+          "# Safety\nThresholds: see "
+          "[canonical](../CANONICAL.md#real-constants). [drive](drive.md)\n")
+    write(wiki / "drive.md",
+          "---\nsources:\n  - docs/CANONICAL.md\n---\n"
+          "# Drive\nLoops back to [safety](safety.md).\n")
+    write(wiki / "nested" / "deep.md",
+          FRONTMATTER + "# Deep\n[home](../home.md)\n")
     return repo
 
 


### PR DESCRIPTION
Closes #202

## Summary
`check_wiki.py` grows from four structural checks to the full v2 set:

- **Recursive discovery** (graph keyed by relative path; subdirectory notes covered by the selftest)
- **Heading-anchor validation** — `file.md#fragment` must match a real heading (GitHub slug rules)
- **Mandatory `sources:` frontmatter** on every note except README — each note declares the canonical paths it navigates to, and every declared path must exist; a vanished source fails the lint so the note gets reconsidered. `sources: none` for pure-navigation pages. **All 23 real notes gained honest sources in this PR** (each mapping hand-checked against the file inventory)
- **Duplicate-H1 detection** and a **curated deprecated-phrase list** (retired sketch name, retired gate filename, completed-phase framing) — the mechanical slice of "status contradictions"
- **Gitignored notes are skipped** — and Obsidian `Untitled*` scratch files are now gitignored repo-wide, which both un-reds the local lint permanently and structurally prevents the personal-file sweep that briefly hit PR #214 (recurrence of that mistake was caught pre-commit this time and is now impossible)
- Manifest validation deliberately NOT duplicated here — the #199 checker owns it

Selftest demonstrates every failure mode (14). Wiki README documents the frontmatter rule; CLAUDE.md gate list updated.

## Role
[C-Builder]

## Test plan
- Selftest: all failure modes fire on the violating fixture, clean fixture passes
- Real lint: fully green locally (first time — ignored-file noise gone) and against every real note's declared sources
- No firmware files touched — zero behavior change

Documentation receipt
- Areas changed: scripts/, docs/wiki/ (all notes + README), .gitignore, CLAUDE.md
- Pages examined/updated: wiki README (frontmatter rule), CLAUDE.md gate list, agent-governance (already describes wiki lint via README link — no change), TESTING.md (host-suite scope — no change)
- Unverifiable without hardware: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)