### PR TITLE
Version badge injected from the BuildInfo.h SSOT at generation (#222)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -182,8 +182,11 @@ html,body{margin:0;padding:0;background:#000;color:#fff;font-family:'Rajdhani',s
 </style>
 </head>
 <body>
-<!-- Discrete firmware-version badge (top-left). Bump with the sketch version. -->
-<div id="fwVer" style="position:fixed;top:3px;left:5px;z-index:9999;font:10px monospace;color:#6b8;opacity:.6;letter-spacing:.5px;pointer-events:none">V7.33</div>
+<!-- Discrete firmware-version badge (top-left). The placeholder is replaced
+     with config/BuildInfo.h's FIRMWARE_VERSION at generation (#222) — never
+     hand-write a version here. Served pages always show the SSOT value;
+     opening this source file directly shows the raw placeholder. -->
+<div id="fwVer" style="position:fixed;top:3px;left:5px;z-index:9999;font:10px monospace;color:#6b8;opacity:.6;letter-spacing:.5px;pointer-events:none">{{FIRMWARE_VERSION}}</div>
 <div class="dash-frame">
 
 <div class="top-bar">

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -5,6 +5,15 @@ Updated by session hooks — only technical content, no personal info.
 
 ---
 
+## 2026-07-21 — dashboard version badge injected from the SSOT (#222)
+
+- dashboard/index.html carries {{FIRMWARE_VERSION}}; generate_web_page.py
+  substitutes the BuildInfo.h value (regex-anchored, fail-close on a
+  missing declaration or wrong placeholder count). The badge had drifted
+  twice (V7.33 shown vs V7.35 SSOT) — impossible now: a version bump
+  without regenerating web_page.h fails the dashboard-drift CI check, so
+  bumps and regeneration travel in the same commit by construction.
+
 ## 2026-07-20 — epic #116 closed; covenant made permanent (#203)
 
 - Epic #116 closed with all child issues done (operator go-ahead). The

--- a/docs/wiki/telemetry-and-dashboard.md
+++ b/docs/wiki/telemetry-and-dashboard.md
@@ -24,6 +24,10 @@ can ever command a track. Canonical detail and current cadence/keys:
   dashboard source — swapping a skin never touches logic. The default skin is
   generic; vehicle-specific skins (the "Malaki SuperTracks" example is
   documented in the block) are applied by editing only those values.
+- The version badge is injected at generation (#222): the source carries a
+  `{{FIRMWARE_VERSION}}` placeholder and the generator substitutes the
+  `BuildInfo.h` SSOT — a version bump without regeneration now fails the
+  drift check.
 - Dashboard rules (frame budget, UI testing before flashing):
   [.claude/rules/dashboard](../../.claude/rules/dashboard.md)
 - Telemetry feeds the [battery ladder](battery-ladder.md) and

--- a/scripts/generate_web_page.py
+++ b/scripts/generate_web_page.py
@@ -15,6 +15,7 @@ Newlines are normalized to LF so output is byte-identical on every platform
 """
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -22,6 +23,9 @@ sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 PAGE_BUDGET_BYTES = 100 * 1024  # epic #81: served dashboard <= 100 KB
 RAW_DELIMITER = "DIGGER"
+VERSION_PLACEHOLDER = b"{{FIRMWARE_VERSION}}"
+VERSION_PATTERN = re.compile(
+    rb'const\s+char\s+FIRMWARE_VERSION\[\]\s*=\s*"([^"]+)"')
 
 HEADER = f"""\
 // GENERATED FILE — do not edit. Source: dashboard/index.html
@@ -31,9 +35,25 @@ const char INDEX_HTML[] PROGMEM = R"{RAW_DELIMITER}(
 TRAILER = f"){RAW_DELIMITER}\";\n"
 
 
+def firmware_version(repo_root: Path) -> bytes:
+    """The FIRMWARE_VERSION SSOT (#124) from BuildInfo.h — fail loudly if
+    the declaration ever moves or changes shape, never emit a stale badge."""
+    build_info = (repo_root / "sketches" / "dual_track_control" / "src"
+                  / "config" / "BuildInfo.h")
+    match = VERSION_PATTERN.search(build_info.read_bytes())
+    if not match:
+        raise SystemExit(f"FAIL: FIRMWARE_VERSION declaration not found in "
+                         f"{build_info} — badge injection (#222) would go stale")
+    return match.group(1)
+
+
 def generate(repo_root: Path) -> bytes:
     source_path = repo_root / "dashboard" / "index.html"
     page = source_path.read_bytes().replace(b"\r\n", b"\n")
+    if page.count(VERSION_PLACEHOLDER) != 1:
+        raise SystemExit(f"FAIL: {source_path} must contain exactly one "
+                         f"{VERSION_PLACEHOLDER.decode()} placeholder (#222)")
+    page = page.replace(VERSION_PLACEHOLDER, firmware_version(repo_root))
     if len(page) > PAGE_BUDGET_BYTES:
         raise SystemExit(f"FAIL: {source_path} is {len(page)} bytes — over the "
                          f"{PAGE_BUDGET_BYTES} byte page budget (epic #81)")

--- a/sketches/dual_track_control/web_page.h
+++ b/sketches/dual_track_control/web_page.h
@@ -185,8 +185,11 @@ html,body{margin:0;padding:0;background:#000;color:#fff;font-family:'Rajdhani',s
 </style>
 </head>
 <body>
-<!-- Discrete firmware-version badge (top-left). Bump with the sketch version. -->
-<div id="fwVer" style="position:fixed;top:3px;left:5px;z-index:9999;font:10px monospace;color:#6b8;opacity:.6;letter-spacing:.5px;pointer-events:none">V7.33</div>
+<!-- Discrete firmware-version badge (top-left). The placeholder is replaced
+     with config/BuildInfo.h's FIRMWARE_VERSION at generation (#222) — never
+     hand-write a version here. Served pages always show the SSOT value;
+     opening this source file directly shows the raw placeholder. -->
+<div id="fwVer" style="position:fixed;top:3px;left:5px;z-index:9999;font:10px monospace;color:#6b8;opacity:.6;letter-spacing:.5px;pointer-events:none">V7.35</div>
 <div class="dash-frame">
 
 <div class="top-bar">


### PR DESCRIPTION
Closes #222

## Summary
- `dashboard/index.html` now carries a `{{FIRMWARE_VERSION}}` placeholder; `generate_web_page.py` substitutes the `BuildInfo.h` SSOT value at generation. Fail-close both ways: missing/moved declaration or a placeholder count ≠ 1 aborts generation.
- The served badge corrects **V7.33 → V7.35** (the hand-copied literal had drifted twice — this PR is the authorized fix and the mechanism that makes recurrence impossible: bumping `FIRMWARE_VERSION` without regenerating now fails the `dashboard-drift` CI check, so bumps and regeneration travel together by construction).
- Wiki `telemetry-and-dashboard.md` + DECISION-LOG updated.

## Role
[C-Builder]

## Test plan
- `generate_web_page.py` then `--check`: pass; generated `web_page.h` contains exactly one `V7.35` and zero stale versions (grep-verified).
- Playwright harness renders clean (it loads the SOURCE, so its screenshot shows the raw placeholder in the 10px corner badge — expected; the served page always carries the injected SSOT value).
- Host suite 27/27 via pre-commit; local compile clean (`web_page.h` is an inert PROGMEM string — tests-reviewer precedent from PR #221). `DIGGER_NO_TEST_CHANGE=1`: served-HTML content has no host-suite coverage.

Documentation receipt
- Areas changed: dashboard/, scripts/, sketches (generated)
- Pages updated: docs/wiki/telemetry-and-dashboard.md, docs/DECISION-LOG.md
- Pages examined, no change needed: .claude/rules/dashboard.md (regenerate-after-edit rule unchanged), docs/TESTING.md (scripts/ checker list doesn't enumerate generator internals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)