### PR TITLE
Tests mirror src/: five suites move under tests/domain/ (#195)

### DIFF
--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -10,7 +10,7 @@ Updated by session hooks — only technical content, no personal info.
 - Five pure-domain suites moved under tests/domain/ (battery, thermal,
   operator_input, drive, safety) so every suite sits at the path of the
   layer it tests; telemetry/ and alerts/ already mirrored. Pure git moves
-  + include-depth fix + Makefile glob/rule paths — ZERO expectation
+  plus include-depth fix plus Makefile glob/rule paths — ZERO expectation
   changes; full suite green (27 binaries, exit 0). TESTING.md tree
   redrawn (it had already drifted: alerts/ and test_observer_encoders
   were missing) and FILE-MAP line updated.

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,16 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-20 — tests/ mirrors src/ (#195)
+
+- Five pure-domain suites moved under tests/domain/ (battery, thermal,
+  operator_input, drive, safety) so every suite sits at the path of the
+  layer it tests; telemetry/ and alerts/ already mirrored. Pure git moves
+  + include-depth fix + Makefile glob/rule paths — ZERO expectation
+  changes; full suite green (27 binaries, exit 0). TESTING.md tree
+  redrawn (it had already drifted: alerts/ and test_observer_encoders
+  were missing) and FILE-MAP line updated.
+
 ## 2026-07-20 — semantic doc lint: the judgment half (#200)
 
 - New `semantic-doc-lint` skill: monthly deep pass walking every wiki

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -12,8 +12,8 @@ them green, proving behavior parity while no hardware is available.
 The production sketch is not modified for testing. Each test binary compiles
 `sketches/dual_track_control/dual_track_control.ino` directly, plus the extracted
 `sketches/dual_track_control/src/**/*.cpp` domain sources the sketch delegates to as the
-Phase D migration (#117) proceeds. Pure-domain suites (one dir per extracted
-domain, e.g. `battery/`) test the extracted code directly — no firmware, no
+Phase D migration (#117) proceeds. Pure suites live at the path of the
+layer they test — the tree MIRRORS `src/` (#195) — with no firmware, no
 stubs, and no `src/infrastructure/` sources (those include hardware headers
 and are compiled only into the stub-backed firmware suites, #172):
 
@@ -29,27 +29,24 @@ tests/
 │   ├── WDT.h                   counts refresh() calls
 │   ├── sbus.h                  scripted S.BUS frames (bfs::SbusRx/SbusData)
 │   └── SerialPortStub.h        Serial/Serial1/UART fakes — scripted RX, captured TX
-├── characterization/
-│   ├── FirmwareUnderTest.h     includes the REAL dual_track_control.ino + firmware state reset
+├── characterization/           cross-cutting: compiles the REAL firmware
+│   ├── FirmwareUnderTest.h     includes dual_track_control.ino + state reset
 │   └── test_*.cpp              one focused suite per behavior area
-├── invariants/
-│   ├── InvariantChecks.h       reusable safety-invariant checkers + loop driver (#131)
+├── invariants/                 cross-cutting: safety properties under faults
+│   ├── InvariantChecks.h       reusable checkers + loop driver (#131)
 │   └── test_invariant_*.cpp    one property suite per safety invariant
-├── battery/                    pure-domain suites for src/domain/battery/ (#117)
-│   ├── test_voltage_plausibility.cpp
-│   └── test_battery_ladder_domain.cpp
-├── thermal/                    pure-domain suite for src/domain/thermal/ (#117)
-│   └── test_thermal_domain.cpp
-├── telemetry/                  pure suite for src/telemetry/ (#117)
-│   └── test_telemetry_scaling.cpp
-├── operator_input/             pure-domain suite for src/domain/operator_input/ (#117)
-│   └── test_operator_input_domain.cpp
-├── drive/                      pure-domain suites for src/domain/drive/ (#117)
-│   ├── test_curvature_drive_domain.cpp
-│   └── test_gear_mixer_domain.cpp
-└── safety/                     pure-domain suites for src/domain/safety/ (#117)
-    ├── test_safety_supervisor_domain.cpp
-    └── test_output_gate_domain.cpp
+├── domain/                     mirrors src/domain/ (#195)
+│   ├── battery/                test_voltage_plausibility,
+│   │                           test_battery_ladder_domain
+│   ├── thermal/                test_thermal_domain
+│   ├── operator_input/         test_operator_input_domain
+│   ├── drive/                  test_curvature_drive_domain,
+│   │                           test_gear_mixer_domain
+│   └── safety/                 test_safety_supervisor_domain,
+│                               test_output_gate_domain
+├── telemetry/                  mirrors src/telemetry/: test_telemetry_scaling,
+│                               test_observer_encoders
+└── alerts/                     mirrors src/alerts/: test_alert_policy_domain
 ```
 
 The stub headers shadow the real Arduino/library headers via include order

--- a/docs/architecture/FILE-MAP.md
+++ b/docs/architecture/FILE-MAP.md
@@ -40,7 +40,7 @@ docs/TESTING.md                          — Host characterization + invariants 
 docs/SAFETY.md                           — Safety-invariant registry: propulsion-path invariants + test links (#131)
 docs/AGENT-EXAMPLES.md                   — Good/bad task-execution pairs for AI agents (#53, real precedents)
 docs/wiki/                               — AI-maintained knowledge graph (Obsidian-visualizable, links-only — no constants; #141)
-tests/                                   — Host test harness: stub Arduino env + doctest suites (characterization/ + invariants/ + per-domain, e.g. battery/)
+tests/                                   — Host test harness: stub Arduino env + doctest suites (characterization/ + invariants/ cross-cutting; domain/ + telemetry/ + alerts/ mirror src/, #195)
 .claude/skills/                          — Project skills (#127): safety-review, flash-and-log, new-module, field-tune, wiki-impact-review, prepare-pull-request (one procedure per folder)
 .claude/agents/                          — Read-only reviewer subagents (#127): architecture, safety, tests, documentation
 .githooks/pre-commit                     — Commit-time test gate (activate: git config core.hooksPath .githooks)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 # Host test suites: characterization (#47) + safety invariants (#131) +
-# pure-domain suites (one dir per extracted domain, #117 — e.g. battery/).
+# pure-domain suites mirroring src/ (#195 — e.g. domain/battery/).
 # One binary per test file — characterization/invariants compile the REAL
 # dual_track_control.ino inside the stub Arduino environment (see stubs/); pure-domain
 # suites compile only the extracted src/ code WITHOUT -Istubs, so an
@@ -35,12 +35,12 @@ HARNESS  := $(wildcard stubs/*.h) characterization/FirmwareUnderTest.h \
 
 TESTS := $(wildcard characterization/test_*.cpp) \
          $(wildcard invariants/test_*.cpp) \
-         $(wildcard battery/test_*.cpp) \
-         $(wildcard thermal/test_*.cpp) \
+         $(wildcard domain/battery/test_*.cpp) \
+         $(wildcard domain/thermal/test_*.cpp) \
          $(wildcard telemetry/test_*.cpp) \
-         $(wildcard operator_input/test_*.cpp) \
-         $(wildcard drive/test_*.cpp) \
-         $(wildcard safety/test_*.cpp) \
+         $(wildcard domain/operator_input/test_*.cpp) \
+         $(wildcard domain/drive/test_*.cpp) \
+         $(wildcard domain/safety/test_*.cpp) \
          $(wildcard alerts/test_*.cpp)
 BINS  := $(addprefix build/,$(notdir $(TESTS:.cpp=)))
 
@@ -65,11 +65,11 @@ build/%: invariants/%.cpp $(HARNESS) $(FIRMWARE)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(INCLUDES) $< $(SKETCH_SRC_CPPS) -o $@
 
-build/%: battery/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
+build/%: domain/battery/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
-build/%: thermal/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
+build/%: domain/thermal/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
@@ -77,15 +77,15 @@ build/%: telemetry/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
-build/%: operator_input/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
+build/%: domain/operator_input/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
-build/%: drive/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
+build/%: domain/drive/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 
-build/%: safety/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
+build/%: domain/safety/%.cpp $(SKETCH_PURE_CPPS) $(SKETCH_SRC_HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) $(DOMAIN_INCLUDES) $< $(SKETCH_PURE_CPPS) -o $@
 

--- a/tests/domain/battery/test_battery_ladder_domain.cpp
+++ b/tests/domain/battery/test_battery_ladder_domain.cpp
@@ -12,7 +12,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-#include "../../sketches/dual_track_control/src/domain/battery/BatteryLadder.h"
+#include "../../../sketches/dual_track_control/src/domain/battery/BatteryLadder.h"
 
 // Values mirror ECO_LOCK_THRESH_V / ECO_LOCK_DEBOUNCE_MS / CUTOFF_THRESH_V /
 // CUTOFF_DEBOUNCE_MS — but they are parameters here: the domain functions

--- a/tests/domain/battery/test_voltage_plausibility.cpp
+++ b/tests/domain/battery/test_voltage_plausibility.cpp
@@ -10,7 +10,7 @@
 
 #include <cmath>
 
-#include "../../sketches/dual_track_control/src/domain/battery/VoltagePlausibility.h"
+#include "../../../sketches/dual_track_control/src/domain/battery/VoltagePlausibility.h"
 
 // Bounds mirror LOWV_PLAUS_MIN_V / LOWV_PLAUS_MAX_V — but they are
 // parameters here: the domain function has no config dependency.

--- a/tests/domain/drive/test_curvature_drive_domain.cpp
+++ b/tests/domain/drive/test_curvature_drive_domain.cpp
@@ -14,7 +14,7 @@
 
 #include <cmath>
 
-#include "../../sketches/dual_track_control/src/domain/drive/CurvatureDrive.h"
+#include "../../../sketches/dual_track_control/src/domain/drive/CurvatureDrive.h"
 
 // Values mirror [CONFIG] — parameters here, no config dependency.
 const CurvatureParameters NORMAL_PARAMETERS{0.60f, 0.70f, 0.05f, 0.55f, 0.70f};

--- a/tests/domain/drive/test_gear_mixer_domain.cpp
+++ b/tests/domain/drive/test_gear_mixer_domain.cpp
@@ -9,8 +9,8 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-#include "../../sketches/dual_track_control/src/domain/drive/CommandMixer.h"
-#include "../../sketches/dual_track_control/src/domain/drive/GearPolicy.h"
+#include "../../../sketches/dual_track_control/src/domain/drive/CommandMixer.h"
+#include "../../../sketches/dual_track_control/src/domain/drive/GearPolicy.h"
 
 // Values mirror [CONFIG] — parameters here, no config dependency.
 const GearPolicyParameters GEAR_PARAMETERS{0.65f, 0.80f, 1.00f, 1400, 1600};

--- a/tests/domain/operator_input/test_operator_input_domain.cpp
+++ b/tests/domain/operator_input/test_operator_input_domain.cpp
@@ -10,8 +10,8 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-#include "../../sketches/dual_track_control/src/domain/operator_input/DeadbandPolicy.h"
-#include "../../sketches/dual_track_control/src/domain/operator_input/ExpoCurve.h"
+#include "../../../sketches/dual_track_control/src/domain/operator_input/DeadbandPolicy.h"
+#include "../../../sketches/dual_track_control/src/domain/operator_input/ExpoCurve.h"
 
 // Values mirror the [CONFIG] pairs — parameters here, no config dependency.
 const float EXPO_THROTTLE_LINEAR = 0.4f;

--- a/tests/domain/safety/test_output_gate_domain.cpp
+++ b/tests/domain/safety/test_output_gate_domain.cpp
@@ -8,7 +8,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-#include "../../sketches/dual_track_control/src/domain/safety/OutputGate.h"
+#include "../../../sketches/dual_track_control/src/domain/safety/OutputGate.h"
 
 // Values mirror SVC / CUTOFF_HOLD_MS — parameters here.
 const int NEUTRAL = 1500;

--- a/tests/domain/safety/test_safety_supervisor_domain.cpp
+++ b/tests/domain/safety/test_safety_supervisor_domain.cpp
@@ -7,7 +7,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-#include "../../sketches/dual_track_control/src/domain/safety/SafetySupervisor.h"
+#include "../../../sketches/dual_track_control/src/domain/safety/SafetySupervisor.h"
 
 // SafetyInputs positional order:
 // {rcValid, batteryConfirmed, bootGraceElapsed, batteryCutoffLatched,

--- a/tests/domain/thermal/test_thermal_domain.cpp
+++ b/tests/domain/thermal/test_thermal_domain.cpp
@@ -11,8 +11,8 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-#include "../../sketches/dual_track_control/src/domain/thermal/ThermalDerating.h"
-#include "../../sketches/dual_track_control/src/domain/thermal/ThermalHysteresis.h"
+#include "../../../sketches/dual_track_control/src/domain/thermal/ThermalDerating.h"
+#include "../../../sketches/dual_track_control/src/domain/thermal/ThermalHysteresis.h"
 
 // Values mirror TEMP_*_ON_C / TEMP_*_OFF_C / TEMP_DEBOUNCE_MS /
 // TEMP_PLAUS_MIN_C / TEMP_PLAUS_MAX_C — but they are parameters here: the


### PR DESCRIPTION
Closes #195

## Summary
Every host suite now sits at the path of the layer it tests:

- `tests/{battery,thermal,operator_input,drive,safety}/` → **`tests/domain/<name>/`** (pure git renames; `telemetry/` and `alerts/` already mirrored `src/telemetry/` and `src/alerts/`)
- Include depth fixed in the moved files; Makefile globs and pattern rules updated (asserted replacements after an earlier silent-miss taught the lesson)
- `characterization/` and `invariants/` stay top-level as the cross-cutting firmware suites — that split is the documented design
- **Zero expectation changes** — the covenant bar: the pre-commit gate ran the full suite during the commit, all binaries green
- TESTING.md tree redrawn — and it had already drifted (missing `alerts/` and `test_observer_encoders`), so the redraw also fixes real doc rot; FILE-MAP line updated

## Role
[C-Builder]

## Test plan
- `wsl -e make -C tests run`: exit 0, full binary set, zero expectation diffs (visible in the commit's gate output)
- CI `unit-tests` runs the same suite on this PR
- No firmware sources touched — pure test-tree reorganization

Documentation receipt
- Areas changed: tests/
- Pages examined/updated: docs/TESTING.md (tree redrawn), docs/architecture/FILE-MAP.md (updated), docs/wiki/testing.md (sources frontmatter lists tests/ — still valid, content links unaffected)
- Unverifiable without hardware: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)