### PR TITLE
Retire epic-#116 scaffolding: the covenant becomes permanent policy (#203)

### DIFF
--- a/.claude/rules/behavior-preservation.md
+++ b/.claude/rules/behavior-preservation.md
@@ -1,4 +1,4 @@
-# Behavior-Preservation Covenant (epic #116 — highest-priority rule)
+# Behavior-Preservation Covenant (highest-priority rule)
 
 **Operator's words (2026-07-06):** "organizing, refactoring and improving the
 code should never ever, ever cause change of controls or change of behavior
@@ -9,7 +9,9 @@ firmware again, I would like the machine to perform exactly like it used to
 perform before."
 
 The firmware is field-tuned on a real machine with a child rider. The entire
-value of epic #116 is a better-organized firmware that drives IDENTICALLY.
+value of any reorganization is a better-organized firmware that drives
+IDENTICALLY. (Born as epic #116's law; permanent policy since the epic closed,
+2026-07-20, #203.)
 
 ## The rule
 

--- a/.claude/rules/dashboard.md
+++ b/.claude/rules/dashboard.md
@@ -10,8 +10,8 @@ paths:
 - **`dashboard/index.html` is the single source of truth; `web_page.h` is
   GENERATED** (#120) — never hand-edit it. After editing the source, run
   `python scripts/generate_web_page.py` and commit both files; CI
-  (`dashboard-drift` job in structure-check) fails on any mismatch. The
-  generated file moves to `src/generated/` when the Phase D tree exists.
+  (`dashboard-drift` job in structure-check) fails on any mismatch. Its
+  planned home is `src/generated/` per the architecture target (#227).
 - **Test UI changes locally before any flash**: run the Playwright harness
   (`tools/ui-test*.mjs`) with mock data and check the screenshots. Never make
   the operator tether to the machine to verify a UI change.

--- a/.claude/rules/naming.md
+++ b/.claude/rules/naming.md
@@ -7,7 +7,8 @@ every identifier** — types, functions, variables, files, folders.
   `command`, not `cmd`. `temperature`, not `temp` (ambiguous with
   "temporary"). `previous`, not `prev`. `button`, not `btn`.
 - Applies to NEW and MOVED code. Do not mass-rename untouched legacy code —
-  names are fixed as each file is extracted during the Phase D migration.
+  names were fixed as each file was extracted during the Phase D migration
+  (completed, #189); legacy names change only when their code next moves.
 
 ## Permitted exceptions (closed list — extending it requires operator sign-off)
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -8,7 +8,7 @@
 - **One open PR at a time** (operator rule, 2026-07-05). Do not start the next
   work item until the current PR is merged or closed — no parallel PRs, no
   merge-order dependencies to keep track of.
-- **Behavior-preserving refactors only**: no logic
+- **Structural/refactor PRs are behavior-preserving**: no logic
   changes mixed into structural PRs; characterization tests green before and
   after; local `arduino-cli` compile before every push.
 - **Commit test gate (#47)**: `.githooks/pre-commit` hard-blocks commits when

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -8,7 +8,7 @@
 - **One open PR at a time** (operator rule, 2026-07-05). Do not start the next
   work item until the current PR is merged or closed — no parallel PRs, no
   merge-order dependencies to keep track of.
-- **Behavior-preserving refactors only** during epic #116 Phase D: no logic
+- **Behavior-preserving refactors only**: no logic
   changes mixed into structural PRs; characterization tests green before and
   after; local `arduino-cli` compile before every push.
 - **Commit test gate (#47)**: `.githooks/pre-commit` hard-blocks commits when

--- a/.claude/skills/flash-and-log/SKILL.md
+++ b/.claude/skills/flash-and-log/SKILL.md
@@ -12,7 +12,8 @@ description: Firmware upload procedure — use whenever flashing the digger (pro
    `arduino-cli compile --fqbn arduino:renesas_uno:unor4wifi sketches/dual_track_control`
 3. The change is on an issue-linked PR branch (see `prepare-pull-request`
    skill) — never flash unreviewed drive-by edits.
-4. If NO hardware is connected (epic #116 standing constraint), STOP: no
+4. If NO hardware is connected (standing constraint while the machine is
+   away), STOP: no
    flashing, no bench claims. Physical checks go to
    `docs/architecture/BENCH-VERIFICATION-DEFERRED.md` instead.
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,7 +19,7 @@ reviews:
         [covenant] Organization and refactor work in this repo (splitting
         files, domain-driven design per
         docs/architecture/ARCHITECTURE-TARGET.md, doc-code sync, readable
-        meaningful tests) must change NOTHING observable: no timing,
+        and meaningful tests) must change NOTHING observable: no timing,
         no parameter or constant values, no input/output handling, no control
         flow that alters outputs. Do NOT suggest behavior changes, constant
         retunes, or "simplifications" that alter what the firmware does — even
@@ -55,9 +55,9 @@ reviews:
         [covenant] Production firmware behavior is LAW. For structural PRs:
         verify moved code is byte-equivalent in effect, includes/layers
         follow the architecture rules, and nothing "extra" snuck into a move.
-        Any behavior, timing, or parameter concern the PR's linked issue does
-        not explicitly authorize becomes an issue recommendation, never a
-        committable suggestion.
+        Any behavior, timing, or parameter concern that the PR's linked issue
+        does not explicitly authorize becomes an issue recommendation, never
+        a committable suggestion.
     - path: "tests/**"
       instructions: >-
         [covenant] Test EXPECTATIONS are behavior law: changing an expected

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,27 +1,25 @@
 # CodeRabbit review configuration.
 #
-# EPIC #116 SCOPE (TEMPORARY): the sections marked [epic #116] steer reviews
-# during the architecture-remediation program (organize code, split files,
-# domain-driven design, doc-code sync, meaningful tests) under a strict
-# behavior-preservation covenant. Relax/remove those sections when epic #116
-# completes — tracked in the epic's definition of done.
+# The [covenant] sections are PERMANENT policy (epic-#116 scaffolding retired
+# 2026-07-20, #203): the firmware is field-tuned on a child-ridden machine.
+# Behavior changes are legitimate ONLY when a PR's linked issue explicitly
+# authorizes them — never as review corrections.
 language: en-US
 
 tone_instructions: >-
-  Safety-critical child-ridden vehicle, mid behavior-preserving refactor
-  (epic #116). Never suggest changes to behavior, timing, parameters, or
-  test expectations; propose follow-up issues instead. Verify numeric
-  claims against the code first.
+  Safety-critical child-ridden vehicle under a permanent
+  behavior-preservation covenant. Never suggest changes to behavior, timing,
+  parameters, or test expectations; propose follow-up issues instead. Verify
+  numeric claims against the code first.
 
 reviews:
   path_instructions:
     - path: "**"
       instructions: >-
-        [epic #116 — behavior-preservation covenant] This repo is mid
-        refactor whose ONLY goals are: organize code, split large files,
-        follow domain-driven design (docs/architecture/ARCHITECTURE-TARGET.md),
-        keep documentation synchronized with code, and keep tests readable and
-        meaningful. Organization must change NOTHING observable: no timing,
+        [covenant] Organization and refactor work in this repo (splitting
+        files, domain-driven design per
+        docs/architecture/ARCHITECTURE-TARGET.md, doc-code sync, readable
+        meaningful tests) must change NOTHING observable: no timing,
         no parameter or constant values, no input/output handling, no control
         flow that alters outputs. Do NOT suggest behavior changes, constant
         retunes, or "simplifications" that alter what the firmware does — even
@@ -54,14 +52,15 @@ reviews:
         exactly the review comments this program needs.
     - path: "sketches/**"
       instructions: >-
-        [epic #116] Production firmware behavior is LAW during the refactor.
-        Structural review only: verify moved code is byte-equivalent in
-        effect, includes/layers follow the architecture rules, and nothing
-        "extra" snuck into a move. Any behavior, timing, or parameter concern
-        becomes an issue recommendation, never a committable suggestion.
+        [covenant] Production firmware behavior is LAW. For structural PRs:
+        verify moved code is byte-equivalent in effect, includes/layers
+        follow the architecture rules, and nothing "extra" snuck into a move.
+        Any behavior, timing, or parameter concern the PR's linked issue does
+        not explicitly authorize becomes an issue recommendation, never a
+        committable suggestion.
     - path: "tests/**"
       instructions: >-
-        [epic #116] Test EXPECTATIONS are behavior law: changing an expected
+        [covenant] Test EXPECTATIONS are behavior law: changing an expected
         value requires its own issue + operator sign-off first — never suggest
         editing an expectation to "correct" it. Welcome suggestions:
         readability, meaningful scenario coverage (tests should exercise
@@ -71,7 +70,7 @@ reviews:
         firmware.
     - path: "docs/**"
       instructions: >-
-        [epic #116] Doc-code synchronization is a first-class review goal:
+        [covenant] Doc-code synchronization is a first-class review goal:
         flag any constant, threshold, pin, file path, or behavior description
         that no longer matches the code. Do not propose changing the CODE to
         match stale docs — docs follow code.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,12 +1,13 @@
 # Copilot Code Review Instructions — Arduino Digger Controller
 
-## ⚠️ Current program: epic #116 — behavior-preservation covenant (TEMPORARY until epic completes)
+## ⚠️ Behavior-preservation covenant (permanent policy)
 
-The repo is mid architecture-remediation: organize code, split large files,
-domain-driven design, doc-code sync, readable and meaningful tests. During
-this program, organization must change NOTHING observable — no behavior, no
-timing, no parameter/constant values, no input/output handling. Firmware
-flashed after a refactor must make the machine perform exactly as before.
+This firmware is field-tuned on a real machine with a child rider.
+Organization and refactor work must change NOTHING observable — no behavior,
+no timing, no parameter/constant values, no input/output handling. Firmware
+flashed after a refactor must make the machine perform exactly as before; a
+behavior change is legitimate only when the PR's linked issue explicitly
+authorizes it.
 
 - Do NOT suggest behavior changes, constant retunes, or simplifications that
   alter what the firmware does — even where current behavior looks wrong.

--- a/.github/workflows/architecture-fitness.yml
+++ b/.github/workflows/architecture-fitness.yml
@@ -3,8 +3,8 @@ name: Architecture Fitness
 # Fitness functions for the epic #116 target architecture (#129):
 # forbidden includes, layer direction, file-size policy, banned names,
 # no mutable domain globals, generated-file guard, version SSOT.
-# Advisory until the Phase D extraction lands (not in branch protection);
-# flip to required afterwards — see ARCHITECTURE-TARGET.md section 10.
+# Advisory until the operator adds it to branch protection (#196) —
+# see ARCHITECTURE-TARGET.md section 10.
 
 on:
   push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ dashboard (monitoring only).
 
 Behavioral guardrails for every agent working in this repo. The
 **behavior-preservation covenant** (`.claude/rules/behavior-preservation.md`)
-sits above all four: during epic #116, organization changes NOTHING observable
+sits above all four: organization changes NOTHING observable
 — firmware flashed after a refactor must drive exactly as before.
 
 1. **Think before coding — never guess on safety-relevant ambiguity.**

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -16,8 +16,13 @@ Updated by session hooks — only technical content, no personal info.
   instruction now scopes the no-committable-suggestion rule to changes the
   PR's linked issue does not authorize), agent-governance + home wiki
   notes, flash-and-log skill (no-hardware constraint unhooked from the
-  epic — it stands while the machine is away).
-  architecture-remediation.md keeps its epic title as dated history.
+  epic — it stands while the machine is away). Self-review round widened
+  the sweep to Phase-D-conditioned wording: SAFETY.md (known-gaps clause +
+  stale .ino loop-order reference), naming rule (migration past tense),
+  TESTING.md intro, architecture-fitness advisory-until claims (now point
+  at #196), and the dashboard rule's src/generated promise (now tracked
+  as #227). architecture-remediation.md keeps its epic title as dated
+  history.
 
 ## 2026-07-20 — single-writer state: the two named #119 remnants closed
 

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,20 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-20 — epic #116 closed; covenant made permanent (#203)
+
+- Epic #116 closed with all child issues done (operator go-ahead). The
+  behavior-preservation covenant survives the epic as PERMANENT policy —
+  one home: .claude/rules/behavior-preservation.md. Epic-conditioned
+  wording retired from CLAUDE.md, workflow rule, copilot-instructions
+  (covenant section retitled permanent), .coderabbit.yaml ([epic #116]
+  markers → [covenant]; "mid-refactor" framing dropped; sketches/ path
+  instruction now scopes the no-committable-suggestion rule to changes the
+  PR's linked issue does not authorize), agent-governance + home wiki
+  notes, flash-and-log skill (no-hardware constraint unhooked from the
+  epic — it stands while the machine is away).
+  architecture-remediation.md keeps its epic title as dated history.
+
 ## 2026-07-20 — single-writer state: the two named #119 remnants closed
 
 - lowVoltLatched now has ONE writer: [SAFETY]'s batteryCutoffUpdate() calls

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -57,8 +57,9 @@ The watchdog (#69, `WDT_TIMEOUT_MS` 250 ms) cannot fire in the host stub; the
 host suite asserts its *contract* — exactly one `WDT.refresh()` per loop pass
 (`tests/characterization/test_control_loop.cpp`; the stub counts calls, it
 does not assert ordering). That the single refresh sits *after* the control
-path is a code-placement rule (`[MODULE]` loop order in `dual_track_control.ino`,
-enforced by review + `.claude/rules/firmware-realtime.md`). That a WDT reset
+path is a code-placement rule (the loop order in
+`src/application/FirmwareApp.cpp`, enforced by review +
+`.claude/rules/firmware-realtime.md`). That a WDT reset
 actually stops PWM is physical behavior — tracked in
 `docs/architecture/BENCH-VERIFICATION-DEFERRED.md`.
 
@@ -66,7 +67,8 @@ actually stops PWM is physical behavior — tracked in
 
 Both gaps below are **locked as current behavior** by `// #131 FINDING:` test
 cases; fixing either is a behavior change requiring its own issue + operator
-sign-off (behavior-preserving constraint during epic #116). Follow-up
+sign-off (the behavior-preservation covenant,
+`.claude/rules/behavior-preservation.md` — permanent policy). Follow-up
 hardening issues are pending operator filing; until then the full drafts live
 in the appendix of the PR that introduced this registry
 ([PR #138](https://github.com/boulaajaj/Arduino-DiggerSetup/pull/138) — the

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -58,8 +58,8 @@ host suite asserts its *contract* — exactly one `WDT.refresh()` per loop pass
 (`tests/characterization/test_control_loop.cpp`; the stub counts calls, it
 does not assert ordering). That the single refresh sits *after* the control
 path is a code-placement rule (the loop order in
-`src/application/FirmwareApp.cpp`, enforced by review +
-`.claude/rules/firmware-realtime.md`). That a WDT reset
+`sketches/dual_track_control/src/application/FirmwareApp.cpp`, enforced by
+review + `.claude/rules/firmware-realtime.md`). That a WDT reset
 actually stops PWM is physical behavior — tracked in
 `docs/architecture/BENCH-VERIFICATION-DEFERRED.md`.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,15 +4,15 @@ The firmware's control logic runs on a laptop, byte-for-byte unchanged, inside
 a fake Arduino environment. Two suites share the harness: **characterization**
 (#47) locks in example behavior, and **invariants** (#131) asserts safety
 properties that must always hold, under injected faults. Together they are the
-**primary safety net for the Phase D refactor**: every extraction PR must keep
-them green, proving behavior parity while no hardware is available.
+**primary safety net for any structural change**: every PR must keep them
+green, proving behavior parity while no hardware is available.
 
 ## How it works — zero firmware changes
 
 The production sketch is not modified for testing. Each test binary compiles
 `sketches/dual_track_control/dual_track_control.ino` directly, plus the extracted
-`sketches/dual_track_control/src/**/*.cpp` domain sources the sketch delegates to as the
-Phase D migration (#117) proceeds. Pure suites live at the path of the
+`sketches/dual_track_control/src/**/*.cpp` domain sources the sketch delegates
+to (extracted during Phase D, #117 — complete). Pure suites live at the path of the
 layer they test — the tree MIRRORS `src/` (#195) — with no firmware, no
 stubs, and no `src/infrastructure/` sources (those include hardware headers
 and are compiled only into the stub-backed firmware suites, #172):

--- a/docs/architecture/ARCHITECTURE-TARGET.md
+++ b/docs/architecture/ARCHITECTURE-TARGET.md
@@ -266,7 +266,7 @@ version SSOT (activates with #124). Implementation:
 `architecture-fitness` workflow after a self-test
 (`scripts/check_architecture_selftest.py`) proves every failure mode fires.
 The check is **advisory** (not in branch protection) until the operator
-flips it to required (#196 — Phase D itself landed 2026-07-20). Section 3's table is canonical —
+flips it to required (#196 — the Phase D extraction itself landed, #189). Section 3's table is canonical —
 a rule change here must change the script in the same PR.
 
 **Migration window (#150):** the composition-root rule (`.ino` →

--- a/docs/architecture/ARCHITECTURE-TARGET.md
+++ b/docs/architecture/ARCHITECTURE-TARGET.md
@@ -265,8 +265,8 @@ version SSOT (activates with #124). Implementation:
 `scripts/check_architecture.py` + `scripts/architecture_rules.py`, run by the
 `architecture-fitness` workflow after a self-test
 (`scripts/check_architecture_selftest.py`) proves every failure mode fires.
-The check is **advisory** (not in branch protection) until the Phase D
-extraction lands, then flipped to required. Section 3's table is canonical —
+The check is **advisory** (not in branch protection) until the operator
+flips it to required (#196 — Phase D itself landed 2026-07-20). Section 3's table is canonical —
 a rule change here must change the script in the same PR.
 
 **Migration window (#150):** the composition-root rule (`.ino` →

--- a/docs/wiki/agent-governance.md
+++ b/docs/wiki/agent-governance.md
@@ -9,7 +9,7 @@ sources:
 
 How AI agents (Claude Code, Copilot, CodeRabbit) are steered in this repo —
 the Karpathy method (#53) plus the behavior-preservation covenant
-(epic #116).
+(permanent policy — born in epic #116, retained after its 2026-07-20 close).
 
 - **Working Agreement** — four principles (think before coding, simplicity
   first, surgical changes, goal-driven execution with a verifiable gate):
@@ -34,7 +34,7 @@ the Karpathy method (#53) plus the behavior-preservation covenant
 - **Reviewer subagents** (#127) — read-only specialist reviewers under
   `.claude/agents/` (architecture, safety, tests, documentation) that
   challenge a diff before it is marked ready — they report, never edit.
-- **Review bots** — `.coderabbit.yaml` (epic-scoped covenant steering) and
+- **Review bots** — `.coderabbit.yaml` (permanent covenant steering) and
   [copilot-instructions](../../.github/copilot-instructions.md) mirror the
   same rules so bot reviews align with the program
 - **This wiki** is itself governed here: agents maintain it, PRs that change

--- a/docs/wiki/home.md
+++ b/docs/wiki/home.md
@@ -24,8 +24,8 @@ Which artifact wins for what: [authority-matrix](authority-matrix.md).
   ([application-loop](application-loop.md) ·
   [ports-and-adapters](ports-and-adapters.md) ·
   [configuration-authority](configuration-authority.md))
-- [Architecture remediation](architecture-remediation.md) — epic #116 program
-  (dated migration history)
+- [Architecture remediation](architecture-remediation.md) — epic #116 program,
+  completed 2026-07-20 (dated migration history)
 
 ## People and operations
 


### PR DESCRIPTION
Closes #203

## Summary
Epic #116 closed today with every child issue done, which unblocks this: no live instruction is conditioned on the epic anymore.

- **Covenant → one permanent home**: `.claude/rules/behavior-preservation.md` (title de-scoped; a dated line records its origin). CLAUDE.md and the workflow rule lose their "during epic #116" clauses — the law is unchanged, just no longer temporary.
- **Bot steering made permanent**: `.coderabbit.yaml` header/tone rewritten, `[epic #116]` markers → `[covenant]`, "mid-refactor" framing dropped; the sketches/ instruction now scopes the no-committable-behavior-suggestion rule to changes *the PR's linked issue does not authorize* (post-epic, authorized feature PRs exist). `copilot-instructions.md` covenant section retitled permanent with the same authorization clause.
- **Wiki**: agent-governance + home updated; `architecture-remediation.md` keeps its epic title — that page is dated migration history, exactly what #203 says to preserve.
- **flash-and-log skill**: the no-hardware STOP is unhooked from the epic — it stands while the machine is away.
- Verified: grep for epic-conditioned phrases across all instruction surfaces returns nothing; `check_wiki.py` OK.

## Role
[A-Content]

## Test plan
- Docs/instructions only — zero firmware or tests touched (`git diff --stat` confirms).
- wiki-lint, markdownlint, structure-check on CI; covenant text diff is wording-only (rules 1–3 and the triage ladder byte-identical in meaning).

Documentation receipt
- Areas changed: .claude/, .github/, .coderabbit.yaml, docs/wiki/
- Pages updated: docs/wiki/agent-governance.md, docs/wiki/home.md, docs/DECISION-LOG.md
- Pages examined, no change needed: docs/TESTING.md (no epic-conditioned text), docs/wiki/architecture-remediation.md (dated history — deliberately kept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated governance and workflow guidance to establish behavior-preservation requirements as a permanent policy.
  * Removed outdated temporary project references from instructions and review guidance.
  * Clarified that structural changes must preserve observable behavior, including timing, parameters, and input/output handling.
  * Recorded the policy transition and project completion in decision logs and wiki documentation.
  * Preserved the existing safety stop condition when hardware is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->