### PR TITLE
Semantic doc lint: the judgment half of doc-code sync (#200)

### DIFF
--- a/.claude/skills/semantic-doc-lint/SKILL.md
+++ b/.claude/skills/semantic-doc-lint/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: semantic-doc-lint
+description: The periodic semantic health review of the knowledge base — the judgment half that structural lint cannot do. Use when the monthly reminder issue appears, when the operator asks whether the docs still tell the truth, or after any large refactor lands. Read-only findings; fixes go through issues.
+---
+
+# Semantic documentation lint — does the prose still describe the code?
+
+Structural lint (`scripts/check_wiki.py`) proves the graph is healthy;
+the change-impact check (#199) proves changed areas were considered.
+Neither can judge whether a sentence is still TRUE. This procedure is that
+judgment pass. It reports; it never fixes inline.
+
+## 1. Walk the declared sources
+
+Every wiki note declares its `sources:` frontmatter (#202). For each note:
+read the note, read its sources, and ask of every claim that overlaps the
+source: is this still what the code/doc says? The two prior precedents to
+look for by class:
+- **Superseded claims** — code moved on, prose did not (the pre-#185
+  "tunables live in CLAUDE.md" class).
+- **Described-but-removed** — the note explains something that no longer
+  exists (the retired module-sections class).
+
+## 2. Cross-page contradiction sweep
+
+Compare notes that share a topic (the [authority-matrix](../../../docs/wiki/authority-matrix.md)
+rows are the topic list). Two pages answering the same question
+differently is a finding even when each cites a real source.
+
+## 3. Coverage gaps
+
+Grep the last month of `docs/DECISION-LOG.md` entries and merged PR titles
+for concepts mentioned repeatedly that have NO wiki page — recurring
+nouns without a home are the strongest signal a page is missing.
+
+## 4. Report — never fix inline
+
+For each finding: file ONE issue (label `documentation`) stating the page,
+the claim, what the source actually says, and the suggested correction.
+Then record a one-line receipt in `docs/DECISION-LOG.md`: date, notes
+walked, findings count, issue numbers (zero findings is also a record).
+Behavior-relevant discoveries follow the covenant's severity triage —
+a doc claiming something SAFER than the code does is operator-escalation,
+not just an issue.
+
+## Per-PR advisory layer (already standing)
+
+Between periodic runs, the same judgment runs in miniature on every PR:
+the `documentation-reviewer` agent in the pre-request self-review
+(prepare-pull-request skill, step 1) plus the #199 receipt requirement.
+This skill is the deep pass those quick passes cannot afford.

--- a/.github/workflows/semantic-lint-reminder.yml
+++ b/.github/workflows/semantic-lint-reminder.yml
@@ -1,0 +1,40 @@
+name: semantic-lint-reminder
+
+on:
+  schedule:
+    - cron: "0 14 1 * *"  # first of the month, 14:00 UTC
+  workflow_dispatch: {}
+
+jobs:
+  open-reminder:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open the monthly semantic-lint reminder issue (#200)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "Run the semantic documentation lint (monthly)";
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: "open", labels: "documentation", per_page: 100,
+            });
+            if (open.data.some(issue => issue.title === title)) {
+              core.info("Reminder already open — nothing to do.");
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner, repo: context.repo.repo,
+              title,
+              labels: ["documentation"],
+              body: [
+                "Monthly cadence for the judgment half of doc-code sync",
+                "(#200). Run the `semantic-doc-lint` skill:",
+                "walk every wiki note's declared sources, sweep for",
+                "cross-page contradictions, check for missing pages, file",
+                "one issue per finding, and record the receipt in",
+                "docs/DECISION-LOG.md. Close this issue when the receipt",
+                "is logged.",
+              ].join("\n"),
+            });

--- a/.github/workflows/semantic-lint-reminder.yml
+++ b/.github/workflows/semantic-lint-reminder.yml
@@ -16,11 +16,14 @@ jobs:
         with:
           script: |
             const title = "Run the semantic documentation lint (monthly)";
-            const open = await github.rest.issues.listForRepo({
-              owner: context.repo.owner, repo: context.repo.repo,
-              state: "open", labels: "documentation", per_page: 100,
-            });
-            if (open.data.some(issue => issue.title === title)) {
+            const open = await github.paginate(
+              github.rest.issues.listForRepo, {
+                owner: context.repo.owner, repo: context.repo.repo,
+                state: "open", labels: "documentation", per_page: 100,
+              });
+            // listForRepo returns PRs too — only true issues count.
+            if (open.some(issue => !issue.pull_request
+                                   && issue.title === title)) {
               core.info("Reminder already open — nothing to do.");
               return;
             }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,8 @@ Repeatable procedures are packaged as project skills in `.claude/skills/`
 - **wiki-impact-review** — diff → affected docs/wiki walk + receipt
 - **prepare-pull-request** — issue-first lifecycle: draft PR, review rounds,
   autonomous merge protocol
+- **semantic-doc-lint** — monthly judgment pass: do the docs still tell the
+  truth (reminder issue opens on a schedule, #200)
 
 Read-only reviewer subagents live in `.claude/agents/`:
 `architecture-reviewer`, `safety-reviewer`, `tests-reviewer`,

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,20 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-20 — semantic doc lint: the judgment half (#200)
+
+- New `semantic-doc-lint` skill: monthly deep pass walking every wiki
+  note's declared sources (#202 frontmatter is the input), sweeping for
+  cross-page contradictions (authority-matrix rows as the topic list) and
+  coverage gaps (recurring DECISION-LOG/PR nouns without a page); one
+  issue per finding + a dated receipt line here, never inline fixes;
+  safety-overclaiming docs escalate to the operator per the covenant
+  triage. A scheduled workflow (semantic-lint-reminder, monthly +
+  manual dispatch) opens the reminder issue when none is open. Per-PR
+  advisory layer = documentation-reviewer agent in the pre-request
+  self-review + the #199 receipt requirement — Phase F build items
+  complete.
+
 ## 2026-07-20 — wiki lint v2: sources frontmatter + semantic-adjacent checks (#202)
 
 - check_wiki.py extended: recursive note discovery (graph keyed by

--- a/docs/wiki/agent-governance.md
+++ b/docs/wiki/agent-governance.md
@@ -44,7 +44,11 @@ the Karpathy method (#53) plus the behavior-preservation covenant
   enforces the deterministic half (#199): the change-impact manifest
   (`docs/architecture/change-impact.json`) maps source areas to knowledge
   pages, and a PR touching a mapped area must update an affected page or
-  carry a documentation receipt
+  carry a documentation receipt. The judgment half (#200) is the
+  semantic-doc-lint skill — a monthly deep pass over every note's declared
+  sources (a scheduled workflow opens the reminder issue), with per-PR
+  coverage from the documentation-reviewer agent in the pre-request
+  self-review
 
 The [testing](testing.md) suites are the enforcement arm: expectations are
 law, and the gate defines "done" for any agent task.

--- a/docs/wiki/agent-governance.md
+++ b/docs/wiki/agent-governance.md
@@ -48,7 +48,7 @@ the Karpathy method (#53) plus the behavior-preservation covenant
   semantic-doc-lint skill — a monthly deep pass over every note's declared
   sources (a scheduled workflow opens the reminder issue), with per-PR
   coverage from the documentation-reviewer agent in the pre-request
-  self-review
+  self-review.
 
 The [testing](testing.md) suites are the enforcement arm: expectations are
 law, and the gate defines "done" for any agent task.


### PR DESCRIPTION
Closes #200

## Summary
The last Phase F build item — the judgment layer on top of the deterministic machinery:

- **`semantic-doc-lint` skill** — the monthly deep pass: walk every wiki note's declared `sources:` (the #202 frontmatter is the machine-readable input), judge whether overlapping claims still hold (the two known drift classes named as precedents), sweep for cross-page contradictions using the authority-matrix rows as the topic list, detect coverage gaps from recurring DECISION-LOG/PR nouns without a page. One issue per finding, a dated receipt in DECISION-LOG (zero findings is also a record), never inline fixes; a doc claiming something SAFER than the code escalates to the operator per the covenant triage.
- **`semantic-lint-reminder` workflow** — scheduled monthly (+ manual dispatch), opens the reminder issue when none is open; closing it requires the logged receipt.
- **Per-PR advisory layer documented**: the `documentation-reviewer` agent already runs in every pre-request self-review (amended protocol), and #199 enforces the receipt — this skill is the deep pass those quick passes cannot afford.

Advisory-first per the issue: nothing here blocks a merge; the deterministic authorities (#199, wiki lint, tests) remain the gates.

## Role
[B-Research]

## Test plan
- Docs + one scheduled workflow (no PR-blocking job); zero firmware change
- Wiki lint green; workflow YAML follows the existing minimal-permissions pattern (issues: write only)
- Self-review sweep pre-request: skills index, governance note, and log all updated together

Documentation receipt
- Areas changed: .claude/skills/, .github/workflows/, CLAUDE.md, docs/wiki/, DECISION-LOG
- Pages examined/updated: agent-governance (updated), CLAUDE.md skills index (updated), TESTING.md (no change — not a test gate)
- Unverifiable without hardware: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)