### PR TITLE
Repo front door: ARCHITECTURE.md + CONTRIBUTING.md (#126)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,11 @@
 # Contributing
 
 The human mirror of the agent-facing rules (`CLAUDE.md`, `.claude/rules/`,
-`.claude/skills/`). Same law, different audience. When this page and a rule
-file disagree, the rule file wins — file the discrepancy.
+`.claude/skills/`). Same law, different audience. When this page disagrees with the law
+layer, the law wins — the path-scoped rules, and above them the canonical
+spec (`docs/architecture/ARCHITECTURE-TARGET.md`); the full hierarchy is
+[docs/wiki/authority-matrix.md](docs/wiki/authority-matrix.md). File the
+discrepancy either way.
 
 This firmware drives a real machine with a child rider. The bar for every
 change is: **the machine behaves exactly as reviewed, and every behavior

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing
+
+The human mirror of the agent-facing rules (`CLAUDE.md`, `.claude/rules/`,
+`.claude/skills/`). Same law, different audience. When this page and a rule
+file disagree, the rule file wins — file the discrepancy.
+
+This firmware drives a real machine with a child rider. The bar for every
+change is: **the machine behaves exactly as reviewed, and every behavior
+change is deliberate, discussed, and test-locked.**
+
+## Real-time rules (the control loop)
+
+- No blocking calls in `loop()`: no `delay()`, no `pulseIn()`, no unbounded
+  `while`. Non-blocking state machines only.
+- `constrain()` every value before `writeMicroseconds()`.
+- Every independent input path gets its own timeout that returns to
+  neutral on loss.
+- `micros()` is read fresh at the point of use.
+- The watchdog is refreshed exactly once per pass, after the control path —
+  never add a second refresh point.
+- Float literals carry `f` (`1.0f`) — `double` is software-emulated on the
+  RA4M1.
+
+## Where things go
+
+- Architecture layers and the dependency direction:
+  [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) (narrative) and
+  `.claude/rules/architecture.md` (law). One file = one concept, 150-line
+  soft / 250-line hard limit, full-word names.
+- Every tunable lives in `sketches/dual_track_control/src/config/`
+  (adapter-local knobs stay with their adapter). Docs describe behavior,
+  never live numbers.
+- Tests mirror the source tree under `tests/` and compile the REAL
+  firmware — see [docs/TESTING.md](docs/TESTING.md).
+
+## Workflow
+
+1. **Issue first.** Every change attaches to an open GitHub issue; one PR
+   per issue.
+2. **Draft PR immediately** on branch `agent/<role>/<description>` (humans:
+   any clear branch name) with `Closes #N`, a summary, and a test plan.
+   Active work must be visible on the project board.
+3. **The gate**, before every push:
+   - host suites green: `wsl -e make -C tests run` (Linux/macOS: plain
+     `make -C tests run`)
+   - firmware compiles:
+     `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/dual_track_control`
+   - the commit hook is active: `git config core.hooksPath .githooks`
+     (it hard-blocks red tests and firmware changes without test changes)
+4. **A changed test expectation is a behavior change** — it needs its own
+   issue and operator sign-off BEFORE code. Characterization expectations
+   are law, including float32 rounding points and hysteresis holds.
+5. **Every firmware flash gets a row** in
+   [docs/FIRMWARE-UPLOAD-LOG.md](docs/FIRMWARE-UPLOAD-LOG.md) immediately —
+   an unlogged flash is treated as not done.
+6. Commit messages: `V{major}.{minor}: {imperative verb} {what changed}`
+   for firmware; plain imperative for tooling/docs.
+
+## Documentation travels with code
+
+A PR touching a mapped source area must update the pages that describe it
+or carry an explicit documentation receipt — CI enforces this via
+`docs/architecture/change-impact.json`. The wiki (`docs/wiki/`) is a
+navigation layer: notes declare their sources and never restate tunable
+values.
+
+## Running the CI checks locally
+
+```sh
+python scripts/check_architecture.py     # layer/size/naming fitness
+python scripts/check_wiki.py             # wiki graph + sources health
+python scripts/check_change_impact.py    # doc-impact (vs origin/main)
+python scripts/check_hook_registration.py
+python scripts/generate_web_page.py --check
+make -C tests run
+```
+
+The dashboard is generated: edit `dashboard/index.html`, never
+`web_page.h`.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ python live_plot.py
 
 | Doc | What's inside |
 | --- | --- |
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | How the code is shaped and why — pipeline, safety model, key decisions |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Real-time rules, workflow, and how to run every check locally |
 | [`PROJECT-PLAN.md`](PROJECT-PLAN.md) | Full technical specification and pin map |
 | [`OPERATOR-GUIDE.md`](OPERATOR-GUIDE.md) | Plain-language guide for the RC operator and the rider |
 | [`docs/WIRING-GUIDE-V8.md`](docs/WIRING-GUIDE-V8.md) | Canonical hardware wiring reference |
