### PR TITLE
Single-writer state: the last two #119 remnants (#119)

### DIFF
--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,7 +5,7 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
-## 2026-07-20 — single-writer state: the last two #119 remnants closed
+## 2026-07-20 — single-writer state: the two named #119 remnants closed
 
 - lowVoltLatched now has ONE writer: [SAFETY]'s batteryCutoffUpdate() calls
   alertNotifyBatteryCutoff() ([ALERT]'s new narrow interface, which does
@@ -20,6 +20,9 @@ Updated by session hooks — only technical content, no personal info.
 - #119's struct-encapsulation proposal judged superseded: extern +
   single-writer + pure domain cores satisfies the acceptance; converting
   the remaining externs to structs would be churn against simplicity-first.
+  Known residual (acknowledged, not in the issue's complaints):
+  updateJoystick() reads currentGear for the joystick forward cap — an
+  application-layer boundary read, single-writer respected.
 
 ## 2026-07-20 — temporary diagnostics removed from production firmware (#122)
 

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,22 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-20 — single-writer state: the last two #119 remnants closed
+
+- lowVoltLatched now has ONE writer: [SAFETY]'s batteryCutoffUpdate() calls
+  alertNotifyBatteryCutoff() ([ALERT]'s new narrow interface, which does
+  the write) at the exact point it used to write the flag directly — same
+  pass, same instant, alarm still starts WITH the cut. The two rule-file
+  "historical example" sins are now literally historical.
+- curvatureDrive() application delegate is pure: the gear-selected pivot
+  cap arrives as a parameter; the composition root owns the currentGear
+  read (Eco → looser cap). 17 test call sites updated mechanically with
+  the faithful per-site cap value — ZERO expectation changes; suite
+  27/27 green. Flash 119740 (+16 call plumbing), RAM 9800 unchanged.
+- #119's struct-encapsulation proposal judged superseded: extern +
+  single-writer + pure domain cores satisfies the acceptance; converting
+  the remaining externs to structs would be churn against simplicity-first.
+
 ## 2026-07-20 — temporary diagnostics removed from production firmware (#122)
 
 - CALIBRATION_MODE (compile-time-false raw-throttle bypass inside the

--- a/sketches/dual_track_control/src/application/AlertControl.cpp
+++ b/sketches/dual_track_control/src/application/AlertControl.cpp
@@ -96,8 +96,13 @@ void alertInit() { alertBootMs = clockNowMs(); }
 
 // NOTE: [ALERT] below is AUDIO-ONLY — it drives the D8 piezo and never touches the
 // motors. The motor-affecting battery cutoff lives in its own [SAFETY] section
-// (search [SAFETY]); it only *borrows* this module's lowVoltLatched to start the
-// chirp when it cuts.
+// (search [SAFETY]); it signals through alertNotifyBatteryCutoff() below to
+// start the chirp when it cuts — this module is the only writer of its latch.
+
+// [SAFETY]'s narrow interface (#119): latch the alarm the instant the hard
+// cutoff latches, so the cut is never silent. Same latch-until-power-cycle
+// semantics as the policy's own debounced latch.
+void alertNotifyBatteryCutoff() { lowVoltLatched = true; }
 
 // Call every loop. rcOn = sbusValid. Sets alarmOutputOn for the piezo.
 // The decision logic and playback live in alerts/AlertPolicy +

--- a/sketches/dual_track_control/src/application/AlertControl.h
+++ b/sketches/dual_track_control/src/application/AlertControl.h
@@ -20,6 +20,11 @@ extern uint32_t beepPhaseMs;
 extern uint32_t rcOffSinceMs;
 extern uint32_t lowVStartMs;
 extern bool     lowVoltLatched;
+
+// Narrow interface for [SAFETY] (#119): starts the low-battery alarm the
+// instant the hard cutoff latches, without another module writing this
+// module's latch. [ALERT] is the ONLY writer of lowVoltLatched.
+void alertNotifyBatteryCutoff();
 extern uint32_t alertBootMs;
 extern const uint16_t* alarmSeq;
 extern int alarmLen, alarmIdx;

--- a/sketches/dual_track_control/src/application/FirmwareApp.cpp
+++ b/sketches/dual_track_control/src/application/FirmwareApp.cpp
@@ -61,7 +61,12 @@ void firmwareLoop() {
     // Combine RC + joystick at the axis level (#90), then run curvatureDrive once
     // on the combined command so a single operator keeps full range.
     DriveCommand cmd = mixCommands(rcCommand(), rcOverride(), cachedJoyCmd);
-    mix = wheelSpeedsToServo(curvatureDrive(cmd.xSpeed, cmd.zRotation, gearScale));
+    // Gear-selected pivot cap: Eco keeps the looser cap for maneuvering
+    // authority. Read here so curvatureDrive stays a pure function (#119).
+    float pivotCap = (currentGear == GEAR_LOW) ? PIVOT_SPEED_CAP_LOW
+                                               : PIVOT_SPEED_CAP;
+    mix = wheelSpeedsToServo(
+        curvatureDrive(cmd.xSpeed, cmd.zRotation, gearScale, pivotCap));
   } else {
     mix.left = SVC;  mix.right = SVC;
   }

--- a/sketches/dual_track_control/src/application/OperatorInput.cpp
+++ b/sketches/dual_track_control/src/application/OperatorInput.cpp
@@ -20,13 +20,11 @@
 
 // The curvature mix is extracted to src/domain/drive/CurvatureDrive.* (#117
 // step 6, #164) — the algorithm and its commentary (#72/#86/#96/#114) moved
-// with it. This delegate keeps the call sites and every test reference
-// unchanged, and owns the one dependency the domain must not read: the
-// gear-selected pivot cap (state-ownership rule — currentGear is read HERE,
-// visibly, instead of hidden behind the parameter list).
-WheelSpeeds curvatureDrive(float xSpeed, float zRotation, float gearScale) {
-  float pivotCap = (currentGear == GEAR_LOW) ? PIVOT_SPEED_CAP_LOW
-                                             : PIVOT_SPEED_CAP;
+// with it. This delegate bundles the fixed blend/taper tunables; every
+// per-pass dependency, including the gear-selected pivot cap, arrives as a
+// parameter (#119 — the composition root owns the gear read).
+WheelSpeeds curvatureDrive(float xSpeed, float zRotation, float gearScale,
+                           float pivotCap) {
   TrackCommand command = curvatureDriveStep(
       xSpeed, zRotation, gearScale,
       CurvatureParameters{pivotCap, PIVOT_THROTTLE_TAPER, PIVOT_BLEND_START,

--- a/sketches/dual_track_control/src/application/OperatorInput.h
+++ b/sketches/dual_track_control/src/application/OperatorInput.h
@@ -24,7 +24,8 @@ extern DriveCommand  cachedJoyCmd;
 extern uint32_t      lastAdcTime;
 const uint32_t ADC_INTERVAL = 10000UL;  // 10 ms = 100 Hz
 
-WheelSpeeds curvatureDrive(float xSpeed, float zRotation, float gearScale);
+WheelSpeeds curvatureDrive(float xSpeed, float zRotation, float gearScale,
+                           float pivotCap);
 ServoOutput wheelSpeedsToServo(WheelSpeeds ws);
 int sbusToServo(int raw);
 int rcDeadband(int pw);

--- a/sketches/dual_track_control/src/application/SafetyControl.cpp
+++ b/sketches/dual_track_control/src/application/SafetyControl.cpp
@@ -22,8 +22,9 @@
 //   Stage 1 — Eco lock   (≤ ECO_LOCK_THRESH_V ~10.8 V): updateGear() forces Eco
 //             regardless of the RC gear switch, to ease load on a draining pack.
 //   Stage 2 — Hard cutoff (≤ CUTOFF_THRESH_V 10.0 V): the output gate stops the
-//             motors, and we assert lowVoltLatched so the D8 alarm chirps WITH
-//             the cut — never a silent cutoff.
+//             motors, and alertNotifyBatteryCutoff() starts the D8 alarm WITH
+//             the cut — never a silent cutoff (#119: [ALERT] owns its latch;
+//             this module signals through that narrow interface).
 
 uint32_t cutoffStartMs  = 0;
 uint32_t ecoLockStartMs = 0;
@@ -71,7 +72,7 @@ void batteryCutoffUpdate() {         // Stage 2 — hard cutoff
   batteryOkConfirmed   = ladder.okConfirmed;
   cutoffStartMs        = ladder.cutoffStartMs;
   if (cutoffJustLatched) {
-    lowVoltLatched = true;           // start the D8 alarm WITH the cut (no silent cutoff)
+    alertNotifyBatteryCutoff();      // start the D8 alarm WITH the cut (no silent cutoff)
   }
 }
 

--- a/tests/characterization/test_curvature_drive.cpp
+++ b/tests/characterization/test_curvature_drive.cpp
@@ -9,26 +9,26 @@
 
 TEST_CASE("straight line: output = xSpeed * gearScale on both tracks") {
   resetHarness();
-  WheelSpeeds ws = curvatureDrive(1.0f, 0.0f, 1.0f);
+  WheelSpeeds ws = curvatureDrive(1.0f, 0.0f, 1.0f, PIVOT_SPEED_CAP_LOW);
   CHECK(ws.left == doctest::Approx(1.0f));
   CHECK(ws.right == doctest::Approx(1.0f));
 
   // Below the blend band the pivot branch contributes — but with zero
   // steering both branches equal xSpeed*gearScale, so straight-line throttle
   // is exact at ANY speed (the #114 taper leaves z=0 unchanged).
-  ws = curvatureDrive(0.10f, 0.0f, 0.80f);
+  ws = curvatureDrive(0.10f, 0.0f, 0.80f, PIVOT_SPEED_CAP_LOW);
   CHECK(ws.left == doctest::Approx(0.08f));
   CHECK(ws.right == doctest::Approx(0.08f));
 
-  ws = curvatureDrive(0.0f, 0.0f, 1.0f);
+  ws = curvatureDrive(0.0f, 0.0f, 1.0f, PIVOT_SPEED_CAP_LOW);
   CHECK(ws.left == doctest::Approx(0.0f));
   CHECK(ws.right == doctest::Approx(0.0f));
 }
 
 TEST_CASE("inputs beyond ±1 are clamped before mixing") {
   resetHarness();
-  WheelSpeeds clamped = curvatureDrive(2.0f, -3.0f, 1.0f);
-  WheelSpeeds unit = curvatureDrive(1.0f, -1.0f, 1.0f);
+  WheelSpeeds clamped = curvatureDrive(2.0f, -3.0f, 1.0f, PIVOT_SPEED_CAP_LOW);
+  WheelSpeeds unit = curvatureDrive(1.0f, -1.0f, 1.0f, PIVOT_SPEED_CAP_LOW);
   CHECK(clamped.left == doctest::Approx(unit.left));
   CHECK(clamped.right == doctest::Approx(unit.right));
 }
@@ -38,30 +38,27 @@ TEST_CASE("pure pivot counter-rotates at the per-gear pivot cap") {
   // Eco (default failsafe gear) uses the looser 0.725 cap for maneuvering
   // authority: wheel speed = cap * gearScale = 0.725 * 0.65.
   REQUIRE(currentGear == GEAR_LOW);
-  WheelSpeeds ws = curvatureDrive(0.0f, 1.0f, GEAR_LOW_SCALE);
+  WheelSpeeds ws = curvatureDrive(0.0f, 1.0f, GEAR_LOW_SCALE, PIVOT_SPEED_CAP_LOW);
   CHECK(ws.left == doctest::Approx(-0.725f * 0.65f));
   CHECK(ws.right == doctest::Approx(0.725f * 0.65f));
 
   // Normal/Boost use the standard 0.60 cap.
-  currentGear = GEAR_MID;
-  ws = curvatureDrive(0.0f, 1.0f, GEAR_MID_SCALE);
+  ws = curvatureDrive(0.0f, 1.0f, GEAR_MID_SCALE, PIVOT_SPEED_CAP);
   CHECK(ws.left == doctest::Approx(-0.60f * 0.80f));
   CHECK(ws.right == doctest::Approx(0.60f * 0.80f));
 
   // Below the cap, steering passes through gear-scaled.
-  currentGear = GEAR_LOW;
-  ws = curvatureDrive(0.0f, 0.30f, GEAR_LOW_SCALE);
+  ws = curvatureDrive(0.0f, 0.30f, GEAR_LOW_SCALE, PIVOT_SPEED_CAP_LOW);
   CHECK(ws.left == doctest::Approx(-0.30f * 0.65f));
   CHECK(ws.right == doctest::Approx(0.30f * 0.65f));
 }
 
 TEST_CASE("pivot throttle taper (#114): low throttle mid-steer arcs, no surge") {
   resetHarness();
-  currentGear = GEAR_MID;
   // 10% throttle at full left steer, Normal gear. Pivot branch throttle is
   // tapered to 0.10*(1-0.70) = 0.03, so the inner track keeps counter-rotating
   // (-0.456 before blend) instead of surging forward with the outer.
-  WheelSpeeds ws = curvatureDrive(0.10f, 1.0f, GEAR_MID_SCALE);
+  WheelSpeeds ws = curvatureDrive(0.10f, 1.0f, GEAR_MID_SCALE, PIVOT_SPEED_CAP);
   // Blend t at |x|=0.10: smoothstep((0.10-0.05)/0.50) = 0.028.
   // pivot (L,R) = (0.03-0.6, 0.03+0.6)*0.8 ; curvature (L,R) = (0, 0.16).
   CHECK(ws.left == doctest::Approx(-0.443232f).epsilon(0.0005));
@@ -71,9 +68,8 @@ TEST_CASE("pivot throttle taper (#114): low throttle mid-steer arcs, no surge") 
 
 TEST_CASE("reverse steering (#86): stick-left turns the nose left in both directions") {
   resetHarness();
-  currentGear = GEAR_HIGH;
-  WheelSpeeds forward = curvatureDrive(0.5f, 0.5f, GEAR_HIGH_SCALE);
-  WheelSpeeds reverse = curvatureDrive(-0.5f, 0.5f, GEAR_HIGH_SCALE);
+  WheelSpeeds forward = curvatureDrive(0.5f, 0.5f, GEAR_HIGH_SCALE, PIVOT_SPEED_CAP);
+  WheelSpeeds reverse = curvatureDrive(-0.5f, 0.5f, GEAR_HIGH_SCALE, PIVOT_SPEED_CAP);
 
   // Forward left turn: left track slower.
   CHECK(forward.left < forward.right);
@@ -90,8 +86,7 @@ TEST_CASE("reverse steering (#86): stick-left turns the nose left in both direct
 
 TEST_CASE("outer-track ceiling (#96): full steer at full speed caps the outer at 0.70") {
   resetHarness();
-  currentGear = GEAR_HIGH;
-  WheelSpeeds ws = curvatureDrive(1.0f, 1.0f, GEAR_HIGH_SCALE);
+  WheelSpeeds ws = curvatureDrive(1.0f, 1.0f, GEAR_HIGH_SCALE, PIVOT_SPEED_CAP);
   // Pure curvature (t=1): inner stops, outer would hit 2.0 → desaturated to
   // the faded ceiling 1 - (1-0.70)*|z| = 0.70.
   CHECK(ws.left == doctest::Approx(0.0f));
@@ -100,8 +95,7 @@ TEST_CASE("outer-track ceiling (#96): full steer at full speed caps the outer at
 
 TEST_CASE("gear turn headroom (#72): outer track borrows above the gear cap in Normal") {
   resetHarness();
-  currentGear = GEAR_MID;
-  WheelSpeeds ws = curvatureDrive(1.0f, 0.5f, GEAR_MID_SCALE);
+  WheelSpeeds ws = curvatureDrive(1.0f, 0.5f, GEAR_MID_SCALE, PIVOT_SPEED_CAP);
   // avg=0.8, delta=0.4 → raw (0.4, 1.2); ceiling at |z|=0.5 is 0.85 →
   // k=0.85/1.2, preserving the turn ratio.
   CHECK(ws.right == doctest::Approx(0.85f));
@@ -112,10 +106,9 @@ TEST_CASE("gear turn headroom (#72): outer track borrows above the gear cap in N
 
 TEST_CASE("blend band (#72): smoothstep hand-off between pivot and curvature") {
   resetHarness();
-  currentGear = GEAR_MID;
   // At the band edges the branches are pure; midway they mix smoothly.
   // |x| = 0.30 (band middle): t = smoothstep(0.5) = 0.5 exactly.
-  WheelSpeeds mid = curvatureDrive(0.30f, 0.40f, GEAR_MID_SCALE);
+  WheelSpeeds mid = curvatureDrive(0.30f, 0.40f, GEAR_MID_SCALE, PIVOT_SPEED_CAP);
   // pivot: thr = 0.3*(1-0.7*0.4) = 0.216 → (0.216∓0.4)*0.8 = (-0.1472, 0.4928)
   // curvature: avg = 0.24, delta = 0.096 → (0.144, 0.336), ceiling 0.88, no desat
   // blend 50/50: (-0.0016, 0.4144)
@@ -123,7 +116,7 @@ TEST_CASE("blend band (#72): smoothstep hand-off between pivot and curvature") {
   CHECK(mid.right == doctest::Approx(0.4144f).epsilon(0.005));
 
   // At/above the band end the pivot branch is fully out.
-  WheelSpeeds atEnd = curvatureDrive(0.55f, 0.40f, GEAR_MID_SCALE);
+  WheelSpeeds atEnd = curvatureDrive(0.55f, 0.40f, GEAR_MID_SCALE, PIVOT_SPEED_CAP);
   float avg = 0.55f * 0.80f;
   float delta = avg * 0.40f;
   CHECK(atEnd.left == doctest::Approx(avg - delta));

--- a/tests/invariants/test_invariant_output_bounds.cpp
+++ b/tests/invariants/test_invariant_output_bounds.cpp
@@ -11,8 +11,10 @@
 
 TEST_CASE("mixer grid (#131): outputs bounded for every gear x xSpeed x zRotation, incl. out-of-range") {
   resetHarness();
-  const struct { Gear gear; float scale; } gears[] = {
-    {GEAR_LOW, GEAR_LOW_SCALE}, {GEAR_MID, GEAR_MID_SCALE}, {GEAR_HIGH, GEAR_HIGH_SCALE}};
+  const struct { float scale; float pivotCap; } gears[] = {
+    {GEAR_LOW_SCALE, PIVOT_SPEED_CAP_LOW},      // Eco
+    {GEAR_MID_SCALE, PIVOT_SPEED_CAP},          // Normal
+    {GEAR_HIGH_SCALE, PIVOT_SPEED_CAP}};        // Boost
   // Grid straddles the pivot blend band (0.05 / 0.55), the pivot caps
   // (0.60 / 0.725), full deflection, and out-of-range values.
   const float grid[] = {-2.5f, -1.0f, -0.725f, -0.55f, -0.3f, -0.05f, 0.0f,
@@ -20,11 +22,9 @@ TEST_CASE("mixer grid (#131): outputs bounded for every gear x xSpeed x zRotatio
   int checked = 0;
   int outOfBounds = 0;
   for (const auto& g : gears) {
-    currentGear = g.gear;  // curvatureDrive reads this global for the pivot cap
-    gearScale = g.scale;
     for (float xSpeed : grid) {
       for (float zRotation : grid) {
-        ServoOutput out = wheelSpeedsToServo(curvatureDrive(xSpeed, zRotation, g.scale));
+        ServoOutput out = wheelSpeedsToServo(curvatureDrive(xSpeed, zRotation, g.scale, g.pivotCap));
         if (out.left < SVMIN || out.left > SVMAX ||
             out.right < SVMIN || out.right > SVMAX) {
           outOfBounds++;
@@ -49,7 +49,7 @@ TEST_CASE("non-finite mixer inputs (#131): NaN / Inf cannot escape the us clamp"
   int checked = 0;
   int outOfBounds = 0;
   auto probe = [&](float xSpeed, float zRotation) {
-    ServoOutput out = wheelSpeedsToServo(curvatureDrive(xSpeed, zRotation, gearScale));
+    ServoOutput out = wheelSpeedsToServo(curvatureDrive(xSpeed, zRotation, gearScale, PIVOT_SPEED_CAP_LOW));
     if (out.left < SVMIN || out.left > SVMAX ||
         out.right < SVMIN || out.right > SVMAX) {
       outOfBounds++;


### PR DESCRIPTION
Closes #119

## Summary
The post-Phase-D audit (issue comment) found exactly two remnants of this issue's acceptance; this PR closes both, behavior-preserving:

- **`lowVoltLatched` gets one writer.** `[SAFETY]`'s `batteryCutoffUpdate()` no longer writes `[ALERT]`'s latch; it calls `alertNotifyBatteryCutoff()` — a narrow interface owned by AlertControl that does the write — at the exact code point of the old assignment. Same pass, same instant: the alarm still starts WITH the cut (the `test_battery_ladder` "never a silent cutoff" and `test_control_loop` "alarm sounds WITH the cut" locks pass untouched).
- **`curvatureDrive()` is pure.** The application delegate takes the gear-selected pivot cap as a fourth parameter; the composition root computes it visibly (`Eco → PIVOT_SPEED_CAP_LOW`). The state-ownership rule's two "historical example" sins are now literally historical.
- Acceptance (c) — pipeline-shaped `loop()` — was already met; the issue's struct-encapsulation *proposal* is judged superseded (extern + single-writer + pure domain cores satisfies the acceptance; converting the remaining externs to structs is churn against simplicity-first). Reasoning on the issue.

## Role
[C-Builder]

## Test plan
- **Zero expectation changes.** 17 `curvatureDrive` test call sites updated mechanically with the faithful per-site cap value (the value the deleted global read would have selected); every CHECK/REQUIRE untouched, including the reset-default `REQUIRE(currentGear == GEAR_LOW)`.
- Host suite 27/27 green through the pre-commit gate; local `arduino-cli` compile clean — flash 119740 (+16, call plumbing), RAM 9800 unchanged.
- Bench re-verification rides `docs/architecture/BENCH-VERIFICATION-DEFERRED.md` (no hardware).

Documentation receipt
- Areas changed: src/application/, tests/
- Pages updated: docs/DECISION-LOG.md
- Pages examined, no change needed: docs/SAFETY.md + wiki safety-system/application-loop/control-pipeline (none described the borrow or the hidden read — grep clean); `.claude/rules/state-ownership.md` already phrases both as historical examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved low-battery cutoff alarm handling so the alert reliably latches when a hard cutoff occurs.
  * Preserved drive behavior while making pivot-speed limits apply correctly for the selected gear.

* **Tests**
  * Updated drive-mixing and output-bound checks to cover gear-specific pivot limits and maintain existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->