### PR TITLE
White-label branding: one BRANDING block drives the dashboard skin (#136)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3,12 +3,31 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<title>Malaki SuperTracks</title>
+<title>Dashboard</title>
+<!-- ═══ BRANDING (#136) — the ONLY place product identity lives ═══
+     White-label platform: swap the skin by editing ONLY this block; nothing
+     below hardcodes these values. The logo/badge asset is the
+     apple-touch-icon data URI below — swap the image to re-badge.
+     Example skin — "Malaki SuperTracks":
+       name: 'MALAKI SUPERTRACKS', tagline: 'EXCAVATOR COMMAND',
+       appTitle: 'Digger', accent: '#f0a000',
+       accentGlow: 'rgba(240,160,0,0.4)', accentDim: '#3a2a10'          -->
+<script>
+const BRANDING = {
+  name:       'DUAL TRACK CONTROL',   // title banner + browser tab
+  tagline:    'VEHICLE COMMAND',      // subtitle under the banner
+  appTitle:   'Dashboard',            // home-screen app name (meta below)
+  accent:     '#f0a000',              // title color + underline center
+  accentGlow: 'rgba(240,160,0,0.4)',  // title glow
+  accentDim:  '#3a2a10'               // underline edge fade
+};
+document.title = BRANDING.name;
+</script>
 <!-- Installable home-screen app: launches standalone (no browser chrome) on iOS/iPadOS. -->
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-<meta name="apple-mobile-web-app-title" content="Digger">
+<meta name="apple-mobile-web-app-title" content="Dashboard">
 <meta name="theme-color" content="#0a0b0d">
 <link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAZUSURBVHhe7d2vjx1VGMbxbQulQNulDSEIECQEUUMCpgIBAgSihhBMDSGYChKCAEEChhAECBKCqGmCQuJwOBwOh8Ph+A8ueXbZdPede/fO3HNm7nmf8xUf0+6Pe+d+xczsO+ccXD+8uQJcHMR/ADIjaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFgh6IW8+PxTg39DfQS9gOeevbH687uLq1svEPXcCHoBP3z42OrfBwerXz59dPB/qIugZ/b6y9ePYj5x942rg69BPQQ9s9+/unQm6L++v7h65ukbg69DHQQ9o4/vPHEm5hPfvn9l8LWog6Bnorsa/9y/MIj5xO1bh4PvQTmCnsnPn1weRHyaTkXi96AcQc/g3deuDgJeR6ck8XtRhqAr0wWf7jnHeNf5+8cL/MGlMoKu7Ou7Vwbhnuenjy4PfgZ2R9AV6ULvvAvBTe7cvjb4WdgNQVf025ePDGId449vLnFvuhKCruSDN58chDrFF+89PviZmI6gK9CFnf4CGCOdQqcqr7zEvelSBF3B/XvHw0elfv2c4aVSBF0oDh+VYnipDEEX0IVcHD4qpVMXzU/H34VxCLrAZ++sHz4qpfnp+LswDkHvSE+f7HLPeSydysTfie0Iekfbho9KMby0G4Lewdjho1IML01H0BPpQrD0nvNYOqVheGkagp5IT5vE8OakU5v4GrAZQU+g4aMY3BIYXhqPoCfYdfiolOarGV4ah6BHuvd22fBRKc1Zx9eEIYIeQRdmerokRrYkXSDyYO12BD1CreGjUgwvbUfQW7z16rVBWPukuev4GvEQQZ9DF2J6miRGtU+6B8696c0I+hx6iiQG1QKdAsXXimMEvcHcw0elGF5aj6A30NK3MaKWaHiJe9NDBL2GnhqJAbVI89jxtfeOoAM9LbLU8FEphpeGCDpYevioFMNLZxH0KfsaPiql+ez4XnpF0KfUfuB1KewK8BBB/2/TavtZsCvAMYJuZPioFMNLxwj68ObRkrYxkIw0rx3fW2+6D1pPg8QwMtPcdnyPPek66Cmr7WfR+64AXQfd6vBRqZ6Hl7oNWkvXtjx8VEpz3PE996DboPX0R4zASa+7AnQZdOlq+1n0OLzUXdCZho9K6ZRKc93xGDjrLmgtVRs/eGea647HwFlXQddebT+LnnYF6CrorMNHpXoaXuom6OzDR6V6GV7qImj95cz5nvNYPQwvdRH03KvtZ9HDrgD2QS+12n4W7rsCWAftOHxUyn14yTpoLUEbP1AcHM1/x2PlwjZoXQBxIbiZ664AtkHva7X9LFyHlyyD7mX4qJTmweOxy84uaF3w9DJ8VEqnZJoLj8cwM7ugW1ltPwu3XQGsgu51+KiU0/CSTdC6wOl1+KiUTtE0Jx6PaUY2QevpjPhBYTzNicdjmpFF0K2vtp+Fw64AFkEzfFSHw/BS+qAZPqor+/BS6qB1Icg957qy7wqQOuhsq+1nkXlXgLRBZ11tP4usw0tpg2b4aF6aI884vJQyaC0ZGz8A1Kd58njsW5cuaIfV9rPIuCtAuqAZPlpWtuGlVEFridh4wDE/zZfHz6JVaYLWBYqesogHG/PTvf4s96bTBO262n4WWXYFSBE0w0dtyDC8lCJoLQkbDy6Wp+Gl1u9NNx+0nqaIBxb70/quAE0H3dNq+1m0PrzUdNAMH7Wp5eGlZoNm+KhtmkOPn1kLmg2aB17b1uquAE0G3ftq+1m0uCtAc0EzfJRHi8NLzQWtpV7jgUO7NJceP8N9aipoPSURDxjap/n0+FnuSzNBs9p+Xi3tCtBM0Awf5dbK8FITQWtJV4aP8tO8evxsl9ZE0HoqIh4c5NPCrgB7D1rnXjrdgId9L6C+96CBmggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVv4DWreiLpysy+4AAAAASUVORK5CYII=">
 <style>
@@ -48,10 +67,12 @@ html,body{margin:0;padding:0;background:#000;color:#fff;font-family:'Rajdhani',s
 /* Title banner */
 .title-bar{text-align:center;padding:6px 0 2px;position:relative}
 .title-main{font-family:'Orbitron';font-size:1.8em;font-weight:900;letter-spacing:4px;
-  color:#f0a000;text-shadow:0 0 20px rgba(240,160,0,0.4),0 2px 4px rgba(0,0,0,0.8)}
+  color:var(--brand-accent,#f0a000);
+  text-shadow:0 0 20px var(--brand-accent-glow,rgba(240,160,0,0.4)),0 2px 4px rgba(0,0,0,0.8)}
 .title-sub{font-family:'Orbitron';font-size:0.6em;letter-spacing:6px;color:#665;margin-top:-4px}
 .title-bar::after{content:'';display:block;height:2px;margin-top:4px;
-  background:linear-gradient(90deg,transparent 5%,#3a2a10 20%,#f0a000 50%,#3a2a10 80%,transparent 95%)}
+  background:linear-gradient(90deg,transparent 5%,var(--brand-accent-dim,#3a2a10) 20%,
+    var(--brand-accent,#f0a000) 50%,var(--brand-accent-dim,#3a2a10) 80%,transparent 95%)}
 
 /* Main grid */
 .main{flex:1;display:grid;grid-template-columns:1fr auto 1fr;gap:0;padding:4px 8px;
@@ -170,8 +191,9 @@ html,body{margin:0;padding:0;background:#000;color:#fff;font-family:'Rajdhani',s
 </div>
 
 <div class="title-bar">
-  <div class="title-main">MALAKI SUPERTRACKS</div>
-  <div class="title-sub">EXCAVATOR COMMAND</div>
+  <!-- Text filled from the BRANDING block by applyBranding() — never hardcode here. -->
+  <div class="title-main"></div>
+  <div class="title-sub"></div>
 </div>
 
 <div class="mode-bar">
@@ -425,6 +447,20 @@ html,body{margin:0;padding:0;background:#000;color:#fff;font-family:'Rajdhani',s
 </svg>
 
 <script>
+// ── [BRANDING] apply the skin — values live ONLY in the head block (#136) ──
+(function applyBranding(){
+  const appTitleMeta = document.querySelector('meta[name="apple-mobile-web-app-title"]');
+  if (appTitleMeta) appTitleMeta.setAttribute('content', BRANDING.appTitle);
+  const titleMain = document.querySelector('.title-main');
+  if (titleMain) titleMain.textContent = BRANDING.name;
+  const titleSub = document.querySelector('.title-sub');
+  if (titleSub) titleSub.textContent = BRANDING.tagline;
+  const rootStyle = document.documentElement.style;
+  rootStyle.setProperty('--brand-accent', BRANDING.accent);
+  rootStyle.setProperty('--brand-accent-glow', BRANDING.accentGlow);
+  rootStyle.setProperty('--brand-accent-dim', BRANDING.accentDim);
+})();
+
 // ── Live telemetry client — robust SSE with watchdog + explicit recovery ──
 const AP_IP = '192.168.4.1';
 const SAME_ORIGIN = (location.protocol === 'http:' && location.host);

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5,9 +5,10 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>Dashboard</title>
 <!-- ═══ BRANDING (#136) — the ONLY place product identity lives ═══
-     White-label platform: swap the skin by editing ONLY this block; nothing
-     below hardcodes these values. The logo/badge asset is the
-     apple-touch-icon data URI below — swap the image to re-badge.
+     White-label platform: swap the skin by editing ONLY this block. The
+     neutral "Dashboard" literals in <title> and the app-title meta are
+     pre-JS fallbacks that applyBranding() overwrites. The logo/badge asset
+     is the apple-touch-icon data URI below — swap the image to re-badge.
      Example skin — "Malaki SuperTracks":
        name: 'MALAKI SUPERTRACKS', tagline: 'EXCAVATOR COMMAND',
        appTitle: 'Digger', accent: '#f0a000',

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -22,6 +22,7 @@ const BRANDING = {
   accentGlow: 'rgba(240,160,0,0.4)',  // title glow
   accentDim:  '#3a2a10'               // underline edge fade
 };
+// Early title set — avoids a tab-title flicker; applyBranding() re-applies it.
 document.title = BRANDING.name;
 </script>
 <!-- Installable home-screen app: launches standalone (no browser chrome) on iOS/iPadOS. -->
@@ -450,6 +451,7 @@ html,body{margin:0;padding:0;background:#000;color:#fff;font-family:'Rajdhani',s
 <script>
 // ── [BRANDING] apply the skin — values live ONLY in the head block (#136) ──
 (function applyBranding(){
+  document.title = BRANDING.name;   // re-applies the early head set — full skin in one place
   const appTitleMeta = document.querySelector('meta[name="apple-mobile-web-app-title"]');
   if (appTitleMeta) appTitleMeta.setAttribute('content', BRANDING.appTitle);
   const titleMain = document.querySelector('.title-main');

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,21 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-20 — white-label dashboard: one BRANDING block (#136)
+
+- Product identity (name, tagline, home-screen app title, accent trio) now
+  lives in a single BRANDING config block at the top of
+  dashboard/index.html; applyBranding() writes the text/meta and sets
+  --brand-accent\* CSS custom properties (CSS carries the same values as
+  fallbacks). Default skin is the generic DUAL TRACK CONTROL /
+  VEHICLE COMMAND; "Malaki SuperTracks" is documented in the block as the
+  example skin. Verified both directions with the Playwright harness:
+  config-only edit produces the full Malaki look and back, all gauges and
+  layout pixel-identical. The badge asset slot is the apple-touch-icon
+  data URI (noted in the block); epic #81 lands the HUD badge against
+  this. Remaining Malaki/Jason mentions repo-wide are operator
+  documentation, which the naming rule permits.
+
 ## 2026-07-20 — dev tooling consolidated under tools/ (#123)
 
 - All human-run tools in one home with a README index: serial

--- a/docs/wiki/telemetry-and-dashboard.md
+++ b/docs/wiki/telemetry-and-dashboard.md
@@ -19,6 +19,11 @@ can ever command a track. Canonical detail and current cadence/keys:
 - [XBUS-PROTOCOL](../XBUS-PROTOCOL.md) — wire protocol reference
 - Dashboard source lives at `dashboard/index.html`, embedded into firmware as
   `sketches/dual_track_control/web_page.h` (generated — edit the source, regenerate)
+- The platform is white-label (#136): product name, tagline, home-screen app
+  name, and accent colors live in ONE `BRANDING` block at the top of the
+  dashboard source — swapping a skin never touches logic. The default skin is
+  generic; vehicle-specific skins (the "Malaki SuperTracks" example is
+  documented in the block) are applied by editing only those values.
 - Dashboard rules (frame budget, UI testing before flashing):
   [.claude/rules/dashboard](../../.claude/rules/dashboard.md)
 - Telemetry feeds the [battery ladder](battery-ladder.md) and

--- a/sketches/dual_track_control/web_page.h
+++ b/sketches/dual_track_control/web_page.h
@@ -25,6 +25,7 @@ const BRANDING = {
   accentGlow: 'rgba(240,160,0,0.4)',  // title glow
   accentDim:  '#3a2a10'               // underline edge fade
 };
+// Early title set — avoids a tab-title flicker; applyBranding() re-applies it.
 document.title = BRANDING.name;
 </script>
 <!-- Installable home-screen app: launches standalone (no browser chrome) on iOS/iPadOS. -->
@@ -453,6 +454,7 @@ html,body{margin:0;padding:0;background:#000;color:#fff;font-family:'Rajdhani',s
 <script>
 // ── [BRANDING] apply the skin — values live ONLY in the head block (#136) ──
 (function applyBranding(){
+  document.title = BRANDING.name;   // re-applies the early head set — full skin in one place
   const appTitleMeta = document.querySelector('meta[name="apple-mobile-web-app-title"]');
   if (appTitleMeta) appTitleMeta.setAttribute('content', BRANDING.appTitle);
   const titleMain = document.querySelector('.title-main');

--- a/sketches/dual_track_control/web_page.h
+++ b/sketches/dual_track_control/web_page.h
@@ -8,9 +8,10 @@ const char INDEX_HTML[] PROGMEM = R"DIGGER(
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>Dashboard</title>
 <!-- ═══ BRANDING (#136) — the ONLY place product identity lives ═══
-     White-label platform: swap the skin by editing ONLY this block; nothing
-     below hardcodes these values. The logo/badge asset is the
-     apple-touch-icon data URI below — swap the image to re-badge.
+     White-label platform: swap the skin by editing ONLY this block. The
+     neutral "Dashboard" literals in <title> and the app-title meta are
+     pre-JS fallbacks that applyBranding() overwrites. The logo/badge asset
+     is the apple-touch-icon data URI below — swap the image to re-badge.
      Example skin — "Malaki SuperTracks":
        name: 'MALAKI SUPERTRACKS', tagline: 'EXCAVATOR COMMAND',
        appTitle: 'Digger', accent: '#f0a000',

--- a/sketches/dual_track_control/web_page.h
+++ b/sketches/dual_track_control/web_page.h
@@ -6,12 +6,31 @@ const char INDEX_HTML[] PROGMEM = R"DIGGER(
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<title>Malaki SuperTracks</title>
+<title>Dashboard</title>
+<!-- ═══ BRANDING (#136) — the ONLY place product identity lives ═══
+     White-label platform: swap the skin by editing ONLY this block; nothing
+     below hardcodes these values. The logo/badge asset is the
+     apple-touch-icon data URI below — swap the image to re-badge.
+     Example skin — "Malaki SuperTracks":
+       name: 'MALAKI SUPERTRACKS', tagline: 'EXCAVATOR COMMAND',
+       appTitle: 'Digger', accent: '#f0a000',
+       accentGlow: 'rgba(240,160,0,0.4)', accentDim: '#3a2a10'          -->
+<script>
+const BRANDING = {
+  name:       'DUAL TRACK CONTROL',   // title banner + browser tab
+  tagline:    'VEHICLE COMMAND',      // subtitle under the banner
+  appTitle:   'Dashboard',            // home-screen app name (meta below)
+  accent:     '#f0a000',              // title color + underline center
+  accentGlow: 'rgba(240,160,0,0.4)',  // title glow
+  accentDim:  '#3a2a10'               // underline edge fade
+};
+document.title = BRANDING.name;
+</script>
 <!-- Installable home-screen app: launches standalone (no browser chrome) on iOS/iPadOS. -->
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-<meta name="apple-mobile-web-app-title" content="Digger">
+<meta name="apple-mobile-web-app-title" content="Dashboard">
 <meta name="theme-color" content="#0a0b0d">
 <link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAZUSURBVHhe7d2vjx1VGMbxbQulQNulDSEIECQEUUMCpgIBAgSihhBMDSGYChKCAEEChhAECBKCqGmCQuJwOBwOh8Ph+A8ueXbZdPede/fO3HNm7nmf8xUf0+6Pe+d+xczsO+ccXD+8uQJcHMR/ADIjaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFghaFgh6IW8+PxTg39DfQS9gOeevbH687uLq1svEPXcCHoBP3z42OrfBwerXz59dPB/qIugZ/b6y9ePYj5x942rg69BPQQ9s9+/unQm6L++v7h65ukbg69DHQQ9o4/vPHEm5hPfvn9l8LWog6Bnorsa/9y/MIj5xO1bh4PvQTmCnsnPn1weRHyaTkXi96AcQc/g3deuDgJeR6ck8XtRhqAr0wWf7jnHeNf5+8cL/MGlMoKu7Ou7Vwbhnuenjy4PfgZ2R9AV6ULvvAvBTe7cvjb4WdgNQVf025ePDGId449vLnFvuhKCruSDN58chDrFF+89PviZmI6gK9CFnf4CGCOdQqcqr7zEvelSBF3B/XvHw0elfv2c4aVSBF0oDh+VYnipDEEX0IVcHD4qpVMXzU/H34VxCLrAZ++sHz4qpfnp+LswDkHvSE+f7HLPeSydysTfie0Iekfbho9KMby0G4Lewdjho1IML01H0BPpQrD0nvNYOqVheGkagp5IT5vE8OakU5v4GrAZQU+g4aMY3BIYXhqPoCfYdfiolOarGV4ah6BHuvd22fBRKc1Zx9eEIYIeQRdmerokRrYkXSDyYO12BD1CreGjUgwvbUfQW7z16rVBWPukuev4GvEQQZ9DF2J6miRGtU+6B8696c0I+hx6iiQG1QKdAsXXimMEvcHcw0elGF5aj6A30NK3MaKWaHiJe9NDBL2GnhqJAbVI89jxtfeOoAM9LbLU8FEphpeGCDpYevioFMNLZxH0KfsaPiql+ez4XnpF0KfUfuB1KewK8BBB/2/TavtZsCvAMYJuZPioFMNLxwj68ObRkrYxkIw0rx3fW2+6D1pPg8QwMtPcdnyPPek66Cmr7WfR+64AXQfd6vBRqZ6Hl7oNWkvXtjx8VEpz3PE996DboPX0R4zASa+7AnQZdOlq+1n0OLzUXdCZho9K6ZRKc93xGDjrLmgtVRs/eGea647HwFlXQddebT+LnnYF6CrorMNHpXoaXuom6OzDR6V6GV7qImj95cz5nvNYPQwvdRH03KvtZ9HDrgD2QS+12n4W7rsCWAftOHxUyn14yTpoLUEbP1AcHM1/x2PlwjZoXQBxIbiZ664AtkHva7X9LFyHlyyD7mX4qJTmweOxy84uaF3w9DJ8VEqnZJoLj8cwM7ugW1ltPwu3XQGsgu51+KiU0/CSTdC6wOl1+KiUTtE0Jx6PaUY2QevpjPhBYTzNicdjmpFF0K2vtp+Fw64AFkEzfFSHw/BS+qAZPqor+/BS6qB1Icg957qy7wqQOuhsq+1nkXlXgLRBZ11tP4usw0tpg2b4aF6aI884vJQyaC0ZGz8A1Kd58njsW5cuaIfV9rPIuCtAuqAZPlpWtuGlVEFridh4wDE/zZfHz6JVaYLWBYqesogHG/PTvf4s96bTBO262n4WWXYFSBE0w0dtyDC8lCJoLQkbDy6Wp+Gl1u9NNx+0nqaIBxb70/quAE0H3dNq+1m0PrzUdNAMH7Wp5eGlZoNm+KhtmkOPn1kLmg2aB17b1uquAE0G3ftq+1m0uCtAc0EzfJRHi8NLzQWtpV7jgUO7NJceP8N9aipoPSURDxjap/n0+FnuSzNBs9p+Xi3tCtBM0Awf5dbK8FITQWtJV4aP8tO8evxsl9ZE0HoqIh4c5NPCrgB7D1rnXjrdgId9L6C+96CBmggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVggaVv4DWreiLpysy+4AAAAASUVORK5CYII=">
 <style>
@@ -51,10 +70,12 @@ html,body{margin:0;padding:0;background:#000;color:#fff;font-family:'Rajdhani',s
 /* Title banner */
 .title-bar{text-align:center;padding:6px 0 2px;position:relative}
 .title-main{font-family:'Orbitron';font-size:1.8em;font-weight:900;letter-spacing:4px;
-  color:#f0a000;text-shadow:0 0 20px rgba(240,160,0,0.4),0 2px 4px rgba(0,0,0,0.8)}
+  color:var(--brand-accent,#f0a000);
+  text-shadow:0 0 20px var(--brand-accent-glow,rgba(240,160,0,0.4)),0 2px 4px rgba(0,0,0,0.8)}
 .title-sub{font-family:'Orbitron';font-size:0.6em;letter-spacing:6px;color:#665;margin-top:-4px}
 .title-bar::after{content:'';display:block;height:2px;margin-top:4px;
-  background:linear-gradient(90deg,transparent 5%,#3a2a10 20%,#f0a000 50%,#3a2a10 80%,transparent 95%)}
+  background:linear-gradient(90deg,transparent 5%,var(--brand-accent-dim,#3a2a10) 20%,
+    var(--brand-accent,#f0a000) 50%,var(--brand-accent-dim,#3a2a10) 80%,transparent 95%)}
 
 /* Main grid */
 .main{flex:1;display:grid;grid-template-columns:1fr auto 1fr;gap:0;padding:4px 8px;
@@ -173,8 +194,9 @@ html,body{margin:0;padding:0;background:#000;color:#fff;font-family:'Rajdhani',s
 </div>
 
 <div class="title-bar">
-  <div class="title-main">MALAKI SUPERTRACKS</div>
-  <div class="title-sub">EXCAVATOR COMMAND</div>
+  <!-- Text filled from the BRANDING block by applyBranding() — never hardcode here. -->
+  <div class="title-main"></div>
+  <div class="title-sub"></div>
 </div>
 
 <div class="mode-bar">
@@ -428,6 +450,20 @@ html,body{margin:0;padding:0;background:#000;color:#fff;font-family:'Rajdhani',s
 </svg>
 
 <script>
+// ── [BRANDING] apply the skin — values live ONLY in the head block (#136) ──
+(function applyBranding(){
+  const appTitleMeta = document.querySelector('meta[name="apple-mobile-web-app-title"]');
+  if (appTitleMeta) appTitleMeta.setAttribute('content', BRANDING.appTitle);
+  const titleMain = document.querySelector('.title-main');
+  if (titleMain) titleMain.textContent = BRANDING.name;
+  const titleSub = document.querySelector('.title-sub');
+  if (titleSub) titleSub.textContent = BRANDING.tagline;
+  const rootStyle = document.documentElement.style;
+  rootStyle.setProperty('--brand-accent', BRANDING.accent);
+  rootStyle.setProperty('--brand-accent-glow', BRANDING.accentGlow);
+  rootStyle.setProperty('--brand-accent-dim', BRANDING.accentDim);
+})();
+
 // ── Live telemetry client — robust SSE with watchdog + explicit recovery ──
 const AP_IP = '192.168.4.1';
 const SAME_ORIGIN = (location.protocol === 'http:' && location.host);


### PR DESCRIPTION
Closes #136

## Summary
Branding is now data, not code:

- **One `BRANDING` block** at the top of `dashboard/index.html` holds the product name, tagline, home-screen app title, and the accent color trio. `applyBranding()` writes the title bar text, `document.title`, the iOS app-title meta, and sets `--brand-accent*` CSS custom properties; the stylesheet keeps the same values as fallbacks.
- **Default skin is generic** (`DUAL TRACK CONTROL` / `VEHICLE COMMAND`), per the issue; **"Malaki SuperTracks" is the documented example skin** inside the block. The badge/logo slot is the apple-touch-icon data URI, noted in the block; epic #81 lands the HUD badge against this.
- `web_page.h` regenerated (`--check` passes); wiki page `telemetry-and-dashboard.md` gains the white-label note; DECISION-LOG entry added.
- Repo sweep: every remaining Malaki/Jason mention is operator documentation, which the naming rule explicitly permits — no code identifiers or architecture docs carry branding.

## Role
[C-Builder]

## Test plan
- **Acceptance proven both directions with the Playwright harness (no flash)**: default config renders the generic skin; editing ONLY the config block to the example values renders the exact Malaki look — gauges/layout pixel-identical in both screenshots.
- Host suite green (27 binaries) via pre-commit; local `arduino-cli` compile clean (45% flash).
- `DIGGER_NO_TEST_CHANGE=1` used: dashboard HTML has no host-suite coverage; firmware logic untouched.

Documentation receipt
- Areas changed: dashboard/ (+ generated web_page.h)
- Pages updated: docs/wiki/telemetry-and-dashboard.md (white-label note), docs/DECISION-LOG.md
- Pages examined, no change needed: OPERATOR-GUIDE.md (describes controls/beeps, not dashboard branding), README.md (already brand-neutral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable dashboard branding for product names, taglines, app titles, and accent colors.
  * Dashboard titles, installable app labels, banner text, and visual accents now update dynamically from the selected branding.
  * Applied the same branding capabilities to the generated web interface.

* **Documentation**
  * Documented branding configuration, available skins, and verification details in the decision log and telemetry dashboard guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->