@@ -176,9 +178,11 @@ python live_plot.py
 | [`docs/XBUS-PROTOCOL.md`](docs/XBUS-PROTOCOL.md) | X.BUS telemetry protocol reference |
 | [`docs/DECISION-LOG.md`](docs/DECISION-LOG.md) | Technical decision history |
 
-The main firmware is [`sketches/dual_track_control/dual_track_control.ino`](sketches/dual_track_control/dual_track_control.ino),
-organized into searchable `[MODULE]` sections (`[CONFIG]`, `[DRIVE]`, `[RC]`,
-`[JOYSTICK]`, `[GEAR]`, `[MIXER]`, `[OUTPUT]`, `[TELEMETRY]`, `[WIFI]`, `[DEBUG]`).
+The main firmware entry is
+[`sketches/dual_track_control/dual_track_control.ino`](sketches/dual_track_control/dual_track_control.ino) —
+a twelve-line composition root; the code lives in layers under its `src/`
+(domain / application / ports / infrastructure — see
+[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ down. Boost is already at the rail, so it has no extra turn headroom.
 | **Boost** | Fastest | Full authority (at the rail — no turn headroom) |
 
 Reverse is additionally capped below forward speed per gear, and pivot rotation
-has its own speed cap. The exact percentages are tunables — see the current
-values in `[CONFIG]` (`sketches/dual_track_control/dual_track_control.ino`) and the operator-facing
-table in [OPERATOR-GUIDE.md](OPERATOR-GUIDE.md).
+has its own speed cap. The exact percentages are tunables — the current values
+live in `sketches/dual_track_control/src/config/`, and the operator-facing
+table is in [OPERATOR-GUIDE.md](OPERATOR-GUIDE.md).
 
 ---
 
@@ -180,7 +180,7 @@ python live_plot.py
 
 The main firmware entry is
 [`sketches/dual_track_control/dual_track_control.ino`](sketches/dual_track_control/dual_track_control.ino) —
-a twelve-line composition root; the code lives in layers under its `src/`
+a small composition root; the code lives in layers under its `src/`
 (domain / application / ports / infrastructure — see
 [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,104 @@
+# Architecture — how the code is shaped, and why
+
+Written for a human engineer landing on the repo. The machine-checked
+contracts live elsewhere (spec: [ARCHITECTURE-TARGET](architecture/ARCHITECTURE-TARGET.md),
+inventory: [FILE-MAP](architecture/FILE-MAP.md), authority hierarchy:
+[authority-matrix](wiki/authority-matrix.md)); this page is the narrative.
+
+## The shape
+
+The production sketch's `.ino` is twelve lines: it includes the application
+layer and delegates `setup()`/`loop()`. Everything real lives under
+`sketches/dual_track_control/src/` in one-way layers:
+
+```text
+.ino ─▶ application ─▶ domain      (pure logic: battery, thermal,
+              │        operator_input, drive, safety — no hardware
+              │        includes, time passed as a parameter)
+              ├──────▶ ports       (hardware contracts, link-time seams)
+              ├──────▶ telemetry   (read-only observers of one snapshot)
+              ├──────▶ alerts      (beep policy + pattern players)
+              └──────▶ config      (every tunable, per domain)
+        infrastructure ─▶ ports    (the ONLY layer with hardware includes:
+                                    Arduino core, S.BUS, X.BUS, Wi-Fi)
+```
+
+Domain logic is host-testable by construction: the test suites compile the
+REAL firmware against a stub Arduino environment, and the pure-domain
+suites compile without stubs at all — an accidental hardware include fails
+the build loudly ([TESTING](TESTING.md)).
+
+## The signal pipeline
+
+One loop pass, in order (full walk with ordering invariants:
+[application-loop](wiki/application-loop.md)):
+
+1. **Inputs** — S.BUS frame (all channels in one frame, one freshness
+   timeout) and the 14-bit joystick ADC on its own cadence.
+2. **Protection ladders** — battery Eco-lock and cutoff, thermal stages —
+   run BEFORE gear selection so a lock can force Eco.
+3. **Shaping and mixing** — deadband, per-axis expo, then one
+   `curvatureDrive` pass over the combined RC+joystick command: the gear
+   cap bounds the AVERAGE track speed (the outer track keeps turn
+   headroom), pivot mode blends in smoothly at standstill.
+4. **Safety decision + output gate** — drive-allowed is decided from RC
+   freshness, battery confirmation, the cutoff latch, and the thermal cut;
+   the gate executes ACTIVE → ease-to-neutral → CUT (ESCs lose signal and
+   failsafe), re-attaching on recovery.
+5. **Watchdog refresh — the only refresh point, directly after the control
+   path.** Any stall below misses it, the MCU resets, PWM stops, the
+   machine stops. This is the runaway backstop.
+6. **Observers** — X.BUS telemetry poll and the Wi-Fi dashboard, both
+   strictly read-only with respect to control.
+
+Current values for every threshold and cap live in
+`sketches/dual_track_control/src/config/` — no document carries a live
+copy, by rule.
+
+## The safety model
+
+- **Battery ladder** (three escalating stages: Eco lock, audible alarm,
+  latched motor cutoff) with a plausibility filter so garbage telemetry
+  can neither trip nor release it, and a boot gate so a drained pack
+  cannot drive after a reset wipes the latch.
+- **Thermal stages** with hysteresis — a stage releases at a lower
+  temperature than it trips, so the machine never oscillates at a
+  boundary; the thermal cut auto-recovers when the motor cools.
+- **Output gate state machine** — neutral is commanded and held before PWM
+  is cut, so the ESC decelerates smoothly instead of freewheeling.
+- **Hardware watchdog** armed after init, refreshed exactly once per pass.
+- **Two permanent invariants**: control is open-loop (telemetry never
+  feeds throttle — a bad sensor cannot command motion), and there is no
+  control path over Wi-Fi (the dashboard can only watch). Both are locked
+  by executable invariant tests ([SAFETY](SAFETY.md)).
+
+Every invariant maps to a host test that drives the real `loop()` under
+injected faults and re-checks the property after every pass.
+
+## Key decisions, with receipts
+
+Dated rationale lives in [DECISION-LOG](DECISION-LOG.md); the big ones:
+
+- **FOC in the ESC, not PID on the Arduino** — the GL10's internal
+  field-oriented control owns motor smoothness, so the Arduino-side
+  dual-loop PID plan was retired and the firmware's job shrank to
+  shaping, mixing, capping, and gating (2026-04-25).
+- **Telemetry via X.BUS Read Register, never bulk throttle** — the
+  read-only service function preserves full PWM control authority; the
+  bulk function would seize it.
+- **Hardware UARTs only for telemetry** — bit-banged serial input is
+  banned on the control board.
+- **Bounded Wi-Fi serving** — capped modem writes, ETag/304 caching, and
+  incremental page transfer keep the dashboard from ever stalling the
+  control loop (the watchdog would catch it; the design avoids it).
+
+## What runs where
+
+- **RA4M1 (the Arduino's Cortex-M4)** — everything in this repo's `src/`:
+  the pipeline, ladders, gate, watchdog, telemetry poll, HTTP/SSE serving.
+- **ESP32-S3 (the UNO R4 WiFi's radio coprocessor)** — the Wi-Fi modem,
+  driven through the core's AT-command bridge; no application code runs
+  there today.
+- **GL10 ESCs** — field-oriented commutation, acceleration and drag-brake
+  shaping, and their own low-voltage/thermal protections, all internal;
+  the Arduino speaks plain 50 Hz servo PWM to them.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,8 +7,9 @@ inventory: [FILE-MAP](architecture/FILE-MAP.md), authority hierarchy:
 
 ## The shape
 
-The production sketch's `.ino` is twelve lines: it includes the application
-layer and delegates `setup()`/`loop()`. Everything real lives under
+The production sketch's `.ino` is a small composition root: it includes
+the application layer, delegates `setup()`/`loop()`, and does nothing
+else. Everything real lives under
 `sketches/dual_track_control/src/` in one-way layers:
 
 ```text
@@ -22,6 +23,10 @@ layer and delegates `setup()`/`loop()`. Everything real lives under
         infrastructure ─▶ ports    (the ONLY layer with hardware includes:
                                     Arduino core, S.BUS, X.BUS, Wi-Fi)
 ```
+
+One sanctioned read-back: the telemetry and alert observers read a single
+application-owned struct (the SystemSnapshot) — a data edge by design,
+not a dependency inversion.
 
 Domain logic is host-testable by construction: the test suites compile the
 REAL firmware against a stub Arduino environment, and the pure-domain
@@ -58,19 +63,24 @@ copy, by rule.
 ## The safety model
 
 - **Battery ladder** (three escalating stages: Eco lock, audible alarm,
-  latched motor cutoff) with a plausibility filter so garbage telemetry
-  can neither trip nor release it, and a boot gate so a drained pack
-  cannot drive after a reset wipes the latch.
+  motor cutoff that LATCHES until power-cycle) with a plausibility filter
+  so garbage telemetry can neither trip nor release it. A boot gate holds
+  drive until a valid reading confirms the pack after a reset wipes the
+  latch — and deliberately fails OPEN if telemetry never reports, so a
+  dead sensor bus cannot permanently disable driving.
 - **Thermal stages** with hysteresis — a stage releases at a lower
   temperature than it trips, so the machine never oscillates at a
-  boundary; the thermal cut auto-recovers when the motor cools.
+  boundary; unlike the battery cutoff, the thermal cut auto-recovers when
+  the motor cools and the gate re-attaches the ESCs (RC-loss recovery
+  behaves the same way).
 - **Output gate state machine** — neutral is commanded and held before PWM
   is cut, so the ESC decelerates smoothly instead of freewheeling.
-- **Hardware watchdog** armed after init, refreshed exactly once per pass.
-- **Two permanent invariants**: control is open-loop (telemetry never
-  feeds throttle — a bad sensor cannot command motion), and there is no
-  control path over Wi-Fi (the dashboard can only watch). Both are locked
-  by executable invariant tests ([SAFETY](SAFETY.md)).
+- **Three permanent invariants**: control is open-loop (telemetry never
+  feeds throttle — a bad sensor cannot command motion); there is no
+  control path over Wi-Fi (the dashboard can only watch); and the
+  hardware watchdog is refreshed exactly once per pass, directly after
+  the control path — never anywhere else. All are locked by executable
+  invariant tests ([SAFETY](SAFETY.md)).
 
 Every invariant maps to a host test that drives the real `loop()` under
 injected faults and re-checks the property after every pass.

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,17 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-20 — repo front door: ARCHITECTURE.md + CONTRIBUTING.md (#126)
+
+- docs/ARCHITECTURE.md: human-facing narrative (layer shape, signal
+  pipeline with the ordering invariants, safety model incl. the two
+  permanent invariants and why, key decisions with DECISION-LOG receipts,
+  RA4M1/ESP32-S3/GL10 split) — behavior only, no live values, per the
+  authority matrix. CONTRIBUTING.md: human mirror of the agent rules
+  (real-time law, placement, workflow incl. the flash-log rule, local
+  check commands). README's stale [MODULE]-sections paragraph replaced
+  with the composition-root description and both docs linked.
+
 ## 2026-07-20 — tests/ mirrors src/ (#195)
 
 - Five pure-domain suites moved under tests/domain/ (battery, thermal,

--- a/docs/architecture/FILE-MAP.md
+++ b/docs/architecture/FILE-MAP.md
@@ -7,6 +7,8 @@ home. Layer rules live in `.claude/rules/architecture.md`; the canonical
 architecture spec is [ARCHITECTURE-TARGET.md](ARCHITECTURE-TARGET.md).
 
 ```text
+docs/ARCHITECTURE.md                     — Human-facing narrative: shape, pipeline, safety model, decisions (#126)
+CONTRIBUTING.md                          — Human mirror of the agent rules: real-time law, workflow, local checks (#126)
 PROJECT-PLAN.md                          — Full technical specification
 OPERATOR-GUIDE.md                        — User guide for Jason (RC) and Malaki (joystick)
 sketches/dual_track_control/dual_track_control.ino             — COMPOSITION ROOT ONLY (#189): includes src/application/FirmwareApp.h and delegates setup()/loop(); the firmware lives under src/

--- a/docs/wiki/architecture-overview.md
+++ b/docs/wiki/architecture-overview.md
@@ -38,4 +38,6 @@ lives under `src/` in layers with a one-way dependency direction:
 - Annotated file inventory: [FILE-MAP](../architecture/FILE-MAP.md)
 - Mechanical enforcement: the architecture-fitness CI workflow
   (layer/size/naming rules) — see [testing](testing.md) for the gate list
+- Human-facing narrative of all of the above:
+  [ARCHITECTURE](../ARCHITECTURE.md) (#126)
 - Which artifact wins for what: [authority-matrix](authority-matrix.md)


### PR DESCRIPTION
Closes #126

## Summary
The two human-facing documents the issue called the missing presentation layer:

- **`docs/ARCHITECTURE.md`** — the narrative for an engineer landing on the repo: the layer shape, the signal pipeline in loop order (with its two ordering invariants), the safety model as a first-class section (ladder, thermal hysteresis, output gate, watchdog, the two permanent invariants and WHY), key decisions with DECISION-LOG receipts, and the RA4M1 / ESP32-S3 / GL10 split. Behavior only — no live values, per the authority matrix (the issue's example numbers deliberately not hardcoded; the config layer is the authority).
- **`CONTRIBUTING.md`** — the human mirror of the agent rules: real-time law, placement rules, the issue→draft-PR→board workflow, expectation-changes-are-behavior-changes, the flash-log rule, and copy-paste commands to run every CI check locally.
- **README** — both linked at the top of the docs table, and its stale `[MODULE]`-sections paragraph (the #194 class, outside that PR's scope) replaced with the composition-root description.
- FILE-MAP and the wiki architecture-overview note link the narrative; agent files stay the enforcement layer and now have a presentation layer to point at.

## Role
[A-Content]

## Test plan
- Docs-only; zero firmware change; wiki lint green
- Self-review pre-request: every claim in ARCHITECTURE.md cross-checked against the wiki pages verified earlier this session (loop order against FirmwareApp.cpp); no tunable values anywhere

Documentation receipt
- Areas changed: docs/, root markdown
- Pages examined/updated: README (stale paragraph fixed + links), FILE-MAP (entries), wiki architecture-overview (link); CLAUDE.md examined — already points at rules/skills, no duplication introduced
- Unverifiable without hardware: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive contribution guidelines covering development workflow, firmware safety constraints, testing, flashing, commits, and documentation updates.
  - Added an architecture guide describing the firmware layers, control-loop flow, safety model, hardware responsibilities, and key design decisions.
  - Updated the README, architecture file map, decision log, and wiki links to improve documentation discoverability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->